### PR TITLE
Add handling for route not found

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -20,4 +20,14 @@ $app->after( function( Request $request, Response $response ) {
 	return $response;
 } );
 
+$app->error( function ( \Exception $e, $code ) {
+	return new JsonResponse(
+		[
+			'message' => $e->getMessage(),
+			'code' => $code
+		],
+		$code
+	);
+} );
+
 return require __DIR__ . '/routes.php';

--- a/tests/System/RouteNotFoundTest.php
+++ b/tests/System/RouteNotFoundTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Tests\System;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class RouteNotFoundTest extends SystemTestCase {
+
+	public function testGivenUnknownRoute_404isReturned() {
+		$client = $this->createClient();
+		$client->request( 'GET', '/kittens' );
+
+		$this->assert404( $client->getResponse(), 'No route found for "GET /kittens"' );
+	}
+
+}

--- a/tests/System/Routes/ListCommentsRssRouteTest.php
+++ b/tests/System/Routes/ListCommentsRssRouteTest.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace WMDE\Fundraising\Frontend\Tests\System;
+namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
+
+use WMDE\Fundraising\Frontend\Tests\System\SystemTestCase;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/System/Routes/ValidateEmailRouteTest.php
+++ b/tests/System/Routes/ValidateEmailRouteTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace WMDE\Fundraising\Frontend\Tests\System;
+namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
 
 use Symfony\Component\HttpFoundation\Response;
+use WMDE\Fundraising\Frontend\Tests\System\SystemTestCase;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/System/SystemTestCase.php
+++ b/tests/System/SystemTestCase.php
@@ -4,6 +4,7 @@ namespace WMDE\Fundraising\Frontend\Tests\System;
 
 use Silex\Application;
 use Silex\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
 use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 
 /**
@@ -31,6 +32,27 @@ abstract class SystemTestCase extends WebTestCase {
 		unset( $app['exception_handler'] );
 
 		return $app;
+	}
+
+	protected function assert404( Response $response, $expectedMessage = 'Not Found' ) {
+		$this->assertJson( $response->getContent(), 'response is json' );
+
+		$this->assertJsonResponse(
+			[
+				'message' => $expectedMessage,
+				'code' => 404,
+			],
+			$response
+		);
+
+		$this->assertSame( 404, $response->getStatusCode() );
+	}
+
+	private function assertJsonResponse( $expected, Response $response ) {
+		$this->assertSame(
+			json_encode( $expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
+			$response->getContent()
+		);
 	}
 
 }


### PR DESCRIPTION
/kittens

```json
{
    "message": "No route found for \"GET /kittens\"",
    "code": 404
}
```