### PR TITLE
Move and document cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ var/
 .flooignore
 
 app/config/
-app/cache/
 
 res/blz.lut2f
 web/res/js/wmde_fr.js

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ When accessing the API via `web/index.dev.php`, profiling information will be ge
 	* `System/`: edge-to-edge tests
 	* `TestEnvironment.php`: encapsulates application setup for integration and system tests
 	* `Fixtures/`: test stubs and spies
+* `var/`: Ephemeral application data
+    * `logs`: Log files (in debug mode, every request creates a log file)
+    * `cache`: Cache directory for Twig templates
 
 ## Test type restrictions
 

--- a/src/TwigFactory.php
+++ b/src/TwigFactory.php
@@ -30,7 +30,7 @@ class TwigFactory {
 		$options = [];
 
 		if ( $this->config['enable-cache'] ) {
-			$options['cache'] = __DIR__ . '/../app/cache';
+			$options['cache'] = __DIR__ . '/../var/cache';
 		}
 
 		$loader = new \Twig_Loader_Chain( $loaders );


### PR DESCRIPTION
I accidentally enabled caching in my local config and saw that it generated files in the
"wrong" directory. `app` should only be used for code and configs, for
ephemeral data like caches `var` is more appropriate.