### PR TITLE
Add basis for logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ composer.lock
 
 vendor/
 build/
+var/
 
 .idea/
 .floo

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 		"jeroen/file-fetcher": "~3.1",
 		"wmde/fundraising-store": "~1.0",
 		"addwiki/mediawiki-api-base": "~2.1",
-		"psr/log": "~1.0"
+		"psr/log": "~1.0",
+		"monolog/monolog": "~1.17"
 	},
 	"require-dev": {
 		"ext-pdo_sqlite": "*",

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 
 		"silex/silex": "~1.3",
 		"twig/twig": "~1.23",
+		"pimple/pimple": "~1.0",
 
 		"jeroen/file-fetcher": "~3.1",
 		"wmde/fundraising-store": "~1.0",

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -84,6 +84,19 @@ class FunFunFactory {
 			);
 		} );
 
+		$pimple['twig'] = $pimple->share( function() {
+			$options = [];
+
+			if ( $this->config['enable-twig-cache'] ) {
+				$options['cache'] = __DIR__ . '/../app/cache';
+			}
+
+			return new Twig_Environment(
+				new Twig_Loader_Filesystem( __DIR__ . '/../app/templates' ),
+				$options
+			);
+		} );
+
 		return $pimple;
 	}
 
@@ -129,22 +142,13 @@ class FunFunFactory {
 
 	public function newDisplayPagePresenter(): DisplayPagePresenter {
 		return new DisplayPagePresenter( new TwigTemplate(
-			$this->newTwig(),
+			$this->getTwig(),
 			'DisplayPageLayout.twig'
 		) );
 	}
 
-	private function newTwig() {
-		$options = [];
-
-		if ( $this->config['enable-twig-cache'] ) {
-			$options['cache'] = __DIR__ . '/../app/cache';
-		}
-
-		return new Twig_Environment(
-			new Twig_Loader_Filesystem( __DIR__ . '/../app/templates' ),
-			$options
-		);
+	private function getTwig(): Twig_Environment {
+		return $this->pimple['twig'];
 	}
 
 	private function newPageRetriever(): PageRetriever {

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -42,12 +42,10 @@ class FunFunFactory {
 
 	private $config;
 
-	private $connection;
-	private $fileFetcher;
-	private $requestValidator;
-	private $mwApi;
-
-	private $requestRepository;
+	/**
+	 * @var \Pimple
+	 */
+	private $pimple;
 
 	/**
 	 * @param array $config
@@ -61,18 +59,36 @@ class FunFunFactory {
 	 */
 	public function __construct( array $config ) {
 		$this->config = $config;
+		$this->pimple = $this->newPimple();
+	}
+
+	private function newPimple(): \Pimple {
+		$pimple = new \Pimple();
+
+		$pimple['dbal_connection'] = $pimple->share( function() {
+			return DriverManager::getConnection( $this->config['db'] );
+		} );
+
+		$pimple['request_repository'] = $pimple->share( function() {
+			return new DoctrineRequestRepository( $this->getConnection() );
+		} );
+
+		$pimple['request_validator'] = $pimple->share( function() {
+			return new RequestValidator( new MailValidator( MailValidator::TEST_WITH_MX ) );
+		} );
+
+		$pimple['mw_api'] = $pimple->share( function() {
+			return new MediawikiApi(
+				$this->config['cms-wiki-api-url'],
+				$this->newGuzzleClient()
+			);
+		} );
+
+		return $pimple;
 	}
 
 	public function getConnection(): Connection {
-		if ( $this->connection === null ) {
-			$this->connection = $this->newConnection();
-		}
-
-		return $this->connection;
-	}
-
-	private function newConnection(): Connection {
-		return DriverManager::getConnection( $this->config['db'] );
+		return $this->pimple['dbal_connection'];
 	}
 
 	public function newInstaller(): Installer {
@@ -92,22 +108,15 @@ class FunFunFactory {
 	}
 
 	private function newRequestRepository(): RequestRepository {
-		if ( $this->requestRepository === null ) {
-			$this->requestRepository = new DoctrineRequestRepository( $this->getConnection() );
-		}
-
-		return $this->requestRepository;
+		return $this->pimple['request_repository'];
 	}
 
 	public function setRequestRepository( RequestRepository $requestRepository ) {
-		$this->requestRepository = $requestRepository;
+		$this->pimple['request_repository'] = $requestRepository;
 	}
 
 	private function newRequestValidator(): RequestValidator {
-		if ( $this->requestValidator === null ) {
-			$this->requestValidator = new RequestValidator( new MailValidator( MailValidator::TEST_WITH_MX ) );
-		}
-		return $this->requestValidator;
+		return $this->pimple['request_validator'];
 	}
 
 	public function newDisplayPageUseCase(): DisplayPageUseCase {
@@ -146,19 +155,12 @@ class FunFunFactory {
 		);
 	}
 
-	private function getMediaWikiApi() {
-		if ( $this->mwApi === null ) {
-			$this->mwApi = new MediawikiApi(
-				$this->config['cms-wiki-api-url'],
-				$this->newGuzzleClient()
-			);
-		}
-
-		return $this->mwApi;
+	private function getMediaWikiApi(): MediawikiApi {
+		return $this->pimple['mw_api'];
 	}
 
 	public function setMediaWikiApi( MediawikiApi $api ) {
-		$this->mwApi = $api;
+		$this->pimple['mw_api'] = $api;
 	}
 
 	private function newGuzzleClient(): ClientInterface {
@@ -201,23 +203,8 @@ class FunFunFactory {
 		return new BankDataConverter( $this->config['bank-data-file'] );
 	}
 
-	private function getFileFetcher(): FileFetcher {
-		if ( $this->fileFetcher === null ) {
-			$this->fileFetcher = new SimpleFileFetcher();
-		}
-
-		return $this->fileFetcher;
-	}
-
-	/**
-	 * Should only be used by test setup code!
-	 */
-	public function setFileFetcher( FileFetcher $fileFetcher ) {
-		$this->fileFetcher = $fileFetcher;
-	}
-
 	public function setRequestValidator( RequestValidator $requestValidator ) {
-		$this->requestValidator = $requestValidator;
+		$this->pimple['request_validator'] = $requestValidator;
 	}
 
 	public function setPageTitlePrefix( string $prefix ) {


### PR DESCRIPTION
Based on #52, which can be merged first. Trying out the workflow of including those commits and submitting this against master.

This is just some very basic stuff. I figure we might want to add some options to specify the logging (and also cache) paths, and which levels should be logged at (def difference between production and dev there). Not done any of that yet as I think this is better done when having a better idea about what we actually need there. So certainly feel free to do stuff in that direction.

The debug handler currently writes to a file based on the timestamp. This means output from one phpunit run will (likely) get written to a single file (even though the logger gets re-instantiated for each test method. Not sure how to easily make this better.