### PR TITLE
generalizing referring domains

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -44,5 +44,41 @@
 		}
 	},
 	"subscription-interval": "PT30M",
-	"locale": "de_DE"
+	"locale": "de_DE",
+	"referrer-generalization": {
+		"default": "web",
+		"domain-map": {
+			"localhost": "LOCALHOST",
+			"wikimedia.de": "wikimedia.de",
+			"www.wikimedia.de": "wikimedia.de",
+			"secure.wikimedia.de": "wikimedia.de",
+			"spenden.wikimedia.de": "wikimedia.de",
+			"blog.wikimedia.de": "wikimedia.de",
+			"wikipedia.de": "wikipedia.de",
+			"www.wikipedia.de": "wikipedia.de",
+			"de.wikipedia.org": "de.wikipedia.org",
+			"wikipedia.org": "wikipedia.org",
+			"wikimediafoundation.org": "wikimediafoundation.org",
+			"www.wikimediafoundation.org": "wikimediafoundation.org",
+			"wikidata.org": "wikidata.org",
+			"www.wikidata.org": "wikidata.org",
+			"commons.wikimedia.org": "commons.wikimedia.org",
+			"meta.wikimedia.org": "meta.wikimedia.org",
+			"de.wiktionary.org": "de.wiktionary.org",
+			"wiktionary.org": "wiktionary.org",
+			"de.wikiquotes.org": "de.wikiquotes.org",
+			"wikiquotes.org": "wikiquotes.org",
+			"de.wikinews.org": "de.wikinews.org",
+			"wikinews.org": "wikinews.org",
+			"de.wikisources.org": "de.wikisources.org",
+			"wikisources.org": "wikisources.org",
+			"de.wikijunior.org": "de.wikijunior.org",
+			"wikijunior.org": "wikijunior.org",
+			"de.wikiversity.org": "de.wikiversity.org",
+			"wikiversity.org": "wikiversity.org",
+			"de.wikivoyage.org": "de.wikivoyage.org",
+			"wikivoyage.org": "wikivoyage.org",
+			"wikispecies.org": "wikispecies.org"
+		}
+	}
 }

--- a/src/FunFunFactory.php
+++ b/src/FunFunFactory.php
@@ -351,6 +351,13 @@ class FunFunFactory {
 		);
 	}
 
+	private function newGeneralizedReferrer() {
+		return new GeneralizedReferrer(
+			$this->config['referrer-generalization']['default'],
+			$this->config['referrer-generalization']['domain-map']
+		);
+	}
+
 	private function newPageRetriever(): PageRetriever {
 		return new ApiBasedPageRetriever(
 			$this->getMediaWikiApi(),

--- a/src/GeneralizedReferrer.php
+++ b/src/GeneralizedReferrer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace WMDE\Fundraising\Frontend;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class GeneralizedReferrer {
+
+	private $defaultValue;
+	private $domainMap;
+
+	/**
+	 * @param string $defaultValue
+	 * @param string[] $domainMap
+	 */
+	public function __construct( string $defaultValue, array $domainMap ) {
+		$this->defaultValue = $defaultValue;
+		$this->domainMap = $domainMap;
+	}
+
+	public function generalize( string $referrer ) {
+		$parsedUrl = parse_url( $referrer );
+		if ( array_key_exists( 'host', $parsedUrl ) && array_key_exists( $parsedUrl['host'], $this->domainMap ) ) {
+			return $this->domainMap[$parsedUrl['host']];
+		}
+
+		return $this->defaultValue;
+	}
+
+}

--- a/tests/Unit/GeneralizedReferrerTest.php
+++ b/tests/Unit/GeneralizedReferrerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WMDE\Fundraising\Tests\Unit;
+
+use WMDE\Fundraising\Frontend\GeneralizedReferrer;
+use WMDE\Fundraising\Frontend\Tests\Unit\Validation\ValidatorTestCase;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\GeneralizedReferrer
+ *
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class GeneralizedReferrerTest extends ValidatorTestCase {
+
+	private $domainMap = [
+		'wikimedia.de' => 'wikimedia.de',
+		'www.wikimedia.de' => 'wikimedia.de',
+		'wikipedia.de' => 'wikipedia.de',
+		'www.wikipedia.de' => 'wikipedia.de',
+		'de.wikipedia.org' => 'de.wikipedia.org',
+		'en.wikipedia.org' => 'en.wikipedia.org',
+		'ru.wikivoyage.org' => 'ru.wikivoyage.org',
+	];
+
+	/**
+	 * @dataProvider urlProvider
+	 * @param string $expected
+	 * @param string $url
+	 */
+	public function testGeneralization( string $url, string $expected ) {
+		$generalizer = new GeneralizedReferrer( 'web', $this->domainMap );
+		$this->assertSame( $expected, $generalizer->generalize( $url ) );
+	}
+
+	public function urlProvider() {
+		return [
+			[ 'http://de.wikipedia.org/wiki/Hauptseite', 'de.wikipedia.org' ],
+			[ 'https://en.wikipedia.org/wiki/Main_Page', 'en.wikipedia.org' ],
+			[ 'http://www.wikimedia.de/Mitarbeiter', 'wikimedia.de' ],
+			[ 'https://wikimedia.de/wiki/Hauptseite', 'wikimedia.de' ],
+			[ 'https://www.wikipedia.de/', 'wikipedia.de' ],
+			[ 'http://www.wikipedia.de', 'wikipedia.de' ],
+			[ 'wikipedia.de', 'web' ],
+			[ 'https://www.google.com/?q=wikimedia+spenden', 'web' ],
+			[ 'https://ru.wikivoyage.org/wiki/Молдавия', 'ru.wikivoyage.org' ],
+		];
+	}
+
+}


### PR DESCRIPTION
This generalizes the referring URLs to contain the host name at most. The result of it needs to be stored as a tracking parameter when users enter the site.