### PR TITLE
More work on subscription confirmation

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -19,7 +19,10 @@
 		"loaders": {
 			"wiki": {
 				"enabled": true,
-				"rawpages": []
+				"rawpages": [
+					"Mail_Subscription_Confirmation.twig",
+					"Mail_Subscription_Request.twig"
+				]
 			},
 			"filesystem": {
 				"template-dir": [ "app/templates" ]

--- a/app/routes.php
+++ b/app/routes.php
@@ -132,9 +132,9 @@ $app->post(
 ->bind( 'subscribe' );
 
 $app->get( 'contact/confirm-subscription/{confirmationCode}', function ( $confirmationCode ) use ( $ffFactory ) {
-	// TODO create actual use case
-	$dummyResponse = \WMDE\Fundraising\Frontend\ResponseModel\ValidationResponse::newSuccessResponse();
-	return $ffFactory->newConfirmSubscriptionHtmlPresenter()->present( $dummyResponse );
+	$useCase = $ffFactory->newConfirmSubscriptionUseCase();
+	$response = $useCase->confirmSubscription( $confirmationCode );
+	return $ffFactory->newConfirmSubscriptionHtmlPresenter()->present( $response );
 } )
 ->assert( 'confirmationCode', '^[0-9a-f]+$' );
 

--- a/app/templates/ConfirmSubscription.html.twig
+++ b/app/templates/ConfirmSubscription.html.twig
@@ -4,7 +4,7 @@
     {% if error_message %}
         {# TODO ask Kai if we can make the " Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut." string on
             the error page optional #}
-        {% include 'ErrorPage.twig' with { 'message': error_message|trans } %}
+        {% include 'ErrorPage.twig' with { 'message': error_message|trans({}, 'validations') } %}
     {% else %}
         {% include 'Subscription_Confirmed.twig' %}
     {% endif %}

--- a/app/translations/validations.de_DE.json
+++ b/app/translations/validations.de_DE.json
@@ -2,5 +2,7 @@
   "This field is required": "Dieses Feld ist ein Pflichtfeld",
   "Address has wrong format": "Kein gültiges Email-Adressformat",
   "Address is no valid email": "Keine gültige E-Mail-Adresse",
-  "MX record not found": "Domain der Mailadresse nicht gefunden"
+  "MX record not found": "Domain der Mailadresse nicht gefunden",
+  "No subscription was found with this confirmation code.": "Es konnte kein Eintrag mit diesem Bestätigungs-Code gefunden werden.",
+  "The subscription was already confirmed.": "Diese E-Mail-Adresse wurde bereits bestätigt."
 }

--- a/src/DataAccess/DbalSubscriptionRepository.php
+++ b/src/DataAccess/DbalSubscriptionRepository.php
@@ -39,7 +39,7 @@ class DbalSubscriptionRepository implements SubscriptionRepository {
 
 	public function findByConfirmationCode( string $confirmationCode ) {
 		return $this->entityManager->getRepository( Subscription::class )->findOneBy( [
-			'confirmationCode' => $confirmationCode
+			'confirmationCode' => hex2bin( $confirmationCode )
 		] );
 	}
 

--- a/src/DataAccess/DbalSubscriptionRepository.php
+++ b/src/DataAccess/DbalSubscriptionRepository.php
@@ -37,5 +37,10 @@ class DbalSubscriptionRepository implements SubscriptionRepository {
 		return (int) $query->getSingleScalarResult();
 	}
 
+	public function findByConfirmationCode( string $confirmationCode ) {
+		return $this->entityManager->getRepository( Subscription::class )->findOneBy( [
+			'confirmationCode' => $confirmationCode
+		] );
+	}
 
 }

--- a/src/Domain/SubscriptionRepository.php
+++ b/src/Domain/SubscriptionRepository.php
@@ -10,6 +10,7 @@ use WMDE\Fundraising\Entities\Subscription;
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >
  */
 interface SubscriptionRepository {
+
 	public function storeSubscription( Subscription $subscription );
 
 	/**
@@ -20,4 +21,11 @@ interface SubscriptionRepository {
 	 * @return int
 	 */
 	public function countSimilar( Subscription $subscription, \DateTime $cutoffDateTime ): int;
+
+	/**
+	 * @param string $confirmationCode
+	 * @return Subscription|null
+	 */
+	public function findByConfirmationCode( string $confirmationCode );
+
 }

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -41,6 +41,7 @@ use WMDE\Fundraising\Frontend\Presentation\Presenters\GetInTouchHTMLPresenter;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\IbanPresenter;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\InternalErrorHTMLPresenter;
 use WMDE\Fundraising\Frontend\UseCases\CancelDonation\CancelDonationUseCase;
+use WMDE\Fundraising\Frontend\UseCases\ConfirmSubscription\ConfirmSubscriptionUseCase;
 use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
 use WMDE\Fundraising\Frontend\Validation\MailValidator;
 use WMDE\Fundraising\Frontend\Validation\SubscriptionDuplicateValidator;
@@ -244,7 +245,7 @@ class FunFunFactory {
 		return $this->pimple['comment_repository'];
 	}
 
-	private function getSubscriptionRepository(): SubscriptionRepository {
+	public function getSubscriptionRepository(): SubscriptionRepository {
 		return $this->pimple['subscription_repository'];
 	}
 
@@ -359,6 +360,13 @@ class FunFunFactory {
 		);
 	}
 
+	public function newConfirmSubscriptionUseCase(): ConfirmSubscriptionUseCase {
+		return new ConfirmSubscriptionUseCase(
+			$this->getSubscriptionRepository(),
+			$this->newConfirmSubscriptionMailer()
+		);
+	}
+
 	private function newAddSubscriptionMailer(): TemplateBasedMailer {
 		return new TemplateBasedMailer(
 			$this->getMessenger(),
@@ -368,6 +376,18 @@ class FunFunFactory {
 				[ 'greeting_generator' => $this->getGreetingGenerator() ]
 			),
 			$this->getTranslator()->trans( 'Your membership with Wikimedia Germany' )
+		);
+	}
+
+	private function newConfirmSubscriptionMailer(): TemplateBasedMailer {
+		return new TemplateBasedMailer(
+				$this->getMessenger(),
+				new TwigTemplate(
+						$this->getTwig(),
+						'Mail_Subscription_Confirmation.twig',
+						[ 'greeting_generator' => $this->getGreetingGenerator() ]
+				),
+				$this->getTranslator()->trans( 'Your membership with Wikimedia Germany' )
 		);
 	}
 
@@ -382,6 +402,7 @@ class FunFunFactory {
 	public function newGenerateIbanUseCase(): GenerateIbanUseCase {
 		return new GenerateIbanUseCase( $this->newBankDataConverter() );
 	}
+
 
 	public function newIbanPresenter(): IbanPresenter {
 		return new IbanPresenter();

--- a/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
+++ b/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
@@ -30,8 +30,7 @@ class ConfirmSubscriptionUseCase {
 	}
 
 	public function confirmSubscription( string $confirmationCode ): ValidationResponse {
-		$binaryConfirmationCode = hex2bin( $confirmationCode );
-		$subscription = $this->subscriptionRepository->findByConfirmationCode( $binaryConfirmationCode );
+		$subscription = $this->subscriptionRepository->findByConfirmationCode( $confirmationCode );
 		if ( ! $subscription ) {
 			$errorMsg = 'No subscription was found with this confirmation code.';
 			return ValidationResponse::newFailureResponse( [ new ConstraintViolation( $confirmationCode, $errorMsg ) ] );

--- a/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
+++ b/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
@@ -4,7 +4,12 @@ declare(strict_types = 1);
 
 namespace WMDE\Fundraising\Frontend\UseCases\ConfirmSubscription;
 
+use WMDE\Fundraising\Entities\Subscription;
 use WMDE\Fundraising\Frontend\Domain\SubscriptionRepository;
+use WMDE\Fundraising\Frontend\MailAddress;
+use WMDE\Fundraising\Frontend\ResponseModel\ValidationResponse;
+use WMDE\Fundraising\Frontend\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Validation\ConstraintViolation;
 
 /**
  * @license GNU GPL v2+
@@ -14,13 +19,30 @@ class ConfirmSubscriptionUseCase {
 
 	private $subscriptionRepository;
 
-	public function __construct( SubscriptionRepository $subscriptionRepository ) {
+	/**
+	 * @var TemplateBasedMailer
+	 */
+	private $mailer;
+
+	public function __construct( SubscriptionRepository $subscriptionRepository, TemplateBasedMailer $mailer ) {
 		$this->subscriptionRepository = $subscriptionRepository;
+		$this->mailer = $mailer;
 	}
 
-	public function confirmSubscription( string $confirmationCode ) {
-		// TODO Look for subscription confirmation code
-		// TODO if found && state == unconfirmed -> change state and show success page
-		// TODO else show failure page
+	public function confirmSubscription( string $confirmationCode ): ValidationResponse {
+		$binaryConfirmationCode = hex2bin( $confirmationCode );
+		$subscription = $this->subscriptionRepository->findByConfirmationCode( $binaryConfirmationCode );
+		if ( ! $subscription ) {
+			$errorMsg = 'No subscription was found with this confirmation code.';
+			return ValidationResponse::newFailureResponse( [ new ConstraintViolation( $confirmationCode, $errorMsg ) ] );
+		}
+
+		if ( $subscription->getStatus() !== Subscription::STATUS_NEUTRAL ) {
+			$errorMsg = 'The subscription was already confirmed.';
+			return ValidationResponse::newFailureResponse( [ new ConstraintViolation( $confirmationCode, $errorMsg ) ] );
+		}
+
+		$this->mailer->sendMail( new MailAddress( $subscription->getEmail() ), [ 'subscription' => $subscription ] );
+		return ValidationResponse::newSuccessResponse();
 	}
 }

--- a/tests/Fixtures/InMemorySubscriptionRepository.php
+++ b/tests/Fixtures/InMemorySubscriptionRepository.php
@@ -41,7 +41,7 @@ class InMemorySubscriptionRepository implements SubscriptionRepository {
 
 	public function findByConfirmationCode( string $confirmationCode ) {
 		foreach( $this->subscriptions as $subscription ) {
-			if ( $subscription->getConfirmationCode() === $confirmationCode ) {
+			if ( $subscription->getHexConfirmationCode() === $confirmationCode ) {
 				return $subscription;
 			}
 		}

--- a/tests/Fixtures/InMemorySubscriptionRepository.php
+++ b/tests/Fixtures/InMemorySubscriptionRepository.php
@@ -39,4 +39,12 @@ class InMemorySubscriptionRepository implements SubscriptionRepository {
 		return $count;
 	}
 
+	public function findByConfirmationCode( string $confirmationCode ) {
+		foreach( $this->subscriptions as $subscription ) {
+			if ( $subscription->getConfirmationCode() === $confirmationCode ) {
+				return $subscription;
+			}
+		}
+	}
+
 }

--- a/tests/Fixtures/SubscriptionRepositorySpy.php
+++ b/tests/Fixtures/SubscriptionRepositorySpy.php
@@ -33,4 +33,8 @@ class SubscriptionRepositorySpy implements SubscriptionRepository {
 		return 0;
 	}
 
+	public function findByConfirmationCode( string $confirmationCode ) {
+		return null;
+	}
+
 }

--- a/tests/Integration/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCaseTest.php
+++ b/tests/Integration/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCaseTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\ConfirmSubscription;
+
+use PHPUnit_Framework_MockObject_MockObject;
+use WMDE\Fundraising\Entities\Address;
+use WMDE\Fundraising\Entities\Subscription;
+use WMDE\Fundraising\Frontend\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\InMemorySubscriptionRepository;
+use WMDE\Fundraising\Frontend\UseCases\ConfirmSubscription\ConfirmSubscriptionUseCase;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\UseCases\ConfirmSubscription\ConfirmSubscriptionUseCase
+ *
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class ConfirmSubscriptionUseCaseTest extends \PHPUnit_Framework_TestCase {
+
+	const CONFIRMATION_CODE = 'deadbeef';
+
+	private function newSubscriptionAddress(): Address {
+		$address = new Address();
+
+		$address->setSalutation( 'Herr' );
+		$address->setFirstName( 'Nyan' );
+		$address->setLastName( 'Cat' );
+		$address->setTitle( 'Dr.' );
+
+		return $address;
+	}
+
+	private function newSubscription(): Subscription {
+		$subscription = new Subscription();
+
+		$subscription->setHexConfirmationCode( self::CONFIRMATION_CODE );
+		$subscription->setEmail( 'nyan@awesomecats.com' );
+		$subscription->setAddress( $this->newSubscriptionAddress() );
+
+		return $subscription;
+	}
+
+	/**
+	 * @return PHPUnit_Framework_MockObject_MockObject|TemplateBasedMailer
+	 */
+	private function newMailer() {
+		return $this->getMockBuilder( TemplateBasedMailer::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function testGivenNoSubscriptions_anErrorResponseIsCreated() {
+		$mailer = $this->newMailer();
+		$mailer->expects( $this->never() )->method( 'sendMail' );
+		$useCase = new ConfirmSubscriptionUseCase( new InMemorySubscriptionRepository(), $mailer );
+		$result = $useCase->confirmSubscription( self::CONFIRMATION_CODE );
+		$this->assertFalse( $result->isSuccessful() );
+	}
+
+	public function testGivenASubscriptionWithWrongStatus_anErrorResponseIsCreated() {
+		$subscription = $this->newSubscription();
+		$subscription->setStatus( Subscription::STATUS_CONFIRMED );
+
+		$repo = new InMemorySubscriptionRepository();
+		$repo->storeSubscription( $subscription );
+
+		$mailer = $this->newMailer();
+		$mailer->expects( $this->never() )->method( 'sendMail' );
+
+		$useCase = new ConfirmSubscriptionUseCase( $repo, $mailer );
+
+		$this->assertFalse( $useCase->confirmSubscription( self::CONFIRMATION_CODE )->isSuccessful() );
+	}
+
+	public function testGivenASubscription_aSuccessIsCreated() {
+		$repo = new InMemorySubscriptionRepository();
+		$repo->storeSubscription( $this->newSubscription() );
+
+		$useCase = new ConfirmSubscriptionUseCase( $repo, $this->newMailer() );
+
+		$this->assertTrue( $useCase->confirmSubscription( self::CONFIRMATION_CODE )->isSuccessful() );
+	}
+
+	public function testGivenASubscription_aConfirmationMailIsSent() {
+		$repo = new InMemorySubscriptionRepository();
+		$repo->storeSubscription( $this->newSubscription() );
+
+		$mailer = $this->newMailer();
+		$mailer->expects( $this->once() )->method( 'sendMail' );
+
+		$useCase = new ConfirmSubscriptionUseCase( $repo, $mailer );
+
+		$this->assertTrue( $useCase->confirmSubscription( self::CONFIRMATION_CODE )->isSuccessful() );
+	}
+}

--- a/tests/templates/Mail_Subscription_Confirmation.twig
+++ b/tests/templates/Mail_Subscription_Confirmation.twig
@@ -1,0 +1,3 @@
+Email: {$ subscription.email $}
+First Name: {$ subscription.address.firstName $}
+Greeting: {$ greeting_generator.createGreeting( subscription.address.lastName, subscription.address.salutation, subscription.address.title ) $}


### PR DESCRIPTION
Create actual use case code.
Add method to SubscriptionRepository to fetch a Subscription by
confirmation code.

Checking if the subscription has the right status is not implemented
yet.