### PR TITLE
Introduce TemplateBasedMailer

### DIFF
--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -316,15 +316,15 @@ class FunFunFactory {
 		return new AddSubscriptionUseCase(
 			$this->newRequestRepository(),
 			$this->getRequestValidator(),
-			$this->getMessenger(),
-			$this->newAddSubscriptionMessage()
+			$this->newAddSubscriptionMailer()
 		);
 	}
 
-	private function newAddSubscriptionMessage(): TemplatedMessage {
-		return new TemplatedMessage(
-			'Ihre Mitgliedschaft bei Wikimedia Deutschland', // TODO make this translatable
-			new TwigTemplate( $this->getTwig(), 'AddSubscriptionMailExternal.twig' )
+	private function newAddSubscriptionMailer(): TemplateBasedMailer {
+		return new TemplateBasedMailer(
+			$this->getMessenger(),
+			new TwigTemplate( $this->getTwig(), 'AddSubscriptionMailExternal.twig' ),
+			'Ihre Mitgliedschaft bei Wikimedia Deutschland' // TODO make this translatable
 		);
 	}
 

--- a/src/TemplateBasedMailer.php
+++ b/src/TemplateBasedMailer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace WMDE\Fundraising\Frontend;
+
+use Swift_Message;
+use Swift_Transport;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class TemplateBasedMailer {
+
+	private $messenger;
+	private $template;
+	private $subject;
+
+	public function __construct( Messenger $messenger, TwigTemplate $template, string $mailSubject ) {
+		$this->messenger = $messenger;
+		$this->template = $template;
+		$this->subject = $mailSubject;
+	}
+
+	public function sendMail( MailAddress $recipient, array $templateArguments ) {
+		$this->messenger->sendMessageToUser(
+			new SimpleMessage(
+				$this->subject,
+				$this->template->render( $templateArguments )
+			),
+			$recipient
+		);
+	}
+
+}


### PR DESCRIPTION
PR includes  #104, please merge that one first and then review only the second commit here.

--

This is an interface designed based on the needs of the existing users
of TemplatedMessage and Messeger. They now only require a single service,
no longer need to mutate state part of a field and are exposed only
to what they need.

Only refactored the AddSubscriptionUseCase so far. Same should happen for
GetInTouchUseCase, after which TemplatedMessage can presumably be removed.

How to create weird interfaces:

* my code needs some Foo service
* Let's create a Foo service object
* What makes sense for Foo to have, and how does it work for all users I can think of
* Foo created. Now let's see how I can use it in my code

How to create good interfaces:

* my code needs a Foo service
* it has these variables that it would give to the service
* lets create Foo with a method that takes those parameters

Note how you can finish your code in test driven manner without actually implementing Foo.