### PR TITLE
Make error response Content-Type specific

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -104,7 +104,7 @@ $app->post(
 		] );
 
 		$responseModel = $useCase->addSubscription( $subscriptionRequest );
-		if ( in_array( 'application/json', $request->getAcceptableContentTypes() ) ) {
+		if ( $app['request.is_json'] ) {
 			return $app->json( $ffFactory->newAddSubscriptionJSONPresenter()->present( $responseModel ) );
 		}
 		if ( $responseModel->isSuccessful() ) {

--- a/tests/System/RouteNotFoundTest.php
+++ b/tests/System/RouteNotFoundTest.php
@@ -17,4 +17,19 @@ class RouteNotFoundTest extends WebRouteTestCase {
 		$this->assert404( $client->getResponse() );
 	}
 
+	public function testGivenUnknownRoute_responseIsHTML() {
+		$client = $this->createClient();
+		$client->request( 'GET', '/kittens' );
+
+		$this->assertContains( 'text/html', $client->getResponse()->headers->get( 'Content-Type') );
+		$this->assertContains( '<html', $client->getResponse()->getContent() );
+	}
+
+	public function testGivenUnknownRouteAndJSONRquest_responseIsJSON() {
+		$client = $this->createClient();
+		$client->request( 'GET', '/kittens', [], [], ['HTTP_Accept' => 'application/json'] );
+
+		$this->assertJsonResponse( ['ERR' => 'No route found for "GET /kittens"'], $client->getResponse() );
+	}
+
 }

--- a/tests/System/WebRouteTestCase.php
+++ b/tests/System/WebRouteTestCase.php
@@ -64,7 +64,7 @@ abstract class WebRouteTestCase extends \PHPUnit_Framework_TestCase {
 		$this->assertSame( 404, $response->getStatusCode() );
 	}
 
-	private function assertJsonResponse( $expected, Response $response ) {
+	protected function assertJsonResponse( $expected, Response $response ) {
 		$this->assertSame(
 			json_encode( $expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
 			$response->getContent()


### PR DESCRIPTION
The error response now sends a JSON response if the "Accept" header
of the request contains 'application/json'.

Also added the app parameter `request.is_json` so routes that are not
suffix-based can check for it.