### PR TITLE
Add TODO to getInitialStatus

### DIFF
--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -141,6 +141,7 @@ class Donation {
 		$this->trackingInfo = $trackingInfo;
 	}
 
+	// TODO: this might be misplaced
 	public function getInitialStatus(): string {
 		if ( $this->paymentType === PaymentType::DIRECT_DEBIT ) {
 			return self::STATUS_NEW;


### PR DESCRIPTION
Issues disabled on GitHub, so I'm creating a PR with a TODO instead :)

There is something off about this method and it's usage. It's only used in `DoctrineDonationRepository`:

```php
private function newDonationEntity( Donation $donation ): DoctrineDonation {
    $doctrineDonation = new DoctrineDonation();
    $doctrineDonation->setStatus( $donation->getInitialStatus() );
```

The finding of the initial status is not the job of the repository. Better place is the AddDonation UC. Though when calling this method before the Donation is "fully" constructed (without the initial status), the method might not behave correctly, as it needs to have the payment type set. So perhaps its better to move not only the call to, but also the definition of, this method to the UC.