### PR TITLE
[DNM] Add StringValueGuard

### DIFF
--- a/src/StringValueGuard.php
+++ b/src/StringValueGuard.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class StringValueGuard {
+
+	private $whitelist = [];
+	private $blacklist = [];
+
+	public function isAllowed( string $value ): bool {
+		if ( $this->whitelist !== [] && !in_array( $value, $this->whitelist ) ) {
+			return false;
+		}
+
+		return !in_array( $value, $this->blacklist );
+	}
+
+	/**
+	 * @param string[] $strings
+	 */
+	public function setWhitelist( array $strings ) {
+		$this->assertAreStrings( $strings );
+		$this->whitelist = $strings;
+	}
+
+	/**
+	 * @param string[] $strings
+	 */
+	public function setBlacklist( array $strings ) {
+		$this->assertAreStrings( $strings );
+		$this->blacklist = $strings;
+	}
+
+	private function assertAreStrings( array $strings ) {
+		foreach ( $strings as $string ) {
+			if ( !is_string( $string ) ) {
+				throw new \InvalidArgumentException( 'All array elements must be of type string' );
+			}
+		}
+	}
+
+}

--- a/tests/Unit/StringValueGuardTest.php
+++ b/tests/Unit/StringValueGuardTest.php
@@ -75,7 +75,7 @@ class StringValueGuardTest extends \PHPUnit_Framework_TestCase {
 		$guard->setWhitelist( [ 'cats', 1337, 'ponies' ] );
 	}
 
-	public function testGivenNonString_setBaclklistThrowsException() {
+	public function testGivenNonString_setBlacklistThrowsException() {
 		$guard = new StringValueGuard();
 
 		$this->setExpectedException( \InvalidArgumentException::class );

--- a/tests/Unit/StringValueGuardTest.php
+++ b/tests/Unit/StringValueGuardTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit;
+
+use WMDE\Fundraising\Frontend\StringValueGuard;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\StringValueGuard
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class StringValueGuardTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenNoRestrictions_valueIsAllowed() {
+		$this->assertTrue( ( new StringValueGuard() )->isAllowed( 'kittens' ) );
+	}
+
+	public function testGivenWhitelist_valueNotOnItIsDisallowed() {
+		$guard = new StringValueGuard();
+		$guard->setWhitelist( [ 'cats', 'kittens', 'ponies' ] );
+		$this->assertFalse( $guard->isAllowed( 'unicorns' ) );
+	}
+
+	public function testGivenWhitelist_valueOnWhitelistIsAllowed() {
+		$guard = new StringValueGuard();
+		$guard->setWhitelist( [ 'cats', 'kittens', 'ponies' ] );
+		$this->assertTrue( $guard->isAllowed( 'kittens' ) );
+	}
+
+	public function testGivenBlacklist_valueOnBlacklistIsDisallowed() {
+		$guard = new StringValueGuard();
+		$guard->setBlacklist( [ 'cats', 'kittens', 'ponies' ] );
+		$this->assertFalse( $guard->isAllowed( 'kittens' ) );
+	}
+
+	public function testGivenBlacklist_valueNotOnBlacklistIsAllowed() {
+		$guard = new StringValueGuard();
+		$guard->setBlacklist( [ 'cats', 'kittens', 'ponies' ] );
+		$this->assertTrue( $guard->isAllowed( 'unicorns' ) );
+	}
+
+	public function testBlacklistAndWhitelist_valueOnBothIsNotAllowed() {
+		$guard = new StringValueGuard();
+		$guard->setWhitelist( [ 'cats', 'kittens', 'ponies' ] );
+		$guard->setBlacklist( [ 'cats', 'kittens', 'ponies' ] );
+		$this->assertFalse( $guard->isAllowed( 'kittens' ) );
+	}
+
+	public function testBlacklistAndWhitelist_valueOnNeitherIsNotAllowed() {
+		$guard = new StringValueGuard();
+		$guard->setWhitelist( [ 'cats', 'kittens', 'ponies' ] );
+		$guard->setBlacklist( [ 'cats', 'kittens', 'ponies' ] );
+		$this->assertFalse( $guard->isAllowed( 'unicorns' ) );
+	}
+
+	public function testBlacklistAndWhitelist_valueOnlyOnBlacklistIsNotAllowed() {
+		$guard = new StringValueGuard();
+		$guard->setWhitelist( [ 'cats', 'kittens' ] );
+		$guard->setBlacklist( [ 'ponies', 'unicorns' ] );
+		$this->assertFalse( $guard->isAllowed( 'unicorns' ) );
+	}
+
+	public function testBlacklistAndWhitelist_valueOnlyOnWhitelistIsAllowed() {
+		$guard = new StringValueGuard();
+		$guard->setWhitelist( [ 'cats', 'kittens' ] );
+		$guard->setBlacklist( [ 'ponies', 'unicorns' ] );
+		$this->assertTrue( $guard->isAllowed( 'kittens' ) );
+	}
+
+	public function testGivenNonString_setWhitelistThrowsException() {
+		$guard = new StringValueGuard();
+
+		$this->setExpectedException( \InvalidArgumentException::class );
+		$guard->setWhitelist( [ 'cats', 1337, 'ponies' ] );
+	}
+
+	public function testGivenNonString_setBaclklistThrowsException() {
+		$guard = new StringValueGuard();
+
+		$this->setExpectedException( \InvalidArgumentException::class );
+		$guard->setBlacklist( [ 'cats', 1337, 'ponies' ] );
+	}
+
+}


### PR DESCRIPTION
Originally created a PageNameGuard though then remebered how functional programming
advocates bash typical OOP programs for being overly specific and thus requiring to
reinvent the wheel the whole time. In this case a PageNameGuard would indeed be
overly specific as its logic would not be specific to page names at all.


For page name whitelisting and blacklisting in #16