### PR TITLE
retrieve raw wikitext

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -17,7 +17,10 @@
 	"twig": {
 		"enable-cache": true,
 		"loaders": {
-			"wiki": true,
+			"wiki": {
+				"enabled": true,
+				"rawpages": []
+			},
 			"filesystem": {
 				"template-dir": [ "app/templates" ]
 			},

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -11,7 +11,9 @@
 	"twig": {
 		"enable-cache": false,
 		"loaders": {
-			"wiki": false,
+			"wiki": {
+				"enabled": false
+			},
 			"filesystem": {
 				"template-dir": [
 					"app/templates",

--- a/src/DataAccess/ApiBasedPageRetriever.php
+++ b/src/DataAccess/ApiBasedPageRetriever.php
@@ -28,6 +28,12 @@ class ApiBasedPageRetriever implements PageRetriever {
 		$this->logger = $logger;
 	}
 
+	/**
+	 * @param string $pageTitle
+	 * @param string $action
+	 * @throws \RuntimeException if the value of $action is not supported
+	 * @return string
+	 */
 	public function fetchPage( string $pageTitle, string $action = 'render' ): string {
 		$this->logger->debug( __METHOD__ . ': pageTitle', [ $pageTitle ] );
 
@@ -44,6 +50,7 @@ class ApiBasedPageRetriever implements PageRetriever {
 				$content = $this->retrieveRenderedPage( $pageTitle );
 				break;
 			default:
+				throw new \RuntimeException( 'Action "' . $action . '" not supported' );
 				break;
 		}
 

--- a/src/DataAccess/LocalFilePageRetriever.php
+++ b/src/DataAccess/LocalFilePageRetriever.php
@@ -23,7 +23,7 @@ class LocalFilePageRetriever implements PageRetriever {
 		$this->fetcher = $fetcher;
 	}
 
-	public function fetchPage( string $filename ): string {
+	public function fetchPage( string $filename, string $fetchMode = '' ): string {
 		$this->logger->debug( __METHOD__ . ': wiki_page', [ $filename ] );
 
 		try {

--- a/src/Domain/PageRetriever.php
+++ b/src/Domain/PageRetriever.php
@@ -14,8 +14,9 @@ interface PageRetriever {
 
 	/**
 	 * @param string $pageName
+	 * @param string $fetchMode
 	 * @return string
 	 */
-	public function fetchPage( string $pageName ): string;
+	public function fetchPage( string $pageName, string $fetchMode ): string;
 
 }

--- a/src/Presenters/Content/WikiContentProvider.php
+++ b/src/Presenters/Content/WikiContentProvider.php
@@ -20,10 +20,10 @@ class WikiContentProvider {
 		$this->pageTitlePrefix = $pageTitlePrefix;
 	}
 
-	public function getContent( string $pageName ): string {
+	public function getContent( string $pageName, string $fetchMode = 'render' ): string {
 		$prefixedPageName = $this->getPrefixedPageTitle( $pageName );
 		$normalizedPageName = $this->normalizePageName( $prefixedPageName );
-		$content = $this->pageRetriever->fetchPage( $normalizedPageName );
+		$content = $this->pageRetriever->fetchPage( $normalizedPageName, $fetchMode );
 		$content = $this->contentModifier->getProcessedContent( $content, $normalizedPageName );
 
 		return $content;

--- a/src/TwigFactory.php
+++ b/src/TwigFactory.php
@@ -51,10 +51,10 @@ class TwigFactory {
 	}
 
 	public function newWikiPageLoader( WikiContentProvider $provider ) {
-		if ( empty( $this->config['loaders']['wiki'] ) ) {
+		if ( !$this->config['loaders']['wiki']['enabled'] ) {
 			return null;
 		}
-		return new TwigPageLoader( $provider );
+		return new TwigPageLoader( $provider, $this->config['loaders']['wiki']['rawpages'] ?? [] );
 	}
 
 	public function newFileSystemLoader() {

--- a/src/TwigPageLoader.php
+++ b/src/TwigPageLoader.php
@@ -15,9 +15,11 @@ class TwigPageLoader implements \Twig_LoaderInterface {
 	private $contentProvider;
 	private $pageCache = [];
 	private $errorCache = [];
+	private $rawPagesList = [];
 
-	public function __construct( WikiContentProvider $contentProvider ) {
+	public function __construct( WikiContentProvider $contentProvider, array $rawPagesList = [] ) {
 		$this->contentProvider = $contentProvider;
+		$this->rawPagesList = $rawPagesList;
 	}
 
 	public function getSource( $name ): string {
@@ -42,6 +44,7 @@ class TwigPageLoader implements \Twig_LoaderInterface {
 	}
 
 	private function retrievePage( string $pageName ): string {
+		$fetchMode = in_array( $pageName, $this->rawPagesList ) ? 'raw' : 'render';
 		$title = preg_replace( '/\\.twig$/', '', $pageName );
 		if ( isset( $this->pageCache[$title] ) ) {
 			return $this->pageCache[$title];
@@ -49,7 +52,7 @@ class TwigPageLoader implements \Twig_LoaderInterface {
 		if ( isset( $this->errorCache[$title] ) ) {
 			throw new Twig_Error_Loader( "Wiki page $title not found." );
 		}
-		$content = $this->contentProvider->getContent( $title );
+		$content = $this->contentProvider->getContent( $title, $fetchMode );
 		if ( $content !== '' ) {
 			$this->pageCache[$title] = $content;
 			return $content;

--- a/tests/Unit/TwigPageLoaderTest.php
+++ b/tests/Unit/TwigPageLoaderTest.php
@@ -58,4 +58,27 @@ class TwigPageLoaderTest extends \PHPUnit_Framework_TestCase {
 		$loader = new TwigPageLoader( $pageRetriever );
 		$loader->isFresh( 'Felis silvestris', 0 );
 	}
+
+	public function testPageTitleConfiguredAsRawContent_pageRetrieverFetchesInRawMode() {
+		$pageRetriever = $this->getMockBuilder( WikiContentProvider::class )->disableOriginalConstructor()->getMock();
+		$pageRetriever->method( 'getContent' )->willReturn( 'template text' );
+		$pageRetriever->expects( $this->once() )
+			->method( 'getContent' )
+			->with( 'FetchMeInRawMode', 'raw' );
+
+		$loader = new TwigPageLoader( $pageRetriever, [ 'FetchMeInRawMode' ] );
+		$loader->getSource( 'FetchMeInRawMode' );
+	}
+
+	public function testPageTitleNotConfiguredAsRawContent_pageRetrieverFetchesInRenderMode() {
+		$pageRetriever = $this->getMockBuilder( WikiContentProvider::class )->disableOriginalConstructor()->getMock();
+		$pageRetriever->method( 'getContent' )->willReturn( 'template text' );
+		$pageRetriever->expects( $this->once() )
+			->method( 'getContent' )
+			->with( 'FetchMeInRenderMode', 'render' );
+
+		$loader = new TwigPageLoader( $pageRetriever, [ 'FetchMeInRawMode' ] );
+		$loader->getSource( 'FetchMeInRenderMode' );
+	}
+
 }


### PR DESCRIPTION
This changes the TwigLoader for wiki content to be able to retrieve raw wikitext, which is needed for plain text emails.