### PR TITLE
Remove MediaWiki API dependency for test templates

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -40,6 +40,4 @@ $app->error( function ( \Exception $e, $code ) use ( $ffFactory ) {
 	);
 } );
 
-$ffFactory->getTwig()->addGlobal( 'app', $app );
-
 return require __DIR__ . '/routes.php';

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -14,8 +14,16 @@
 	"cms-wiki-password": "",
 	"cms-wiki-title-prefix": "",
 	"web-basepath": "",
-	"enable-twig-cache": true,
-	"template-dir": "",
+	"twig": {
+		"enable-cache": true,
+		"loaders": {
+			"wiki": true,
+			"filesystem": {
+				"template-dir": [ "app/templates" ]
+			},
+			"array": {}
+		}
+	},
 	"default-layout-templates": {
 		"header": "10hoch16/Seitenkopf",
 		"footer": "10hoch16/Seitenfuß",

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -8,7 +8,18 @@
 	"cms-wiki-api-url": "http://cms.wiki/api.php",
 	"cms-wiki-user": "Wiki User",
 	"cms-wiki-password": "Wiki Password",
-	"enable-twig-cache": false,
+	"twig": {
+		"enable-cache": false,
+		"loaders": {
+			"wiki": false,
+			"filesystem": {
+				"template-dir": [
+					"app/templates",
+					"tests/templates"
+				]
+			}
+		}
+	},
 	"operator-email": "email@operatorsownmailserver.com",
 	"operator-displayname": "Friendly Operator"
 }

--- a/app/templates/AddSubscription.twig
+++ b/app/templates/AddSubscription.twig
@@ -1,5 +1,5 @@
 {% extends 'BaseLayout.twig' %}
 
 {% block main %}
-    {% include 'SubscriptionForm' %}
+    {% include 'SubscriptionForm.twig' %}
 {% endblock %}

--- a/app/templates/Error.twig
+++ b/app/templates/Error.twig
@@ -1,5 +1,5 @@
 {% extends 'BaseLayout.twig' %}
 
 {% block main %}
-    {% include 'ErrorPage' %}
+    {% include 'ErrorPage.twig' %}
 {% endblock %}

--- a/app/templates/GetInTouch.twig
+++ b/app/templates/GetInTouch.twig
@@ -1,5 +1,5 @@
 {% extends 'BaseLayout.twig' %}
 
 {% block main %}
-    {% include 'Kontaktformular' %}
+    {% include 'Kontaktformular.twig' %}
 {% endblock %}

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -135,8 +135,17 @@ class FunFunFactory {
 			] );
 		} );
 
-		$pimple['twig'] = $pimple->share( function() {
-			return TwigFactory::newFromConfig( $this->config, $this->newWikiContentProvider() );
+		$pimple['twig_factory'] = $pimple->share( function () {
+			return new TwigFactory( $this->config['twig'] );
+		} );
+
+		$pimple['twig'] = $pimple->share( function( $pimple ) {
+			$loaders = array_filter( [
+				$pimple['twig_factory']->newFileSystemLoader(),
+				$pimple['twig_factory']->newArrayLoader(), // This is just a fallback for testing
+				$pimple['twig_factory']->newWikiPageLoader( $this->newWikiContentProvider() ),
+			] );
+			return $pimple['twig_factory']->create( $loaders );
 		} );
 
 		$pimple['logger'] = $pimple->share( function() {

--- a/src/TwigFactory.php
+++ b/src/TwigFactory.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\Frontend;
 use Twig_Environment;
 use Twig_Extension_StringLoader;
 use Twig_Lexer;
+use Twig_Loader_Array;
 use Twig_Loader_Filesystem;
 use WMDE\Fundraising\Frontend\Presenters\Content\WikiContentProvider;
 
@@ -15,18 +16,20 @@ use WMDE\Fundraising\Frontend\Presenters\Content\WikiContentProvider;
  */
 class TwigFactory {
 
-	public static function newFromConfig( array $config, WikiContentProvider $provider ): Twig_Environment {
+	private $config;
+
+	public function __construct( array $config ) {
+		$this->config = $config;
+	}
+
+	public function create( array $loaders ): Twig_Environment {
 		$options = [];
 
-		if ( $config['enable-twig-cache'] ) {
+		if ( $this->config['enable-cache'] ) {
 			$options['cache'] = __DIR__ . '/../app/cache';
 		}
 
-		$templateDir = $config['template-dir']  ?: __DIR__ . '/../app/templates';
-		$loader = new \Twig_Loader_Chain( [
-			new Twig_Loader_Filesystem( $templateDir ),
-			new TwigPageLoader( $provider )
-		] );
+		$loader = new \Twig_Loader_Chain( $loaders );
 
 		$twig = new Twig_Environment(
 			$loader,
@@ -43,5 +46,43 @@ class TwigFactory {
 		$twig->setLexer( $lexer );
 
 		return $twig;
+	}
+
+	public function newWikiPageLoader( WikiContentProvider $provider ) {
+		if ( empty( $this->config['loaders']['wiki'] ) ) {
+			return null;
+		}
+		return new TwigPageLoader( $provider );
+	}
+
+	public function newFileSystemLoader() {
+		if ( empty( $this->config['loaders']['filesystem'] ) ) {
+			return null;
+		}
+		if ( empty( $this->config['loaders']['filesystem']['template-dir'] ) ) {
+			$templateDir = [ 'app/templates' ];
+		}
+		elseif( is_string( $this->config['loaders']['filesystem']['template-dir'] ) ) {
+			$templateDir = [ $this->config['loaders']['filesystem']['template-dir'] ];
+		}
+		elseif( is_array( $this->config['loaders']['filesystem']['template-dir'] ) ) {
+			$templateDir = $this->config['loaders']['filesystem']['template-dir'];
+		}
+		else {
+			throw new \RuntimeException( 'wrong template dir type' );
+		}
+		$appRoot = realpath( __DIR__ . '/..' ) . '/';
+		$templateDir = array_map( function( $dir ) use ( $appRoot ) {
+			if ( strlen( $dir ) == 0 || $dir{0} != '/' ) {
+				return $appRoot . $dir;
+			}
+			return $dir;
+		}, $templateDir );
+		return new Twig_Loader_Filesystem( $templateDir );
+	}
+
+	public function newArrayLoader() {
+		$templates = $this->config['loaders']['array'] ?? [];
+		return new Twig_Loader_Array( $templates );
 	}
 }

--- a/tests/Fixtures/ApiPostRequestHandler.php
+++ b/tests/Fixtures/ApiPostRequestHandler.php
@@ -20,13 +20,7 @@ class ApiPostRequestHandler {
 	public function __invoke( Request $request ) {
 		$pageResponses = [
 			'Unicorns' => TestEnvironment::getJsonTestData( 'mwApiUnicornsPage.json' ),
-			'10hoch16/Seitenkopf' => TestEnvironment::getJsonTestData( 'mwApiHeaderPage.json' ),
-			'10hoch16/Seitenfuß' => TestEnvironment::getJsonTestData( 'mwApiFooterPage.json' ),
 			'MyNamespace:MyPrefix/Naked_mole-rat' => TestEnvironment::getJsonTestData( 'mwApiPrefixedTitlePage.json' ),
-			'JavaScript-Notice' => TestEnvironment::getJsonTestData( 'mwApiJsNoticePage.json' ),
-			'SubscriptionForm' => TestEnvironment::getJsonTestData( 'mwApiSubscriptionForm.json' ),
-			'Kontaktformular' => TestEnvironment::getJsonTestData( 'mwApiContactForm.json' ),
-			'ErrorPage' => TestEnvironment::getJsonTestData( 'mwApiErrorPage.json' ),
 		];
 
 		if ( array_key_exists( $request->getParams()['page'], $pageResponses ) ) {

--- a/tests/Integration/TwigFactoryTest.php
+++ b/tests/Integration/TwigFactoryTest.php
@@ -3,43 +3,75 @@
 
 namespace WMDE\Fundraising\Frontend\Tests\Integration;
 
-use WMDE\Fundraising\Frontend\Presenters\Content\WikiContentProvider;
 use WMDE\Fundraising\Frontend\TwigFactory;
+use Twig_LoaderInterface;
+use Twig_Error_Loader;
 
+/**
+ * @covers WMDE\Fundraising\Frontend\TwigFactory
+ *
+ * @licence GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
 class TwigFactoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testTwigInstanceUsesDollarPlaceholdersForVariables() {
-		$contentProvider = $this->getMockBuilder( WikiContentProvider::class )
-			->disableOriginalConstructor()->getMock();
-		$twig = TwigFactory::newFromConfig( [
-			'enable-twig-cache' => false,
-			'template-dir' => __DIR__ . '/../templates'
-		], $contentProvider );
+		$factory = new TwigFactory( [
+			'enable-cache' => false,
+			'loaders' => [
+				'array' => [ 'variableReplacement.twig' => '{$ testvar $}' ]
+			]
+		] );
+		$twig = $factory->create( [ $factory->newArrayLoader() ] );
 		$result = $twig->render( 'variableReplacement.twig', [ 'testvar' => 'Meeow!' ] );
 		$this->assertSame( 'Meeow!', $result);
 	}
 
-	public function testTwigInstancesCanLoadTemplatesFromWiki() {
-		$contentProvider = $this->getMockBuilder( WikiContentProvider::class )
-			->disableOriginalConstructor()->getMock();
-		$contentProvider->method( 'getContent' )->willReturn( 'Meeow!' );
-		$twig = TwigFactory::newFromConfig( [
-			'enable-twig-cache' => false,
-			'template-dir' => __DIR__ . '/../templates'
-		], $contentProvider );
+	public function testTwigInstancesTryAllLoadersUntilTemplateIsFound() {
+		$loaderException = new Twig_Error_Loader( 'not found' );
+		$firstLoader = $this->getMock( Twig_LoaderInterface::class );
+		$firstLoader->method( 'getSource' )->willThrowException( $loaderException );
+		$firstLoader->method( 'isFresh' )->willThrowException( $loaderException );
+		$firstLoader->method( 'getCacheKey' )->willThrowException( $loaderException );
+
+		$secondLoader = $this->getMock( Twig_LoaderInterface::class );
+		$secondLoader->method( 'getSource' )->willReturn( 'Meeow!' );
+		$secondLoader->method( 'isFresh' )->willReturn( true );
+		$secondLoader->method( 'getCacheKey' )->willReturn( 'Canis_silvestris' );
+
+		$thirdLoader = $this->getMock( Twig_LoaderInterface::class );
+		$thirdLoader->expects( $this->never() )->method( $this->anything() );
+
+		$factory = new TwigFactory( [ 'enable-cache' => false ] );
+		$twig = $factory->create( [ $firstLoader, $secondLoader, $thirdLoader ] );
 		$result = $twig->render( 'Canis_silvestris' );
 		$this->assertSame( 'Meeow!', $result);
 	}
 
-	public function testFileTemplatesArePreferredOverWikiPages() {
-		$contentProvider = $this->getMockBuilder( WikiContentProvider::class )
-			->disableOriginalConstructor()->getMock();
-		$contentProvider->method( 'getContent' )->willReturn( 'Woof?' );
-		$twig = TwigFactory::newFromConfig( [
-			'enable-twig-cache' => false,
-			'template-dir' => __DIR__ . '/../templates'
-		], $contentProvider );
-		$result = $twig->render( 'variableReplacement.twig', [ 'testvar' => 'Meeow!' ] );
-		$this->assertSame( 'Meeow!', $result);
+	public function testFilesystemLoaderConvertsStringPathToArray() {
+		$factory = new TwigFactory( [
+			'loaders' => [
+				'filesystem' => [
+					'template-dir' => __DIR__ . '/../templates'
+				]
+			]
+		] );
+		$loader = $factory->newFileSystemLoader();
+		$this->assertSame( [ __DIR__ . '/../templates' ], $loader->getPaths() );
 	}
+
+	public function testFilesystemLoaderPrependsRelativePathsToArray() {
+		$factory = new TwigFactory( [
+			'loaders' => [
+				'filesystem' => [
+					'template-dir' => 'tests/templates'
+				]
+			]
+		] );
+		$loader = $factory->newFileSystemLoader();
+		$realPath = realpath( $loader->getPaths()[0] );
+		$this->assertFalse( $realPath === false, 'path does not exist' );
+		$this->assertSame( $realPath, realPath( __DIR__ . '/../templates' ) );
+	}
+
 }

--- a/tests/Integration/UseCases/DisplayPage/DisplayPageUseCaseTest.php
+++ b/tests/Integration/UseCases/DisplayPage/DisplayPageUseCaseTest.php
@@ -23,7 +23,14 @@ class DisplayPageUseCaseTest extends \PHPUnit_Framework_TestCase {
 	private $testEnvironment;
 
 	public function setUp() {
-		$this->testEnvironment = TestEnvironment::newInstance();
+		$twigConfig = [
+			'twig' => [
+				'loaders' => [
+					'wiki' => true
+				]
+			]
+		];
+		$this->testEnvironment = TestEnvironment::newInstance( $twigConfig );
 		parent::setUp();
 	}
 

--- a/tests/System/Routes/AddSubscriptionRouteTest.php
+++ b/tests/System/Routes/AddSubscriptionRouteTest.php
@@ -83,15 +83,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 	}
 
 	public function testGivenInvalidDataAndNoContentType_routeDisplaysFormPage() {
-		$client = $this->createClient( [], function ( FunFunFactory $factory, array $config ) {
-			$api = $this->getMockBuilder( MediawikiApi::class )->disableOriginalConstructor()->getMock();
-
-			$api->expects( $this->any() )
-				->method( 'postRequest' )
-				->willReturnCallback( new ApiPostRequestHandler() );
-
-			$factory->setMediaWikiApi( $api );
-		} );
+		$client = $this->createClient();
 
 		$client->request(
 			'POST',
@@ -107,7 +99,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'text/html', $contentType, 'Wrong content type: ' . $contentType );
 		$this->assertSame( 1, $errorsFound, 'No error count found in test template' );
 		$this->assertGreaterThan( 0, (int) $errorMatches[1], 'Error list was empty' );
-		$this->assertContains( 'FirstName: Nyan', $content );
+		$this->assertContains( 'First Name: Nyan', $content );
 	}
 
 	public function testGivenInvalidDataAndJSONContentType_routeReturnsSuccessResult() {

--- a/tests/System/Routes/DisplayPageRouteTest.php
+++ b/tests/System/Routes/DisplayPageRouteTest.php
@@ -91,7 +91,19 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 	}
 
 	public function testWhenRequestedPageExists_itGetsEmbedded() {
-		$client = $this->createClient( [], function( FunFunFactory $factory, array $config ) {
+		$client = $this->createClient(
+			[
+				'twig' => [
+					'loaders' => [
+						'array' => [
+							'10hoch16/Seitenkopf' => '<p>I\'m a header</p>',
+							'10hoch16/Seitenfuß' => '<p>I\'m a footer</p>',
+							'JavaScript-Notice' => '<p>Y u no JavaScript!</p>',
+							]
+						]
+					]
+			],
+		function( FunFunFactory $factory, array $config ) {
 			$api = $this->getMockBuilder( MediawikiApi::class )->disableOriginalConstructor()->getMock();
 
 			$api->expects( $this->atLeastOnce() )

--- a/tests/System/Routes/GetInTouchRouteTest.php
+++ b/tests/System/Routes/GetInTouchRouteTest.php
@@ -47,15 +47,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 	}
 
 	public function testGivenInvalidRequest_validationFails() {
-		$client = $this->createClient( [], function ( FunFunFactory $factory, array $config ) {
-			$api = $this->getMockBuilder( MediawikiApi::class )->disableOriginalConstructor()->getMock();
-
-			$api->expects( $this->any() )
-				->method( 'postRequest' )
-				->willReturnCallback( new ApiPostRequestHandler() );
-
-			$factory->setMediaWikiApi( $api );
-		} );
+		$client = $this->createClient();
 
 		$client->request(
 			'POST',
@@ -83,12 +75,6 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 
 	public function testOnException_errorPageIsRendered() {
 		$client = $this->createClient( [], function ( FunFunFactory $factory, array $config ) {
-			$api = $this->getMockBuilder( MediawikiApi::class )->disableOriginalConstructor()->getMock();
-
-			$api->expects( $this->any() )
-				->method( 'postRequest' )
-				->willReturnCallback( new ApiPostRequestHandler() );
-
 			$messenger = $this->getMockBuilder( Messenger::class )
 				->disableOriginalConstructor()
 				->getMock();
@@ -97,7 +83,6 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 				->method( 'sendMessage' )
 				->willThrowException( new \RuntimeException( 'Something unexpected happened' ) );
 
-			$factory->setMediaWikiApi( $api );
 			$factory->setMessenger( $messenger );
 		} );
 

--- a/tests/data/mwApiContactForm.json
+++ b/tests/data/mwApiContactForm.json
@@ -1,9 +1,0 @@
-{
-	"parse": {
-		"title": "Kontaktformular",
-		"pageid": 8192,
-		"text": {
-			"*": "<-- just for testing if data is assigned and processed -->\nErrors: {$ errors|length $}\nFirst Name: {$ firstname $}"
-		}
-	}
-}

--- a/tests/data/mwApiErrorPage.json
+++ b/tests/data/mwApiErrorPage.json
@@ -1,9 +1,0 @@
-{
-	"parse": {
-		"title": "ErrorPage",
-		"pageid": 8118,
-		"text": {
-			"*": "Internal Error: {$ message $}"
-		}
-	}
-}

--- a/tests/data/mwApiSubscriptionForm.json
+++ b/tests/data/mwApiSubscriptionForm.json
@@ -1,9 +1,0 @@
-{
-  "parse": {
-    "title": "SubscriptionForm",
-    "pageid": 9002,
-    "text": {
-      "*": "<-- just for testing if data is assigned and processed -->\nErrors: {$ errors|length $}\nFirstName: {$ firstName $}"
-    }
-  }
-}

--- a/tests/templates/ErrorPage.twig
+++ b/tests/templates/ErrorPage.twig
@@ -1,0 +1,3 @@
+{% if message is defined %}
+Internal Error: {$ message $}
+{% endif %}

--- a/tests/templates/Kontaktformular.twig
+++ b/tests/templates/Kontaktformular.twig
@@ -1,0 +1,3 @@
+<-- just for testing if data is assigned and processed -->
+Errors: {$ errors|length $}
+First Name: {$ firstname $}

--- a/tests/templates/SubscriptionForm.twig
+++ b/tests/templates/SubscriptionForm.twig
@@ -1,0 +1,3 @@
+<-- just for testing if data is assigned and processed -->
+Errors: {$ errors|length $}
+First Name: {$ firstName $}


### PR DESCRIPTION
All tests that were using templates were dependent on the MediaWiki API
and needed complicated setup of templates wrapped in JSON. This patch
introduces the ability to turn the MediaWiki page loading off and
replace the JSON responses with simple Twig templates.

The following changes were made:
* Put all twig configuration in one place in JSON config
* Refactor TwigFactory to use the new twig configuration array to
  create various twig classes.
* Add relative path loading for file system based templates.
* Remove MediaWiki API stubs and their JSON data files from tests.
* Add .twig suffix to included wiki page templates. The Wiki page
  loader will automatically remove the suffix and the tests can use
  files with the correct highlighting.
* Remove Twig injection into $app - this created a Twig instance
  even when none was needed.