### PR TITLE
Add ConfirmationCodeConverter

### DIFF
--- a/src/ConfirmationCodeConverter.php
+++ b/src/ConfirmationCodeConverter.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace WMDE\Fundraising\Frontend;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class ConfirmationCodeConverter {
+
+	public function fromBinaryToReadable( string $binaryString ): string {
+		$data = unpack( 'H*', $binaryString );
+		return base_convert( array_shift( $data ), 16, 36 );
+	}
+
+	public function fromReadableToBinary( string $readableString ): string {
+		$hexData = base_convert( $readableString, 36, 16 );
+		return pack( 'H*', $hexData );
+	}
+}

--- a/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
+++ b/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
@@ -5,6 +5,7 @@ namespace WMDE\Fundraising\Frontend\UseCases\AddSubscription;
 
 use WMDE\Fundraising\Entities\Address;
 use WMDE\Fundraising\Entities\Subscription;
+use WMDE\Fundraising\Frontend\ConfirmationCodeConverter;
 use WMDE\Fundraising\Frontend\Domain\SubscriptionRepository;
 use WMDE\Fundraising\Frontend\MailAddress;
 use WMDE\Fundraising\Frontend\Messenger;
@@ -45,7 +46,12 @@ class AddSubscriptionUseCase {
 		$this->subscriptionRepository->storeSubscription( $subscription );
 
 		$postalAddress = $subscription->getAddress();
-		$this->message->setTemplateParams( [ 'subscription' => $subscription ] );
+		$confirmationCodeConverter = new ConfirmationCodeConverter();
+		$confirmationCode = $confirmationCodeConverter->fromBinaryToReadable( $subscription->getConfirmationCode() );
+		$this->message->setTemplateParams( [
+			'subscription' => $subscription,
+			'confirmation_code' => $confirmationCode
+		] );
 		$this->messenger->sendMessageToUser( $this->message,
 			new MailAddress(
 				$subscription->getEmail(),

--- a/tests/Unit/ConfirmationCodeConverterTest.php
+++ b/tests/Unit/ConfirmationCodeConverterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit;
+
+use WMDE\Fundraising\Frontend\ConfirmationCodeConverter;
+
+class ConfirmationCodeConverterTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenABinaryString_itIsConvertedToReadableFormat() {
+		$binaryString = chr( 42 ) . chr( 24 ) . chr( 13 ) . chr( 37 );
+		$converter = new ConfirmationCodeConverter();
+		$this->assertSame( 'bogqat', $converter->fromBinaryToReadable( $binaryString ) );
+	}
+
+	public function testGivenReadableString_itIsConvertedToBinaryData() {
+		$converter = new ConfirmationCodeConverter();
+		$binaryString = chr( 97 ) . chr( 193 ) . chr( 23 ) . chr( 9 ) . chr( 180 ) . chr( 120 );
+		$this->assertSame( $binaryString, $converter->fromReadableToBinary( '123kittens' ) );
+	}
+
+	public function testGivenReadableStringWithBogusCharacters_itIsConvertedToBinaryData() {
+		$converter = new ConfirmationCodeConverter();
+		$binaryString = chr( 97 ) . chr( 193 ) . chr( 23 ) . chr( 9 ) . chr( 180 ) . chr( 120 );
+		$this->assertSame( $binaryString, $converter->fromReadableToBinary( '123-kittens!!!' ) );
+	}
+
+}


### PR DESCRIPTION
The `ConfirmationCodeConverter` converts the binary data in the
`confirmationCode` field of the `Subscription` entity into readable codes
that can be safely inserted in URLs and templates.