### PR TITLE
Send Subscription email

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -30,5 +30,9 @@
 		"no-js-notice": "JavaScript-Notice"
 	},
 	"operator-email": "",
-	"operator-displayname": ""
+	"operator-displayname": "",
+	"mail-recipients": {
+		"add-subscription": "",
+		"get-in-touch": ""
+	}
 }

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -21,5 +21,9 @@
 		}
 	},
 	"operator-email": "email@operatorsownmailserver.com",
-	"operator-displayname": "Friendly Operator"
+	"operator-displayname": "Friendly Operator",
+	"mail-recipients": {
+		"add-subscription": "email@operatorsownmailserver.com",
+		"get-in-touch": "email@operatorsownmailserver.com"
+	}
 }

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -313,7 +313,20 @@ class FunFunFactory {
 	}
 
 	public function newAddSubscriptionUseCase(): AddSubscriptionUseCase {
-		return new AddSubscriptionUseCase( $this->newRequestRepository(), $this->getRequestValidator() );
+		return new AddSubscriptionUseCase(
+			$this->newRequestRepository(),
+			$this->getRequestValidator(),
+			$this->newAddSubscriptionMessenger()
+		);
+	}
+
+	private function newAddSubscriptionMessenger(): TemplatedMessenger {
+		return new TemplatedMessenger(
+			$this->getMessenger(),
+			'Ihre Mitgliedschaft bei Wikimedia Deutschland', // TODO make this translatable
+			new TwigTemplate( $this->getTwig(), 'AddSubscriptionMailExternal.twig' ),
+			new MailAddress( $this->config['mail-recipients']['add-subscription'] )
+		);
 	}
 
 	public function newCheckIbanUseCase(): CheckIbanUseCase {

--- a/src/TemplatedMessenger.php
+++ b/src/TemplatedMessenger.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace WMDE\Fundraising\Frontend;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class TemplatedMessenger {
+
+	private $messenger;
+	private $subject;
+	private $bodyTemplate;
+	private $recipient;
+
+	public function __construct( Messenger $messenger, string $subject, TwigTemplate $bodyTemplate, MailAddress $recipient ) {
+		$this->messenger = $messenger;
+		$this->subject = $subject;
+		$this->bodyTemplate = $bodyTemplate;
+		$this->recipient = $recipient;
+	}
+
+	public function sendMessage( array $templateData, MailAddress $replyTo = null ) {
+		$this->messenger->sendMessage(
+			$this->subject,
+			$this->bodyTemplate->render( $templateData ),
+			$this->recipient,
+			$replyTo
+		);
+	}
+}

--- a/tests/System/Routes/AddSubscriptionRouteTest.php
+++ b/tests/System/Routes/AddSubscriptionRouteTest.php
@@ -44,9 +44,9 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 	protected function onTestEnvironmentCreated( FunFunFactory $factory, array $config ) {
 		// @codingStandardsIgnoreEnd
 		$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress() )
-		);
+			Swift_NullTransport::newInstance(),
+			$factory->getOperatorAddress()
+		) );
 	}
 
 	public function testValidSubscriptionRequestGetsPersisted() {

--- a/tests/System/Routes/AddSubscriptionRouteTest.php
+++ b/tests/System/Routes/AddSubscriptionRouteTest.php
@@ -4,11 +4,11 @@ declare(strict_types = 1);
 
 namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
 
-use Mediawiki\Api\MediawikiApi;
 use WMDE\Fundraising\Frontend\FunFunFactory;
-use WMDE\Fundraising\Frontend\Tests\Fixtures\ApiPostRequestHandler;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\SubscriptionRepositorySpy;
 use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
+use WMDE\Fundraising\Frontend\Messenger;
+use Swift_NullTransport;
 
 /**
  * @licence GNU GPL v2+
@@ -39,6 +39,15 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		'email' => '',
 		'wikilogin' => true
 	];
+
+	// @codingStandardsIgnoreStart
+	protected function onTestEnvironmentCreated( FunFunFactory $factory, array $config ) {
+		// @codingStandardsIgnoreEnd
+		$factory->setMessenger( new Messenger(
+				Swift_NullTransport::newInstance(),
+				$factory->getOperatorAddress() )
+		);
+	}
 
 	public function testValidSubscriptionRequestGetsPersisted() {
 		$subscriptionRepository = new SubscriptionRepositorySpy();

--- a/tests/Unit/TemplatedMessengerTest.php
+++ b/tests/Unit/TemplatedMessengerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit;
+
+use WMDE\Fundraising\Frontend\TemplatedMessenger;
+use WMDE\Fundraising\Frontend\Messenger;
+use WMDE\Fundraising\Frontend\TwigTemplate;
+use WMDE\Fundraising\Frontend\MailAddress;
+
+class TemplatedMessengerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testItSendsMailsWithMessengerAndTemplate() {
+		$template = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
+		$messenger = $this->getMockBuilder( Messenger::class )->disableOriginalConstructor()->getMock();
+		$recipient = $this->getMockBuilder( MailAddress::class )->disableOriginalConstructor()->getMock();
+		$replyTo = $this->getMockBuilder( MailAddress::class )->disableOriginalConstructor()->getMock();
+		$templatedMessenger  = new TemplatedMessenger( $messenger, 'Important unicorn update', $template, $recipient );
+		$template->method( 'render' )->willReturn( 'Pink fluffy unicorns dancing on rainbows' );
+		$messenger->expects( $this->once() )
+			->method( 'sendMessage' )
+			->with( 'Important unicorn update', 'Pink fluffy unicorns dancing on rainbows', $recipient, $replyTo );
+		$templatedMessenger->sendMessage( [], $replyTo );
+	}
+}

--- a/tests/templates/AddSubscriptionMailExternal.twig
+++ b/tests/templates/AddSubscriptionMailExternal.twig
@@ -1,0 +1,2 @@
+Email: {$ subscription.email $}
+First Name: {$ subscription.address.firstName $}


### PR DESCRIPTION
Added a new class, TemplatedMessenger, that that is prepared with a mail
template and only receives data for sending messages. This avoids having
to inject four additional  dependencies (mail template, translatable
subject line, Messenger, recipient) into the use cases just to send an email.

Made mail recipients configurable.

Did some cleanup in the add subscription use case class.

This is based on #92, please merge that first.