### PR TITLE
Simplify DisplayPageUseCase

### DIFF
--- a/app/templates/404message.html.twig
+++ b/app/templates/404message.html.twig
@@ -1,0 +1,2 @@
+Could not load main content!
+{# TODO translate this and add a link to main page #}

--- a/app/templates/DisplayPageLayout.twig
+++ b/app/templates/DisplayPageLayout.twig
@@ -1,6 +1,5 @@
 {% extends 'BaseLayout.twig' %}
 
 {% block main %}
-    {# the variable 'main' contains unprocessed template text from DisplayPagePresenter #}
-    {% include(template_from_string(main)) %}
+    {% include main_template %}
 {% endblock %}

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -64,6 +64,7 @@ use WMDE\Fundraising\Frontend\UseCases\ListComments\ListCommentsUseCase;
 use WMDE\Fundraising\Frontend\UseCases\CheckIban\CheckIbanUseCase;
 use WMDE\Fundraising\Frontend\UseCases\GenerateIban\GenerateIbanUseCase;
 use WMDE\Fundraising\Frontend\UseCases\ValidateEmail\ValidateEmailUseCase;
+use WMDE\Fundraising\Frontend\Validation\TemplateNameValidator;
 use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
 use WMDE\Fundraising\Store\Factory as StoreFactory;
 use WMDE\Fundraising\Store\Installer;
@@ -128,6 +129,10 @@ class FunFunFactory {
 			);
 		} );
 
+		$pimple['template_name_validator'] = $pimple->share( function() {
+			return new TemplateNameValidator( $this->getTwig() );
+		} );
+
 		$pimple['contact_validator'] = $pimple->share( function() {
 			return new GetInTouchValidator( $this->getMailValidator() );
 		} );
@@ -181,7 +186,6 @@ class FunFunFactory {
 				$twigFactory->newWikiPageLoader( $this->newWikiContentProvider() ),
 			] );
 			$extensions = [
-				$twigFactory->newStringLoaderExtension(),
 				$twigFactory->newTranslationExtension( $this->getTranslator() )
 			];
 			return $twigFactory->create( $loaders, $extensions );
@@ -268,9 +272,13 @@ class FunFunFactory {
 		return $this->pimple['mail_validator'];
 	}
 
+	private function getTemplateNameValidator(): TemplateNameValidator {
+		return $this->pimple['template_name_validator'];
+	}
+
 	public function newDisplayPageUseCase(): DisplayPageUseCase {
 		return new DisplayPageUseCase(
-			$this->newWikiContentProvider()
+			$this->getTemplateNameValidator()
 		);
 	}
 

--- a/src/Presentation/Presenters/DisplayPagePresenter.php
+++ b/src/Presentation/Presenters/DisplayPagePresenter.php
@@ -20,17 +20,12 @@ class DisplayPagePresenter {
 	}
 
 	public function present( PageDisplayResponse $displayResponse ): string {
+		$mainTemplate = '404message.html.twig';
+		if ( $displayResponse->getTemplateExists() ) {
+			$mainTemplate = $displayResponse->getMainContentTemplate();
+		}
 		return $this->template->render( [
-			'main' => $this->getContentOrMissingMessage( $displayResponse->getMainContent(), 'main content' ),
+			'main_template' => $mainTemplate,
 		] );
 	}
-
-	private function getContentOrMissingMessage( string $content, string $contentName ): string {
-		if ( $content === '' ) {
-			return htmlspecialchars( "Could not load $contentName!" );
-		}
-
-		return $content;
-	}
-
 }

--- a/src/UseCases/DisplayPage/DisplayPageUseCase.php
+++ b/src/UseCases/DisplayPage/DisplayPageUseCase.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace WMDE\Fundraising\Frontend\UseCases\DisplayPage;
 
-use WMDE\Fundraising\Frontend\Presentation\Content\WikiContentProvider;
+use WMDE\Fundraising\Frontend\Validation\TemplateNameValidator;
 
 /**
  * @licence GNU GPL v2+
@@ -12,17 +12,17 @@ use WMDE\Fundraising\Frontend\Presentation\Content\WikiContentProvider;
  */
 class DisplayPageUseCase {
 
-	private $contentProvider;
+	private $templateNameValidator;
 
-	public function __construct( WikiContentProvider $contentProvider ) {
-		$this->contentProvider = $contentProvider;
+	public function __construct( TemplateNameValidator $templateNameValidator ) {
+		$this->templateNameValidator = $templateNameValidator;
 	}
 
 	public function getPage( PageDisplayRequest $listingRequest ): PageDisplayResponse {
 		$response = new PageDisplayResponse();
-
-		$response->setMainContent( $this->contentProvider->getContent( $listingRequest->getPageName() ) );
-
+		$response->setMainContentTemplate( $listingRequest->getPageName() );
+		$templateExists = $this->templateNameValidator->validate( $listingRequest->getPageName() )->isSuccessful();
+		$response->setTemplateExists( $templateExists );
 		$response->freeze();
 		$response->assertNoNullFields();
 

--- a/src/UseCases/DisplayPage/PageDisplayResponse.php
+++ b/src/UseCases/DisplayPage/PageDisplayResponse.php
@@ -13,15 +13,29 @@ use WMDE\Fundraising\Frontend\FreezableValueObject;
 class PageDisplayResponse {
 	use FreezableValueObject;
 
-	private $mainContent;
+	private $mainContentTemplate;
+	private $templateExists;
 
-	public function getMainContent(): string {
-		return $this->mainContent;
+	public function getMainContentTemplate(): string {
+		return $this->mainContentTemplate;
 	}
 
-	public function setMainContent( string $mainContent ) {
+	public function setMainContentTemplate( string $mainContentTemplate ): PageDisplayResponse {
 		$this->assertIsWritable();
-		$this->mainContent = $mainContent;
+		$this->mainContentTemplate = $mainContentTemplate;
+		return $this;
 	}
+
+	public function getTemplateExists(): bool {
+		return $this->templateExists;
+	}
+
+	public function setTemplateExists( bool $templateExists ): PageDisplayResponse {
+		$this->assertIsWritable();
+		$this->templateExists = $templateExists;
+		return $this;
+	}
+
+
 }
 

--- a/src/Validation/TemplateNameValidator.php
+++ b/src/Validation/TemplateNameValidator.php
@@ -9,8 +9,6 @@ namespace WMDE\Fundraising\Frontend\Validation;
 class TemplateNameValidator {
 
 	private $twig;
-	private $lastViolation;
-
 
 	public function __construct( \Twig_Environment $twig ) {
 		$this->twig = $twig;
@@ -24,11 +22,11 @@ class TemplateNameValidator {
 	public function validate( $value ): ValidationResult {
 		try {
 			$this->twig->loadTemplate( $value );
-			return new ValidationResult();
 		}
-		catch (\Twig_Error_Loader $e ) {
+		catch ( \Twig_Error_Loader $e ) {
 			return new ValidationResult( new ConstraintViolation( $value, 'Could not find template' ) );
 		}
 
+		return new ValidationResult();
 	}
 }

--- a/src/Validation/TemplateNameValidator.php
+++ b/src/Validation/TemplateNameValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Validation;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class TemplateNameValidator {
+
+	private $twig;
+	private $lastViolation;
+
+
+	public function __construct( \Twig_Environment $twig ) {
+		$this->twig = $twig;
+	}
+
+	/**
+	 * @param $value
+	 * @return ValidationResult+
+	 * @throws \Twig_Error_Syntax
+	 */
+	public function validate( $value ): ValidationResult {
+		try {
+			$this->twig->loadTemplate( $value );
+			return new ValidationResult();
+		}
+		catch (\Twig_Error_Loader $e ) {
+			return new ValidationResult( new ConstraintViolation( $value, 'Could not find template' ) );
+		}
+
+	}
+}

--- a/tests/Integration/UseCases/DisplayPage/DisplayPageUseCaseTest.php
+++ b/tests/Integration/UseCases/DisplayPage/DisplayPageUseCaseTest.php
@@ -26,7 +26,9 @@ class DisplayPageUseCaseTest extends \PHPUnit_Framework_TestCase {
 		$twigConfig = [
 			'twig' => [
 				'loaders' => [
-					'wiki' => true
+					'wiki' => [
+						'enabled' => true
+					]
 				]
 			]
 		];
@@ -44,14 +46,15 @@ class DisplayPageUseCaseTest extends \PHPUnit_Framework_TestCase {
 		$this->testEnvironment->getFactory()->setMediaWikiApi( $api );
 	}
 
-	public function testWhenPageExists_itGetsEmbedded() {
+	public function testWhenPageExists_responseReflectsExistence() {
 		$this->registerWikiPages();
 
 		$useCase = $this->testEnvironment->getFactory()->newDisplayPageUseCase();
 
 		$response = $useCase->getPage( new PageDisplayRequest( 'Unicorns' ) );
 
-		$this->assertSame( '<p>Pink fluffy unicorns dancing on rainbows</p>', $response->getMainContent() );
+		$this->assertTrue( $response->getTemplateExists() );
+		$this->assertSame( 'Unicorns', $response->getMainContentTemplate() );
 	}
 
 	public function testWhenPageTitlePrefixIsConfigured_pageCanBeRetrieved() {
@@ -63,7 +66,8 @@ class DisplayPageUseCaseTest extends \PHPUnit_Framework_TestCase {
 
 		$response = $useCase->getPage( new PageDisplayRequest( 'Naked mole-rat' ) );
 
-		$this->assertSame( '<p>This little guy wants to cuddle, too!</p>', $response->getMainContent() );
+		$this->assertTrue( $response->getTemplateExists() );
+		$this->assertSame( 'Naked mole-rat', $response->getMainContentTemplate() );
 	}
 
 }

--- a/tests/System/Routes/DisplayPageRouteTest.php
+++ b/tests/System/Routes/DisplayPageRouteTest.php
@@ -99,6 +99,9 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 							'10hoch16/Seitenkopf' => '<p>I\'m a header</p>',
 							'10hoch16/Seitenfuß' => '<p>I\'m a footer</p>',
 							'JavaScript-Notice' => '<p>Y u no JavaScript!</p>',
+							],
+						'wiki' => [
+							'enabled' => true
 							]
 						]
 					]

--- a/tests/Unit/Validation/TemplateNameValidatorTest.php
+++ b/tests/Unit/Validation/TemplateNameValidatorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Validation;
+
+use Twig_Environment;
+use Twig_Error_Loader;
+use WMDE\Fundraising\Frontend\Validation\TemplateNameValidator;
+
+class TemplateNameValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testWhenEnvironmentThrowsNoException_validationSuccceeds() {
+		$twig = $this->getMockBuilder( Twig_Environment::class )->disableOriginalConstructor()->getMock();
+		$validator = new TemplateNameValidator( $twig );
+		$this->assertTrue( $validator->validate( 'Unicorns' )->isSuccessful());
+	}
+
+	public function testWhenEnvironmentThrowsLoadException_validationFails() {
+		$twig = $this->getMockBuilder( Twig_Environment::class )->disableOriginalConstructor()->getMock();
+		$twig->method( 'loadTemplate' )->willThrowException( new Twig_Error_Loader( 'That template was not found' ) );
+		$validator = new TemplateNameValidator( $twig );
+		$this->assertFalse( $validator->validate( 'Rainbows' )->isSuccessful());
+	}
+
+}


### PR DESCRIPTION
Instead of pre-rendering the template, use the normal Twig template
loading mechanism and validate via TemplateNameValidator.

This enables testing complex pages by creating them temporarily in the
`app/templates` folder  before uploading them into the CMS wiki.

It'll improve caching, since the previously used extension interfered
with the Twig caching mechanism.