### PR TITLE
Work on display page usecase

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -3,7 +3,7 @@
 /**
  * These variables need to be in scope when this file is included:
  *
- * @var \WMDE\Fundraising\Frontend\FFFactory $ffFactory
+ * @var \WMDE\Fundraising\Frontend\FunFunFactory $ffFactory
  */
 
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/app/routes.php
+++ b/app/routes.php
@@ -4,7 +4,7 @@
  * These variables need to be in scope when this file is included:
  *
  * @var \Silex\Application $app
- * @var \WMDE\Fundraising\Frontend\FFFactory $ffFactory
+ * @var \WMDE\Fundraising\Frontend\FunFunFactory $ffFactory
  */
 
 use Silex\Application;
@@ -37,9 +37,7 @@ $app->get(
 $app->get(
 	'page/{pageName}',
 	function( Application $app, $pageName ) use ( $ffFactory ) {
-		$useCase = $ffFactory->newDisplayPageUseCase();
-
-		return $useCase->getPage( new PageDisplayRequest( $pageName ) );
+		return $ffFactory->newDisplayPageUseCase()->getPage( new PageDisplayRequest( $pageName ) );
 	}
 );
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -9,6 +9,7 @@
 
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
+use WMDE\Fundraising\Frontend\UseCases\DisplayPage\PageDisplayRequest;
 use WMDE\Fundraising\Frontend\UseCases\ListComments\CommentListingRequest;
 
 $app->get(
@@ -36,7 +37,9 @@ $app->get(
 $app->get(
 	'page/{pageName}',
 	function( Application $app, $pageName ) use ( $ffFactory ) {
-		return "<html><header />missing: $pageName</html>";
+		$useCase = $ffFactory->newDisplayPageUseCase();
+
+		return $useCase->getPage( new PageDisplayRequest( $pageName ) );
 	}
 );
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 
 		"silex/silex": "~1.3",
 
-		"jeroen/file-fetcher": "dev-InMemoryFileFetcher"
+		"jeroen/file-fetcher": "~3.1"
 	},
 	"require-dev": {
 		"ext-pdo_sqlite": "*",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
 		"php": ">=7.0",
 		"ext-intl": "*",
 
-		"silex/silex": "~1.3"
+		"silex/silex": "~1.3",
+
+		"jeroen/file-fetcher": "dev-InMemoryFileFetcher"
 	},
 	"require-dev": {
 		"ext-pdo_sqlite": "*",

--- a/src/FFFactory.php
+++ b/src/FFFactory.php
@@ -4,6 +4,7 @@ namespace WMDE\Fundraising\Frontend;
 
 use WMDE\Fundraising\Frontend\Domain\CommentRepository;
 use WMDE\Fundraising\Frontend\Domain\InMemoryCommentRepository;
+use WMDE\Fundraising\Frontend\UseCases\DisplayPage\DisplayPageUseCase;
 use WMDE\Fundraising\Frontend\UseCases\ListComments\ListCommentsUseCase;
 use WMDE\Fundraising\Frontend\UseCases\ValidateEmail\ValidateEmailUseCase;
 
@@ -30,6 +31,10 @@ class FFFactory {
 
 	private function newCommentRepository(): CommentRepository {
 		return new InMemoryCommentRepository( [] ); // TODO
+	}
+
+	public function newDisplayPageUseCase(): DisplayPageUseCase {
+		return new DisplayPageUseCase();
 	}
 
 }

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -2,6 +2,8 @@
 
 namespace WMDE\Fundraising\Frontend;
 
+use FileFetcher\FileFetcher;
+use FileFetcher\SimpleFileFetcher;
 use WMDE\Fundraising\Frontend\Domain\CommentRepository;
 use WMDE\Fundraising\Frontend\Domain\InMemoryCommentRepository;
 use WMDE\Fundraising\Frontend\UseCases\DisplayPage\DisplayPageUseCase;
@@ -12,13 +14,20 @@ use WMDE\Fundraising\Frontend\UseCases\ValidateEmail\ValidateEmailUseCase;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class FFFactory {
+class FunFunFactory {
+
+	private $config;
+
+	private $fileFetcher;
 
 	public static function newFromConfig() {
-		return new self();
+		return new self( [ // TODO: https://phabricator.wikimedia.org/T123065
+			'cms-wiki-url' => 'http://cms.wiki/'
+		] );
 	}
 
-	private function __construct() {
+	private function __construct( array $config ) {
+		$this->config = $config;
 	}
 
 	public function newValidateEmailUseCase(): ValidateEmailUseCase {
@@ -34,7 +43,25 @@ class FFFactory {
 	}
 
 	public function newDisplayPageUseCase(): DisplayPageUseCase {
-		return new DisplayPageUseCase();
+		return new DisplayPageUseCase(
+			$this->getFileFetcher(),
+			$this->config['cms-wiki-url']
+		);
+	}
+
+	private function getFileFetcher(): FileFetcher {
+		if ( $this->fileFetcher === null ) {
+			$this->fileFetcher = new SimpleFileFetcher();
+		}
+
+		return $this->fileFetcher;
+	}
+
+	/**
+	 * Should only be used by test setup code!
+	 */
+	public function setFileFetcher( FileFetcher $fileFetcher ) {
+		$this->fileFetcher = $fileFetcher;
 	}
 
 }

--- a/src/UseCases/DisplayPage/DisplayPageUseCase.php
+++ b/src/UseCases/DisplayPage/DisplayPageUseCase.php
@@ -26,6 +26,12 @@ class DisplayPageUseCase {
 	}
 
 	private function getPageContent( string $pageName ) {
+		// Normalization
+		// White and blacklisting of page name
+		// pageRetriever->fetchPage( $wiki_page, 'render' )
+		// getProcessedContent( $content, $wiki_page, 'render' )
+		// Debug output when dev
+
 		try {
 			$content = $this->fileFetcher->fetchFile( $this->urlBase . $pageName );
 		}

--- a/src/UseCases/DisplayPage/DisplayPageUseCase.php
+++ b/src/UseCases/DisplayPage/DisplayPageUseCase.php
@@ -2,16 +2,42 @@
 
 namespace WMDE\Fundraising\Frontend\UseCases\DisplayPage;
 
+use FileFetcher\FileFetcher;
+use FileFetcher\FileFetchingException;
+
 /**
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class DisplayPageUseCase {
 
-	public function getPage( PageDisplayRequest $listingRequest ): string {
-		$pageName = $listingRequest->getPageName();
+	private $fileFetcher;
+	private $urlBase;
 
-		return "<html><header />missing: $pageName</html>";
+	public function __construct( FileFetcher $fileFetcher, string $urlBase ) {
+		$this->fileFetcher = $fileFetcher;
+		$this->urlBase = $urlBase;
+	}
+
+	public function getPage( PageDisplayRequest $listingRequest ): string {
+		$pageContent = $this->getPageContent( $listingRequest->getPageName() );
+
+		return "<html><header />$pageContent</html>";
+	}
+
+	private function getPageContent( string $pageName ) {
+		try {
+			$content = $this->fileFetcher->fetchFile( $this->urlBase . $pageName );
+		}
+		catch ( FileFetchingException $ex ) {
+			$content = '';
+		}
+
+		if ( $content === '' ) {
+			return 'missing: ' . htmlspecialchars( $pageName );
+		}
+
+		return $content;
 	}
 
 }

--- a/src/UseCases/DisplayPage/DisplayPageUseCase.php
+++ b/src/UseCases/DisplayPage/DisplayPageUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\UseCases\DisplayPage;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class DisplayPageUseCase {
+
+	public function getPage( PageDisplayRequest $listingRequest ): string {
+		$pageName = $listingRequest->getPageName();
+
+		return "<html><header />missing: $pageName</html>";
+	}
+
+}

--- a/src/UseCases/DisplayPage/PageDisplayRequest.php
+++ b/src/UseCases/DisplayPage/PageDisplayRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\UseCases\DisplayPage;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PageDisplayRequest {
+
+	private $pageName;
+
+	public function __construct( string $pageName ) {
+		$this->pageName = $pageName;
+	}
+
+	public function getPageName(): string {
+		return $this->pageName;
+	}
+
+}

--- a/tests/System/DisplayPageRouteTest.php
+++ b/tests/System/DisplayPageRouteTest.php
@@ -2,6 +2,8 @@
 
 namespace WMDE\Fundraising\Frontend\Tests\System;
 
+use FileFetcher\InMemoryFileFetcher;
+
 /**
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
@@ -16,6 +18,43 @@ class DisplayPageRouteTest extends SystemTestCase {
 			'<html><header />missing: kittens</html>',
 			$client->getResponse()->getContent()
 		);
+	}
+
+	public function testWhenPageDoesNotExist_pageNameInResponseIsEscaped() {
+		$client = $this->createClient();
+		$client->request( 'GET', '/page/<script>alert("kittens");' );
+
+		$this->assertSame(
+			'<html><header />missing: &lt;script&gt;alert(&quot;kittens&quot;);</html>',
+			$client->getResponse()->getContent()
+		);
+	}
+
+	public function testWhenPageExists_itGetsEmbedded() {
+		$this->insertUnicornsPage();
+
+		$client = $this->createClient();
+		$client->request( 'GET', '/page/unicorns' );
+
+		$this->assertSame(
+			'<html><header />Pink fluffy unicorns dancing on rainbows</html>',
+			$client->getResponse()->getContent()
+		);
+	}
+
+	private function insertUnicornsPage() {
+		$this->testEnvironment->getFactory()->setFileFetcher( new InMemoryFileFetcher( [
+			'http://cms.wiki/unicorns' => 'Pink fluffy unicorns dancing on rainbows'
+		] ) );
+	}
+
+	public function testWhenPageNameContainsSlash_404isReturned() {
+		$this->insertUnicornsPage();
+
+		$client = $this->createClient();
+		$client->request( 'GET', '/page/unicorns/of-doom' );
+
+		$this->assert404( $client->getResponse(), 'No route found for "GET /page/unicorns/of-doom"' );
 	}
 
 }

--- a/tests/System/Routes/DisplayPageRouteTest.php
+++ b/tests/System/Routes/DisplayPageRouteTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace WMDE\Fundraising\Frontend\Tests\System;
+namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
 
 use FileFetcher\InMemoryFileFetcher;
+use WMDE\Fundraising\Frontend\Tests\System\SystemTestCase;
 
 /**
  * @licence GNU GPL v2+

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -2,7 +2,7 @@
 
 namespace WMDE\Fundraising\Frontend\Tests;
 
-use WMDE\Fundraising\Frontend\FFFactory;
+use WMDE\Fundraising\Frontend\FunFunFactory;
 
 /**
  * @licence GNU GPL v2+
@@ -17,15 +17,15 @@ class TestEnvironment {
 	}
 
 	/**
-	 * @var FFFactory
+	 * @var FunFunFactory
 	 */
 	private $factory;
 
 	private function __construct() {
-		$this->factory = FFFactory::newFromConfig();
+		$this->factory = FunFunFactory::newFromConfig();
 	}
 
-	public function getFactory(): FFFactory {
+	public function getFactory(): FunFunFactory {
 		return $this->factory;
 	}
 

--- a/web/index.php
+++ b/web/index.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$ffFactory = \WMDE\Fundraising\Frontend\FFFactory::newFromConfig();
+$ffFactory = \WMDE\Fundraising\Frontend\FunFunFactory::newFromConfig();
 
 /**
  * @var \Silex\Application $app


### PR DESCRIPTION
The real work in DisplayPageUseCase::getPageContent still needs to happen. The comments there indicate the relevant steps, as far as I can tell, that happen in the old code. I don't just want to copy WikiRip, as it seems to be doing things not needed here, and is also not structured nicely. Instead I want to copy the relevant parts of the relevant methods and reorganizing them. This is what I have in mind ATM:

* normalization - method in the UC itself
* white and blacklisting in a new PageFlufinessDetector class that returns a yay or nay for a page name (see #17)
* fetching of the content via existing PageRetriever stuff (action always seems to be "render", so we can probably drop this parameter and add support for its feature again when we need it (probably in a way different than using such a param))
* old getProcessedContent behaviour via a new service (to not have it in the UC)
* optional outputting of debug into via new service (maybe the same as for getProcessedContent) (maybe we don't need this right away)

(To clarify, these new services/classes would mainly contain code copied from the old codebase)

Thoughts? In particular, did I miss anything that needs to be done in this UC, or are any of these things not actually needed?