### PR TITLE
Make unit tests finish faster

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,8 +12,14 @@
          stopOnSkipped="false"
          verbose="true">
     <testsuites>
-        <testsuite name="FundraisingFrontend">
-            <directory>tests</directory>
+        <testsuite name="FundraisingFrontend-unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="FundraisingFrontend-integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+        <testsuite name="FundraisingFrontend-system">
+            <directory>tests/System</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
With this config PHPUnit will first run the unit tests, then the integration
tests and then the system tests. This makes so that you likely need to wait
a lot less long before the test you are interested in has run.