### PR TITLE
provide page title prefix option

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -12,5 +12,6 @@
 	"cms-wiki-api-url": "",
 	"cms-wiki-user": "",
 	"cms-wiki-password": "",
+	"cms-wiki-title-prefix": "",
 	"enable-twig-cache": true
 }

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -103,7 +103,8 @@ class FunFunFactory {
 	public function newDisplayPageUseCase(): DisplayPageUseCase {
 		return new DisplayPageUseCase(
 			$this->newPageRetriever(),
-			$this->newPageContentModifier()
+			$this->newPageContentModifier(),
+			$this->config['cms-wiki-title-prefix']
 		);
 	}
 
@@ -209,4 +210,7 @@ class FunFunFactory {
 		$this->requestValidator = $requestValidator;
 	}
 
+	public function setPageTitlePrefix( string $prefix ) {
+		$this->config['cms-wiki-title-prefix'] = $prefix;
+	}
 }

--- a/src/UseCases/DisplayPage/DisplayPageUseCase.php
+++ b/src/UseCases/DisplayPage/DisplayPageUseCase.php
@@ -12,18 +12,22 @@ class DisplayPageUseCase {
 
 	private $pageRetriever;
 	private $contentModifier;
+	private $pageTitlePrefix;
 
-	public function __construct( PageRetriever $pageRetriever, PageContentModifier $contentModifier ) {
+	public function __construct( PageRetriever $pageRetriever,
+								 PageContentModifier $contentModifier,
+								 string $pageTitlePrefix = '' ) {
 		$this->pageRetriever = $pageRetriever;
 		$this->contentModifier = $contentModifier;
+		$this->pageTitlePrefix = $pageTitlePrefix;
 	}
 
 	public function getPage( PageDisplayRequest $listingRequest ): PageDisplayResponse {
 		$response = new PageDisplayResponse();
 
-		$response->setHeaderContent( $this->getPageContent( '10hoch16/Seitenkopf' ) );
-		$response->setMainContent( $this->getPageContent( $listingRequest->getPageName() ) );
-		$response->setFooterContent( $this->getPageContent( '10hoch16/Seitenfuß' ) );
+		$response->setHeaderContent( $this->getPageContent( $this->getPrefixedPageTitle( '10hoch16/Seitenkopf' ) ) );
+		$response->setMainContent( $this->getPageContent( $this->getPrefixedPageTitle( $listingRequest->getPageName() ) ) );
+		$response->setFooterContent( $this->getPageContent( $this->getPrefixedPageTitle( '10hoch16/Seitenfuß' ) ) );
 
 		$response->freeze();
 		$response->assertNoNullFields();
@@ -49,6 +53,10 @@ class DisplayPageUseCase {
 
 	private function normalizePageName( string $title ): string {
 		return ucfirst( str_replace( ' ', '_', trim( $title ) ) );
+	}
+
+	private function getPrefixedPageTitle( string $pageTitle ): string {
+		return $this->pageTitlePrefix . $pageTitle;
 	}
 
 }

--- a/tests/Fixtures/ApiPostRequestHandler.php
+++ b/tests/Fixtures/ApiPostRequestHandler.php
@@ -26,6 +26,7 @@ class ApiPostRequestHandler {
 			'Unicorns' => $this->testEnvironment->getJsonTestData( 'mwApiUnicornsPage.json' ),
 			'10hoch16/Seitenkopf' => $this->testEnvironment->getJsonTestData( 'mwApiHeaderPage.json' ),
 			'10hoch16/Seitenfuß' => $this->testEnvironment->getJsonTestData( 'mwApiFooterPage.json' ),
+			'MyNamespace:MyPrefix/Naked_mole-rat' => $this->testEnvironment->getJsonTestData( 'mwApiPrefixedTitlePage.json' ),
 		];
 
 		if ( array_key_exists( $request->getParams()['page'], $pageResponses ) ) {

--- a/tests/Integration/UseCases/DisplayPage/DisplayPageUseCaseTest.php
+++ b/tests/Integration/UseCases/DisplayPage/DisplayPageUseCaseTest.php
@@ -47,4 +47,16 @@ class DisplayPageUseCaseTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame( '<p>I\'m a footer</p>', $response->getFooterContent() );
 	}
 
+	public function testWhenPageTitlePrefixIsConfigured_pageCanBeRetrieved() {
+		$this->registerWikiPages();
+
+		$factory = $this->testEnvironment->getFactory();
+		$factory->setPageTitlePrefix( 'MyNamespace:MyPrefix/' );
+		$useCase = $factory->newDisplayPageUseCase();
+
+		$response = $useCase->getPage( new PageDisplayRequest( 'Naked mole-rat' ) );
+
+		$this->assertSame( '<p>This little guy wants to cuddle, too!</p>', $response->getMainContent() );
+	}
+
 }

--- a/tests/data/mwApiPrefixedTitlePage.json
+++ b/tests/data/mwApiPrefixedTitlePage.json
@@ -1,0 +1,9 @@
+{
+	"parse": {
+		"title": "MyNamespace:MyPrefix/Naked_mole-rat",
+		"pageid": 1337,
+		"text": {
+			"*": "<p>This little guy wants to cuddle, too!</p>"
+		}
+	}
+}


### PR DESCRIPTION
The content in the CMWiki resides in a different namespace and is prefixed (e. g. Web:Spendenseite-HK2013/test/Mitgliedschaft). This PR provides a way to configure the page title prefix in the configuration files.