### PR TITLE
Check spacing around operators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 		"php": ">=5.4.0"
 	},
 	"require-dev": {
-		"squizlabs/php_codesniffer": "~2.1",
+		"squizlabs/php_codesniffer": "~2.2",
 		"phpmd/phpmd": "~2.1"
 	},
 	"autoload": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -78,8 +78,11 @@
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing" />
 
-    <!-- https://github.com/squizlabs/PHP_CodeSniffer/issues/348 -->
-    <!--<rule ref="Squiz.WhiteSpace.OperatorSpacing" />-->
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true" />
+        </properties>
+    </rule>
 
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace" />
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing" />


### PR DESCRIPTION
Issue with PHPCS's operator spacing sniff that had been preventing from including this sniff in checks has been resolved in PHPCS's release 2.2.0, so it could be now included.