### PR TITLE
GetInTouch response

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -135,11 +135,11 @@ $app->post(
 	'contact/get-in-touch',
 	function( Request $request ) use ( $app, $ffFactory ) {
 		$contactFormRequest = new GetInTouchRequest(
-			$request->get( 'Vorname', '' ),
-			$request->get( 'Nachname', '' ),
+			$request->get( 'firstname', '' ),
+			$request->get( 'lastname', '' ),
 			$request->get( 'email', '' ),
-			$request->get( 'Betreff', '' ),
-			$request->get( 'kommentar', '' )
+			$request->get( 'subject', '' ),
+			$request->get( 'messageBody', '' )
 		);
 
 		$contactFormResponse = $ffFactory->newGetInTouchUseCase()->processContact( $contactFormRequest );

--- a/app/routes.php
+++ b/app/routes.php
@@ -142,12 +142,25 @@ $app->post(
 			$request->get( 'messageBody', '' )
 		);
 
-		$contactFormResponse = $ffFactory->newGetInTouchUseCase()->processContact( $contactFormRequest );
-		if ( $contactFormResponse->isSuccessful() ) {
-			return $app->redirect( $app['url_generator']->generate( 'page', [ 'pageName' => 'KontaktBestaetigung' ] ) );
-		}
-		return $ffFactory->newGetInTouchHTMLPresenter()->present( $contactFormResponse, $request->request->all() );
+		try {
+			$contactFormResponse = $ffFactory->newGetInTouchUseCase()->processContact( $contactFormRequest );
+			if ( $contactFormResponse->isSuccessful() ) {
+				return $app->redirect( $app['url_generator']->generate( 'page', [ 'pageName' => 'KontaktBestaetigung' ] ) );
+			}
+			return $ffFactory->newGetInTouchHTMLPresenter()->present( $contactFormResponse, $request->request->all() );
+		} catch ( \RuntimeException $e ) {
+			$ffFactory->getLogger()->error(
+				$e->getMessage(),
+				[
+					'code' => $e->getCode(),
+					'file' => $e->getFile(),
+					'line' => $e->getLine(),
+					'stack_trace' => $e->getTraceAsString()
+				]
+			);
 
+			return $ffFactory->newInternalErrorHTMLPresenter()->present( $e );
+		}
 	}
 );
 

--- a/app/routes.php
+++ b/app/routes.php
@@ -143,7 +143,11 @@ $app->post(
 		);
 
 		$contactFormResponse = $ffFactory->newGetInTouchUseCase()->processContact( $contactFormRequest );
-		return $contactFormResponse;
+		if ( $contactFormResponse->isSuccessful() ) {
+			return $app->redirect( $app['url_generator']->generate( 'page', [ 'pageName' => 'KontaktBestaetigung' ] ) );
+		}
+		return $ffFactory->newGetInTouchHTMLPresenter()->present( $contactFormResponse, $request->request->all() );
+
 	}
 );
 

--- a/app/templates/Error.twig
+++ b/app/templates/Error.twig
@@ -1,0 +1,5 @@
+{% extends 'BaseLayout.twig' %}
+
+{% block main %}
+    {% include 'ErrorPage' %}
+{% endblock %}

--- a/app/templates/GetInTouch.twig
+++ b/app/templates/GetInTouch.twig
@@ -1,0 +1,5 @@
+{% extends 'BaseLayout.twig' %}
+
+{% block main %}
+    {% include 'Kontaktformular' %}
+{% endblock %}

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -36,6 +36,7 @@ use WMDE\Fundraising\Frontend\Presenters\AddSubscriptionHTMLPresenter;
 use WMDE\Fundraising\Frontend\Presenters\AddSubscriptionJSONPresenter;
 use WMDE\Fundraising\Frontend\Presenters\GetInTouchHTMLPresenter;
 use WMDE\Fundraising\Frontend\Presenters\IbanPresenter;
+use WMDE\Fundraising\Frontend\Presenters\InternalErrorHTMLPresenter;
 use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
 use WMDE\Fundraising\Frontend\Validation\MailValidator;
 use WMDE\Fundraising\Frontend\Validation\RequestValidator;
@@ -348,6 +349,10 @@ class FunFunFactory {
 
 	public function getOperatorAddress() {
 		return new MailAddress( $this->config['operator-email'] );
+	}
+
+	public function newInternalErrorHTMLPresenter(): InternalErrorHTMLPresenter {
+		return new InternalErrorHTMLPresenter( $this->getLayoutTemplate( 'Error.twig' ) );
 	}
 
 }

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -34,6 +34,7 @@ use WMDE\Fundraising\Frontend\Presenters\CommentListRssPresenter;
 use WMDE\Fundraising\Frontend\Presenters\Content\WikiContentProvider;
 use WMDE\Fundraising\Frontend\Presenters\AddSubscriptionHTMLPresenter;
 use WMDE\Fundraising\Frontend\Presenters\AddSubscriptionJSONPresenter;
+use WMDE\Fundraising\Frontend\Presenters\GetInTouchHTMLPresenter;
 use WMDE\Fundraising\Frontend\Presenters\IbanPresenter;
 use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
 use WMDE\Fundraising\Frontend\Validation\MailValidator;
@@ -230,6 +231,10 @@ class FunFunFactory {
 
 	public function newAddSubscriptionJSONPresenter(): AddSubscriptionJSONPresenter {
 		return new AddSubscriptionJSONPresenter();
+	}
+
+	public function newGetInTouchHTMLPresenter(): GetInTouchHTMLPresenter {
+		return new GetInTouchHTMLPresenter( $this->getLayoutTemplate( 'GetInTouch.twig' ) );
 	}
 
 	public function getTwig(): Twig_Environment {

--- a/src/Presenters/GetInTouchHTMLPresenter.php
+++ b/src/Presenters/GetInTouchHTMLPresenter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Presenters;
+
+use WMDE\Fundraising\Frontend\ResponseModel\ValidationResponse;
+use WMDE\Fundraising\Frontend\TwigTemplate;
+use WMDE\Fundraising\Frontend\Validation\ConstraintViolation;
+
+/**
+ * Render the contact form with errors
+ *
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class GetInTouchHTMLPresenter {
+
+	private $template;
+
+	public function __construct( TwigTemplate $template ) {
+		$this->template = $template;
+	}
+
+	public function present( ValidationResponse $response, array $formData ): string {
+		$errors = [];
+		/** @var ConstraintViolation $constraintViolation */
+		foreach( $response->getValidationErrors() as $constraintViolation ) {
+			// TODO add translation library and translate message.
+			$errors[$constraintViolation->getSource()] = $constraintViolation->getMessage();
+		}
+
+		return $this->template->render( array_merge( $formData, [ 'errors' => $errors ] ) );
+	}
+
+}

--- a/src/Presenters/InternalErrorHTMLPresenter.php
+++ b/src/Presenters/InternalErrorHTMLPresenter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Presenters;
+
+use WMDE\Fundraising\Frontend\ResponseModel\ValidationResponse;
+use WMDE\Fundraising\Frontend\TwigTemplate;
+use WMDE\Fundraising\Frontend\Validation\ConstraintViolation;
+
+/**
+ * Render an error page
+ *
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class InternalErrorHTMLPresenter {
+
+	private $template;
+
+	public function __construct( TwigTemplate $template ) {
+		$this->template = $template;
+	}
+
+	public function present( \Exception $exception ): string {
+		return $this->template->render( [ 'message' => $exception->getMessage() ] );
+	}
+
+}

--- a/src/UseCases/GetInTouch/GetInTouchUseCase.php
+++ b/src/UseCases/GetInTouch/GetInTouchUseCase.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\Frontend\UseCases\GetInTouch;
 
 use WMDE\Fundraising\Frontend\MailAddress;
 use WMDE\Fundraising\Frontend\Messenger;
+use WMDE\Fundraising\Frontend\ResponseModel\ValidationResponse;
 use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
 
 /**
@@ -24,17 +25,17 @@ class GetInTouchUseCase {
 		$this->messenger = $messenger;
 	}
 
-	public function processContact( GetInTouchRequest $request ): string {
+	public function processContact( GetInTouchRequest $request ): ValidationResponse {
 		$this->request = $request;
 
 		if ( !$this->validator->validate( $request ) ) {
-			return 'validation failed';
+			return ValidationResponse::newFailureResponse( $this->validator->getConstraintViolations() );
 		}
 
 		try {
 			$this->forwardContactRequest();
 			$this->confirmToUser();
-			return 'request successful';
+			return ValidationResponse::newSuccessResponse();
 		} catch ( \RuntimeException $e ) {
 			return 'mail transmission failed';
 		}

--- a/src/UseCases/GetInTouch/GetInTouchUseCase.php
+++ b/src/UseCases/GetInTouch/GetInTouchUseCase.php
@@ -32,13 +32,9 @@ class GetInTouchUseCase {
 			return ValidationResponse::newFailureResponse( $this->validator->getConstraintViolations() );
 		}
 
-		try {
-			$this->forwardContactRequest();
-			$this->confirmToUser();
-			return ValidationResponse::newSuccessResponse();
-		} catch ( \RuntimeException $e ) {
-			return 'mail transmission failed';
-		}
+		$this->forwardContactRequest();
+		$this->confirmToUser();
+		return ValidationResponse::newSuccessResponse();
 	}
 
 	private function forwardContactRequest() {

--- a/src/Validation/GetInTouchValidator.php
+++ b/src/Validation/GetInTouchValidator.php
@@ -28,8 +28,8 @@ class GetInTouchValidator implements InstanceValidator {
 	public function validate( $instance ): bool {
 		$violations = [];
 		$requiredFieldValidator = new RequiredFieldValidator();
-		$violations[] = $this->validateField( $requiredFieldValidator, $instance->getSubject(), 'Betreff');
-		$violations[] = $this->validateField( $requiredFieldValidator, $instance->getMessageBody(), 'kommentar');
+		$violations[] = $this->validateField( $requiredFieldValidator, $instance->getSubject(), 'subject');
+		$violations[] = $this->validateField( $requiredFieldValidator, $instance->getMessageBody(), 'messageBody');
 		$violations[] = $this->validateField( $requiredFieldValidator, $instance->getEmailAddress(), 'email');
 		$violations[] = $this->validateField( $this->mailValidator, $instance->getEmailAddress(), 'email');
 		$this->constraintViolations = array_filter( $violations );

--- a/tests/Fixtures/ApiPostRequestHandler.php
+++ b/tests/Fixtures/ApiPostRequestHandler.php
@@ -25,6 +25,7 @@ class ApiPostRequestHandler {
 			'MyNamespace:MyPrefix/Naked_mole-rat' => TestEnvironment::getJsonTestData( 'mwApiPrefixedTitlePage.json' ),
 			'JavaScript-Notice' => TestEnvironment::getJsonTestData( 'mwApiJsNoticePage.json' ),
 			'SubscriptionForm' => TestEnvironment::getJsonTestData( 'mwApiSubscriptionForm.json' ),
+			'Kontaktformular' => TestEnvironment::getJsonTestData( 'mwApiContactForm.json' ),
 		];
 
 		if ( array_key_exists( $request->getParams()['page'], $pageResponses ) ) {

--- a/tests/Fixtures/ApiPostRequestHandler.php
+++ b/tests/Fixtures/ApiPostRequestHandler.php
@@ -26,6 +26,7 @@ class ApiPostRequestHandler {
 			'JavaScript-Notice' => TestEnvironment::getJsonTestData( 'mwApiJsNoticePage.json' ),
 			'SubscriptionForm' => TestEnvironment::getJsonTestData( 'mwApiSubscriptionForm.json' ),
 			'Kontaktformular' => TestEnvironment::getJsonTestData( 'mwApiContactForm.json' ),
+			'ErrorPage' => TestEnvironment::getJsonTestData( 'mwApiErrorPage.json' ),
 		];
 
 		if ( array_key_exists( $request->getParams()['page'], $pageResponses ) ) {

--- a/tests/Integration/Validation/GetInTouchValidatorTest.php
+++ b/tests/Integration/Validation/GetInTouchValidatorTest.php
@@ -53,7 +53,7 @@ class GetInTouchValidatorTest extends ValidatorTestCase {
 			'I just wanted to say "Hi".'
 		);
 		$this->assertFalse( $validator->validate( $request ) );
-		$this->assertConstraintWasViolated( $validator->getConstraintViolations(), 'Betreff' );
+		$this->assertConstraintWasViolated( $validator->getConstraintViolations(), 'subject' );
 	}
 
 	public function testMessageBodyIsValidated() {
@@ -67,7 +67,7 @@ class GetInTouchValidatorTest extends ValidatorTestCase {
 			''
 		);
 		$this->assertFalse( $validator->validate( $request ) );
-		$this->assertConstraintWasViolated( $validator->getConstraintViolations(), 'kommentar' );
+		$this->assertConstraintWasViolated( $validator->getConstraintViolations(), 'messageBody' );
 	}
 
 }

--- a/tests/System/Routes/GetInTouchRouteTest.php
+++ b/tests/System/Routes/GetInTouchRouteTest.php
@@ -8,7 +8,6 @@ use Swift_NullTransport;
 use WMDE\Fundraising\Frontend\FunFunFactory;
 use WMDE\Fundraising\Frontend\Messenger;
 use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
-use WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchResponse;
 
 /**
  * @licence GNU GPL v2+
@@ -32,11 +31,11 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 			'POST',
 			'/contact/get-in-touch',
 			[
-				'Vorname' => 'Curious',
-				'Nachname' => 'Guy',
+				'firstname' => 'Curious',
+				'lastname' => 'Guy',
 				'email' => 'curious.guy@gmail.com',
-				'Betreff' => 'What is it you are doing?!',
-				'kommentar' => 'Just tell me'
+				'subject' => 'What is it you are doing?!',
+				'messageBody' => 'Just tell me'
 			]
 		);
 
@@ -53,11 +52,11 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 			'POST',
 			'/contact/get-in-touch',
 			[
-				'Vorname' => 'Curious',
-				'Nachname' => 'Guy',
+				'firstname' => 'Curious',
+				'lastname' => 'Guy',
 				'email' => 'curious.guy@gmail',
-				'Betreff' => 'What is it you are doing?!',
-				'kommentar' => 'Just tell me'
+				'subject' => 'What is it you are doing?!',
+				'messageBody' => 'Just tell me'
 			]
 		);
 

--- a/tests/data/mwApiContactForm.json
+++ b/tests/data/mwApiContactForm.json
@@ -1,0 +1,9 @@
+{
+	"parse": {
+		"title": "Kontaktformular",
+		"pageid": 8192,
+		"text": {
+			"*": "<-- just for testing if data is assigned and processed -->\nErrors: {$ errors|length $}\nFirst Name: {$ firstname $}"
+		}
+	}
+}

--- a/tests/data/mwApiErrorPage.json
+++ b/tests/data/mwApiErrorPage.json
@@ -1,0 +1,9 @@
+{
+	"parse": {
+		"title": "ErrorPage",
+		"pageid": 8118,
+		"text": {
+			"*": "Internal Error: {$ message $}"
+		}
+	}
+}

--- a/web/skin/10h16/_styles/styles.css
+++ b/web/skin/10h16/_styles/styles.css
@@ -570,6 +570,19 @@ main { padding-top: 40px; padding-bottom: 100px; background: #f6f6f6; display: b
 #comment-header .box-header { background: #84c5f1; }
 #comment-list .box-header { background: #84c5f1; }
 
+#contact-form .box-header { background: #84c5f1; }
+#contact-form .box-header span[class^="icon-"] { padding-left: 30px; display: inline-block; }
+#contact-form .box-header span[class^="icon-"]:before { font-size: 1.2em; position: absolute; margin-left: -30px; }
+#contact-form label { width: 175px; }
+#contact-form label[for="messageBody"] { vertical-align: top; margin-top: 8px; }
+#contact-form input[type="text"] { width: 350px; }
+#contact-form textarea { width: 350px; height: 200px; }
+#contact-form #first-name { width: 169px; }
+#contact-form #last-name { width: 169px; }
+
+/* inline form input errors */
+form div.input-container span.form-error { margin-left: 180px; font-size: 0.8em; color: red; position: relative; top: 5px; }
+
 /* footer */
 footer { background: #FFF; font-size: 0.8em; color: #BBB; padding-top: 15px; position: absolute; bottom: 0; width: 100%; display: block; }
 footer * { color: #BBB; }


### PR DESCRIPTION
This PR introduces the actual response model for the use case. I also made some changes to styles and changed the on-wiki templates to use twig (and added some layout stuff to make the [contact confirmation](https://backend.wikimedia.de/wiki/index.php?title=Web%3ASpendenseite-HK2013%2Frewrite%2FKontaktBestaetigung&diff=7035&oldid=6922) and the [contact form](https://backend.wikimedia.de/wiki/index.php?title=Web%3ASpendenseite-HK2013%2Frewrite%2FKontaktformular&diff=7034&oldid=6925) look prettier).