### PR TITLE
Validate against word list

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -33,5 +33,11 @@
 		"no-js-notice": "JavaScript-Notice"
 	},
 	"operator-email": "",
-	"operator-displayname": ""
+	"operator-displayname": "",
+	"text-policies": {
+		"fields": {
+			"whitewords": "",
+			"badwords": ""
+		}
+	}
 }

--- a/app/routes.php
+++ b/app/routes.php
@@ -120,6 +120,9 @@ $app->post(
 			return $app->json( $ffFactory->newAddSubscriptionJSONPresenter()->present( $responseModel ) );
 		}
 		if ( $responseModel->isSuccessful() ) {
+			if ( $responseModel->needsModeration() ) {
+				return $app->redirect( $app['url_generator']->generate('page', [ 'pageName' => 'SubscriptionModeration' ] ) );
+			}
 			return $app->redirect( $app['url_generator']->generate('page', [ 'pageName' => 'SubscriptionSuccess' ] ) );
 		}
 		return $ffFactory->newAddSubscriptionHTMLPresenter()->present( $responseModel, $request->request->all() );

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -52,6 +52,7 @@ use WMDE\Fundraising\Frontend\UseCases\ListComments\ListCommentsUseCase;
 use WMDE\Fundraising\Frontend\UseCases\CheckIban\CheckIbanUseCase;
 use WMDE\Fundraising\Frontend\UseCases\GenerateIban\GenerateIbanUseCase;
 use WMDE\Fundraising\Frontend\UseCases\ValidateEmail\ValidateEmailUseCase;
+use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
 use WMDE\Fundraising\Store\Factory as StoreFactory;
 use WMDE\Fundraising\Store\Installer;
 
@@ -108,7 +109,7 @@ class FunFunFactory {
 		} );
 
 		$pimple['request_validator'] = $pimple->share( function() {
-			return new SubscriptionValidator( $this->getMailValidator() );
+			return new SubscriptionValidator( $this->getMailValidator(), $this->getTextPolicyValidator( 'fields' ) );
 		} );
 
 		$pimple['contact_validator'] = $pimple->share( function() {
@@ -415,6 +416,26 @@ class FunFunFactory {
 
 	private function getTwigFactory(): TwigFactory {
 		return $this->pimple['twig_factory'];
+	}
+
+	private function getTextPolicyValidator( $policyName ) {
+		$policyValidator = new TextPolicyValidator();
+		$contentProvider = $this->newWikiContentProvider();
+		$textPolicyConfig = $this->config['text-policies'][$policyName];
+		$badWords = $this->loadWordsFromWiki( $contentProvider, $textPolicyConfig['badwords'] ?? '' );
+		$whiteWords = $this->loadWordsFromWiki( $contentProvider, $textPolicyConfig['whitewords'] ?? '' );
+		$policyValidator->addBadWordsFromArray( $badWords );
+		$policyValidator->addWhiteWordsFromArray( $whiteWords );
+		return $policyValidator;
+	}
+
+	private function loadWordsFromWiki( WikiContentProvider $contentProvider, string $pageName ): array {
+		if ( $pageName === '' ) {
+			return [];
+		}
+		$content = $contentProvider->getContent( $pageName, 'raw' );
+		$words = array_map( 'trim', explode( "\n", $content ) );
+		return array_filter( $words );
 	}
 
 }

--- a/src/ResponseModel/ValidationResponse.php
+++ b/src/ResponseModel/ValidationResponse.php
@@ -9,9 +9,11 @@ namespace WMDE\Fundraising\Frontend\ResponseModel;
 class ValidationResponse {
 
 	private $validationErrors;
+	private $needsModerationValue;
 
-	public function __construct( array $requestValidationErrors = [] ) {
+	public function __construct( array $requestValidationErrors = [], $needsModeration = false ) {
 		$this->validationErrors = $requestValidationErrors;
+		$this->needsModerationValue = $needsModeration;
 	}
 
 	public static function newSuccessResponse(): self {
@@ -22,12 +24,20 @@ class ValidationResponse {
 		return new self( $errors );
 	}
 
+	public static function newModerationNeededResponse(): self {
+		return new self( [], true );
+	}
+
 	public function getValidationErrors(): array {
 		return $this->validationErrors;
 	}
 
 	public function isSuccessful(): bool {
 		return count( $this->validationErrors ) == 0;
+	}
+
+	public function needsModeration(): bool {
+		return $this->needsModerationValue;
 	}
 
 }

--- a/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
+++ b/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
@@ -38,6 +38,11 @@ class AddSubscriptionUseCase {
 		}
 
 		$this->subscriptionRepository->storeSubscription( $subscription );
+
+		if ( $this->subscriptionValidator->needsModeration( $subscription ) ) {
+			return ValidationResponse::newModerationNeededResponse();
+		}
+
 		$this->sendSubscriptionNotification( $subscription );
 
 		return ValidationResponse::newSuccessResponse();

--- a/src/Validation/FieldTextPolicyValidator.php
+++ b/src/Validation/FieldTextPolicyValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Validation;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class FieldTextPolicyValidator implements ScalarValueValidator {
+
+	const VIOLATION_MESSAGE = 'This field has unacceptable language or URLs in it';
+
+	private $lastViolation = null;
+	private $validationFlags;
+	private $textPolicyValidator;
+
+	public function __construct( TextPolicyValidator $textPolicyValidator, int $validationFlags = 0 ) {
+		$this->textPolicyValidator = $textPolicyValidator;
+		$this->validationFlags = $validationFlags;
+	}
+
+	public function validate( $value ): bool {
+		if ( $value === '' ) {
+			return true;
+		}
+		if ( $this->textPolicyValidator->hasHarmlessContent( (string) $value, $this->validationFlags ) ) {
+			return true;
+		}
+		$this->lastViolation = new ConstraintViolation( $value, self::VIOLATION_MESSAGE, $this );
+		return false;
+	}
+
+	public function getLastViolation(): ConstraintViolation {
+		return $this->lastViolation;
+	}
+
+}

--- a/src/Validation/SubscriptionValidator.php
+++ b/src/Validation/SubscriptionValidator.php
@@ -14,11 +14,15 @@ class SubscriptionValidator implements InstanceValidator {
 	use CanValidateField;
 
 	private $mailValidator;
+	private $textPolicyValidator;
 	private $constraintViolations;
+	private $textPolicyViolations;
 
-	public function __construct( MailValidator $mailValidator ) {
+	public function __construct( MailValidator $mailValidator, TextPolicyValidator $textPolicyValidator ) {
 		$this->mailValidator = $mailValidator;
+		$this->textPolicyValidator = $textPolicyValidator;
 		$this->constraintViolations = [];
+		$this->textPolicyViolations = [];
 	}
 
 	/**
@@ -26,20 +30,52 @@ class SubscriptionValidator implements InstanceValidator {
 	 * @return bool
 	 */
 	public function validate( $instance ): bool {
-		$violations = [];
-		$requiredFieldValidator = new RequiredFieldValidator();
-		$address = $instance->getAddress();
-		$violations[] = $this->validateField( $requiredFieldValidator, $address->getSalutation(), 'salutation');
-		$violations[] = $this->validateField( $requiredFieldValidator, $address->getFirstName(), 'firstName');
-		$violations[] = $this->validateField( $requiredFieldValidator, $address->getLastName(), 'lastName');
-		$violations[] = $this->validateField( $requiredFieldValidator, $instance->getEmail(), 'email');
+		$violations = $this->getRequiredFieldViolations( $instance );
 		$violations[] = $this->validateField( $this->mailValidator, $instance->getEmail(), 'email');
 		$this->constraintViolations = array_filter( $violations );
 		return count( $this->constraintViolations ) == 0;
 	}
 
+	public function needsModeration( $instance ): bool {
+		$this->textPolicyViolations = array_filter( $this->getBadWordViolations( $instance ) );
+		return count( $this->textPolicyViolations ) > 0;
+	}
+
+	private function getRequiredFieldViolations( Subscription $instance ): array {
+		$address = $instance->getAddress();
+		$requiredFieldValidator = new RequiredFieldValidator();
+		$violations = [];
+		$violations[] = $this->validateField( $requiredFieldValidator, $address->getSalutation(), 'salutation');
+		$violations[] = $this->validateField( $requiredFieldValidator, $address->getFirstName(), 'firstName');
+		$violations[] = $this->validateField( $requiredFieldValidator, $address->getLastName(), 'lastName');
+		$violations[] = $this->validateField( $requiredFieldValidator, $instance->getEmail(), 'email');
+		return $violations;
+	}
+
+	private function getBadWordViolations( Subscription $instance ) {
+		$violations = [];
+
+		$flags = TextPolicyValidator::CHECK_BADWORDS |
+			TextPolicyValidator::IGNORE_WHITEWORDS |
+			TextPolicyValidator::CHECK_URLS;
+		$fieldTextValidator = new FieldTextPolicyValidator( $this->textPolicyValidator, $flags );
+		$address = $instance->getAddress();
+
+		$violations[] = $this->validateField( $fieldTextValidator, $address->getFirstName(), 'firstName');
+		$violations[] = $this->validateField( $fieldTextValidator, $address->getLastName(), 'lastName');
+		$violations[] = $this->validateField( $fieldTextValidator, $address->getCompany(), 'company' );
+		$violations[] = $this->validateField( $fieldTextValidator, $address->getAddress(), 'address');
+		$violations[] = $this->validateField( $fieldTextValidator, $address->getPostcode(), 'postcode');
+		$violations[] = $this->validateField( $fieldTextValidator, $address->getCity(), 'city');
+		return $violations;
+	}
+
 	public function getConstraintViolations(): array {
 		return $this->constraintViolations;
+	}
+
+	public function getTextPolicyViolations(): array {
+		return $this->textPolicyViolations;
 	}
 
 }

--- a/src/Validation/TextPolicyValidator.php
+++ b/src/Validation/TextPolicyValidator.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace WMDE\Fundraising\Frontend\Validation;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Christoph Fischer < christoph.fischer@wikimedia.de >
+ */
+class TextPolicyValidator {
+
+	private $badWordsArray = [];
+	private $whiteWordsArray = [];
+
+	const CHECK_URLS = 1;
+	const CHECK_URLS_DNS = 2;
+	const CHECK_BADWORDS = 4;
+	const IGNORE_WHITEWORDS = 8;
+
+	public function hasHarmlessContent( string $text, int $flags ): bool {
+		$ignoreWhiteWords = (bool) ( $flags & self::IGNORE_WHITEWORDS );
+
+		if ( $flags & self::CHECK_URLS ) {
+			$testWithDNS = (bool) ( $flags & self::CHECK_URLS_DNS );
+
+			if ( $this->hasUrls( $text, $testWithDNS, $ignoreWhiteWords ) ) {
+				return false;
+			}
+		}
+
+		if ( $flags & self::CHECK_BADWORDS ) {
+			if ( count( $this->badWordsArray ) > 0 && $this->hasBadWords( $text, $ignoreWhiteWords ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public function addBadWordsFromFile( string $badWordsFilePath ) {
+		$newBadWordsArray = file( $badWordsFilePath, FILE_IGNORE_NEW_LINES );
+		$this->addBadWordsFromArray( $newBadWordsArray );
+	}
+
+	public function addBadWordsFromString( string $newBadWordsString ) {
+		$this->addBadWordsFromArray( explode( '|', $newBadWordsString ) );
+	}
+
+	/**
+	 * @param string[] $newBadWordsArray
+	 */
+	public function addBadWordsFromArray( array $newBadWordsArray ) {
+		$this->badWordsArray = array_merge( $this->badWordsArray, $newBadWordsArray );
+	}
+
+	public function addWhiteWordsFromFile( string $whiteWordsFilePath ) {
+		$newWhiteWordsArray = file( $whiteWordsFilePath, FILE_IGNORE_NEW_LINES );
+		$this->addWhiteWordsFromArray( $newWhiteWordsArray );
+	}
+
+	public function addWhiteWordsFromString( string $newWhiteWordsString ) {
+		$this->addWhiteWordsFromArray( explode( '|', $newWhiteWordsString ) );
+	}
+
+	/**
+	 * @param string[] $newWhiteWordsArray
+	 */
+	public function addWhiteWordsFromArray( array $newWhiteWordsArray ) {
+		$this->whiteWordsArray = array_merge( $this->whiteWordsArray, $newWhiteWordsArray );
+	}
+
+	private function hasBadWords( string $text, bool $ignoreWhiteWords ): bool {
+		$badMatches = $this->getMatches( $text, $this->badWordsArray );
+
+		if ( $ignoreWhiteWords ) {
+			$whiteMatches = $this->getMatches( $text, $this->whiteWordsArray );
+
+			if ( count( $whiteMatches ) > 0 ) {
+				return $this->hasBadWordNotMatchingWhiteWords( $badMatches, $whiteMatches );
+			}
+
+		}
+
+		return count( $badMatches ) > 0;
+	}
+
+	private function getMatches( string $text, array $wordArray ): array {
+		$matches = array();
+		preg_match_all( $this->composeRegex( $wordArray ), $text, $matches );
+		return $matches[0];
+	}
+
+	private function hasBadWordNotMatchingWhiteWords( array $badMatches, array $whiteMatches ):bool {
+		return count(
+			array_udiff( $badMatches, $whiteMatches, function( $badMatch, $whiteMatch ) {
+				return !preg_match( $this->composeRegex( array( $badMatch ) ), $whiteMatch );
+			} )
+		) > 0;
+	}
+
+	private function wordMatchesWhiteWords( string $word ): bool {
+		return in_array( strtolower( $word ), array_map( 'strtolower', $this->whiteWordsArray ) );
+	}
+
+	private function hasUrls( string $text, bool $testWithDNS, bool $ignoreWhiteWords ): bool {
+		// check for obvious URLs
+		if ( preg_match( '|https?://www\.[a-z\.0-9]+|i', $text ) || preg_match( '|www\.[a-z\.0-9]+|i', $text ) ) {
+			return true;
+		}
+
+		// check for non-obvious URLs with dns lookup
+		if ( $testWithDNS ) {
+			$possibleUrls = $this->extractPossibleUrls( $text );
+
+			foreach ( $possibleUrls as $url ) {
+				$host = $this->getHostFromUrl( $url );
+				if ( !( $ignoreWhiteWords && $this->wordMatchesWhiteWords( $host ) ) && $this->isExistingDomain( $url ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private function extractPossibleUrls( string $text ): array {
+		preg_match_all( '|[a-z\.0-9]+\.[a-z]{2,6}|i', $text, $possibleUrls );
+		return $possibleUrls[0];
+	}
+
+	private function isExistingDomain( string $host ): bool {
+		return checkdnsrr( $host, 'A' );
+	}
+
+	private function getHostFromUrl( string $url ): string {
+		$parsedUrl = parse_url( 'http://' . $url );
+
+		if ( !$parsedUrl ) {
+			return false;
+		}
+
+		if ( isset( $parsedUrl['host'] ) ) {
+			$host = $parsedUrl['host'];
+		} else {
+			$host = $parsedUrl['path'];
+		}
+
+		return $host;
+	}
+
+	private function composeRegex( array $wordArray ): string {
+		return '#(.*?)(' . implode( '|', $wordArray ) . ')#i';
+	}
+}

--- a/tests/Fixtures/ApiPostRequestHandler.php
+++ b/tests/Fixtures/ApiPostRequestHandler.php
@@ -18,6 +18,17 @@ use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 class ApiPostRequestHandler {
 
 	public function __invoke( Request $request ) {
+		switch ( $request->getParams()['action'] ) {
+			case 'parse':
+				return $this->getPageResponse( $request );
+			case 'query':
+				return $this->getRawResponse( $request );
+			default:
+				throw new UsageException( 'Unsupported API action: ' . $request->getParams()['action'] );
+		}
+	}
+
+	private function getPageResponse( Request $request ) {
 		$pageResponses = [
 			'Unicorns' => TestEnvironment::getJsonTestData( 'mwApiUnicornsPage.json' ),
 			'MyNamespace:MyPrefix/Naked_mole-rat' => TestEnvironment::getJsonTestData( 'mwApiPrefixedTitlePage.json' ),
@@ -30,4 +41,15 @@ class ApiPostRequestHandler {
 		throw new UsageException( 'Page not found: ' . $request->getParams()['page'] );
 	}
 
+	private function getRawResponse( Request $request ) {
+		$rawResponses = [
+			'No_Cats' => TestEnvironment::getJsonTestData( 'mwApiNo_CatsQuery.json' )
+		];
+
+		if ( array_key_exists( $request->getParams()['titles'], $rawResponses ) ) {
+			return $rawResponses[$request->getParams()['titles']];
+		}
+
+		throw new \RuntimeException( 'Page not found: ' . $request->getParams()['titles'] );
+	}
 }

--- a/tests/Unit/Validation/FieldTextPolicyValidatorTest.php
+++ b/tests/Unit/Validation/FieldTextPolicyValidatorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WMDE\Fundraising\Tests\Unit;
+
+use WMDE\Fundraising\Frontend\Validation\FieldTextPolicyValidator;
+use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
+use WMDE\Fundraising\Frontend\Validation\ConstraintViolation;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\Validation\FieldTextPolicyValidator
+ *
+ * @licence GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class FieldTextPolicyValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenHarmlessText_itSucceeds(){
+		$textPolicy = $this->getMock( TextPolicyValidator::class );
+		$textPolicy->method( 'hasHarmlessContent' )->willReturn( true );
+		$validator = new FieldTextPolicyValidator( $textPolicy, 0 );
+		$this->assertTrue( $validator->validate( 'tiny cat' ) );
+	}
+
+	public function testGivenHarmfulText_itFails(){
+		$textPolicy = $this->getMock( TextPolicyValidator::class );
+		$textPolicy->method( 'hasHarmlessContent' )->willReturn( false );
+		$validator = new FieldTextPolicyValidator( $textPolicy, 0 );
+		$this->assertFalse( $validator->validate( 'mean tiger' ) );
+	}
+
+	public function testGivenHarmfulText_itProvidesAConstraintViolation(){
+		$textPolicy = $this->getMock( TextPolicyValidator::class );
+		$textPolicy->method( 'hasHarmlessContent' )->willReturn( false );
+		$validator = new FieldTextPolicyValidator( $textPolicy, 0 );
+		$validator->validate( 'mean tiger' );
+		$this->assertInstanceOf( ConstraintViolation::class, $validator->getLastViolation() );
+	}
+}

--- a/tests/Unit/Validation/TextPolicyValidatorTest.php
+++ b/tests/Unit/Validation/TextPolicyValidatorTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace WMDE\Fundraising\Tests\Unit;
+
+use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
+
+/**
+ * @covers WMDE\Fundraising\TextPolicyValidator
+ *
+ * @licence GNU GPL v2+
+ * @author Christoph Fischer <christoph.fischer@wikimedia.de
+ */
+class TextPolicyValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	/**
+	 * @dataProvider urlTestProvider
+	 */
+	public function testWhenGivenCommentHasURL_validatorReturnsFalse( $commentToTest ) {
+		$textPolicyValidator = new TextPolicyValidator();
+
+		$this->assertFalse( $textPolicyValidator->hasHarmlessContent(
+			$commentToTest,
+			TextPolicyValidator::CHECK_URLS | TextPolicyValidator::CHECK_URLS_DNS
+		) );
+	}
+
+	public function urlTestProvider() {
+		return array(
+			array( 'www.example.com' ),
+			array( 'http://www.example.com' ),
+			array( 'https://www.example.com' ),
+			array( 'example.com' ),
+			array( 'example.com/test' ),
+			array( 'example.com/teKAst/index.php' ),
+			array( 'Ich mag Wikipedia. Aber meine Seite ist auch toll:example.com/teKAst/index.php' ),
+			array( 'inwx.berlin' ),
+			array( 'wwwwwww.website.com' ),
+			array( 'TriebWerk-Grün.de' ),
+		);
+	}
+
+
+	/**
+	 * @dataProvider harmlessTestProvider
+	 */
+	public function testWhenGivenHarmlesComment_validatorReturnsTrue( $commentToTest ) {
+		$textPolicyValidator = new TextPolicyValidator();
+
+		$this->assertTrue( $textPolicyValidator->hasHarmlessContent(
+			$commentToTest,
+			TextPolicyValidator::CHECK_URLS | TextPolicyValidator::CHECK_URLS_DNS | TextPolicyValidator::CHECK_BADWORDS
+		) );
+	}
+
+	public function harmlessTestProvider() {
+		return array(
+			array( 'Ich mag Wikipedia.Wieso ? Weil ich es so toll finde!' ),
+			array( 'Wikipedia ist so super, meine Eltern sagen es ist eine toll Seite. Berlin ist auch Super.' ),
+			array( 'Ich mag Wikipedia. Aber meine Seite ist auch toll. Googelt mal nach Bunsenbrenner!!!1' ),
+			array( 'Bei Wikipedia kann man eine Menge zum Thema Hamster finden. Hamster fressen voll viel Zeug alter!' ),
+		);
+	}
+
+
+	/**
+	 * @dataProvider insultingTestProvider
+	 */
+	public function testWhenGivenInsultingComment_validatorReturnsFalse( $commentToTest ) {
+		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
+
+		$this->assertFalse( $textPolicyValidator->hasHarmlessContent(
+			$commentToTest,
+			TextPolicyValidator::CHECK_BADWORDS
+		) );
+	}
+
+	public function insultingTestProvider() {
+		return array(
+			array( 'Alles Deppen!' ),
+			array( 'Heil Hitler!' ),
+			array( 'Duhamsterfresse!!!' ),
+			array( 'Alles nur HAMSTERFRESSEN!!!!!!!!1111111111' ),
+		);
+	}
+
+
+	/**
+	 * @dataProvider whiteWordsInsultingTestProvider
+	 */
+	public function testWhenGivenInsultingCommentAndWhiteWords_validatorReturnsFalse( $commentToTest ) {
+		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
+
+		$this->assertFalse(
+			$textPolicyValidator->hasHarmlessContent(
+				$commentToTest,
+				TextPolicyValidator::CHECK_URLS
+				| TextPolicyValidator::CHECK_URLS_DNS
+				| TextPolicyValidator::CHECK_BADWORDS
+				| TextPolicyValidator::IGNORE_WHITEWORDS
+			)
+		);
+	}
+
+	public function whiteWordsInsultingTestProvider() {
+		return array(
+			array( 'Ich heisse Deppendorf ihr Deppen und das ist auch gut so!' ),
+			array( 'Ihr Arschgeigen, ich wohne in Marsch und das ist auch gut so!' ),
+			array( 'Bei Wikipedia gibts echt tolle Arschkrampen!' ),
+		);
+	}
+
+
+	/**
+	 * @dataProvider whiteWordsHarmlessTestProvider
+	 */
+	public function testWhenGivenHarmlessCommentAndWhiteWords_validatorReturnsTrue( $commentToTest ) {
+		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
+
+		$this->assertTrue(
+			$textPolicyValidator->hasHarmlessContent(
+				$commentToTest,
+				TextPolicyValidator::CHECK_URLS
+				| TextPolicyValidator::CHECK_URLS_DNS
+				| TextPolicyValidator::CHECK_BADWORDS
+				| TextPolicyValidator::IGNORE_WHITEWORDS
+			)
+		);
+	}
+
+	public function whiteWordsHarmlessTestProvider() {
+		return array(
+			array( 'Wikipedia ist so super, meine Eltern sagen es ist eine toll Seite. Berlin ist auch Super.' ),
+			array( 'Ich heisse Deppendorf ihr und das ist auch gut so!' ),
+			array( 'Bei Wikipedia gibts echt tolle Dinge!' ),
+			array( 'Ick spend richtig Kohle, denn ick hab ne GmbH & Co.KG' ),
+		);
+	}
+
+	private function getPreFilledTextPolicyValidator() {
+		$textPolicyValidator = new TextPolicyValidator();
+		$textPolicyValidator->addBadWordsFromArray(
+			[
+				'deppen',
+				'hitler',
+				'fresse',
+				'arsch'
+			] );
+		$textPolicyValidator->addWhiteWordsFromArray(
+			[
+				'Deppendorf',
+				'Marsch',
+				'Co.KG',
+			] );
+		return $textPolicyValidator;
+	}
+
+}

--- a/tests/Unit/Validation/TextPolicyValidatorTest.php
+++ b/tests/Unit/Validation/TextPolicyValidatorTest.php
@@ -7,7 +7,7 @@ namespace WMDE\Fundraising\Tests\Unit;
 use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
 
 /**
- * @covers WMDE\Fundraising\TextPolicyValidator
+ * @covers WMDE\Fundraising\Frontend\Validation\TextPolicyValidator
  *
  * @licence GNU GPL v2+
  * @author Christoph Fischer <christoph.fischer@wikimedia.de

--- a/tests/data/mwApiNo_CatsQuery.json
+++ b/tests/data/mwApiNo_CatsQuery.json
@@ -1,0 +1,24 @@
+{
+  "query": {
+    "normalized": [
+      {
+        "from": "Web:Spendenseite-HK2013/test/No_Cats",
+        "to": "Web:Spendenseite-HK2013/test/No Cats"
+      }
+    ],
+    "pages": {
+      "267": {
+        "pageid": 267,
+        "ns": 120,
+        "title": "Web:Spendenseite-HK2013/test/No Cats",
+        "revisions": [
+          {
+            "contentformat": "text/x-wiki",
+            "contentmodel": "wikitext",
+            "*": "Nyan\nGarfield\nFelix da House"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Validate subscription requests against a configurable white- and blacklist from the wiki. This code can be reused for checking donations and membership requests.

This is for https://phabricator.wikimedia.org/T125958 and https://phabricator.wikimedia.org/T123227