### PR TITLE
Show validation messages on client

### DIFF
--- a/app/js/lib/reducers/validation_messages.js
+++ b/app/js/lib/reducers/validation_messages.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var objectAssign = require( 'object-assign' ),
+	_ = require( 'lodash' );
+
+function addStateIfStatusIsNotOk( state, validationResult, additionalState ) {
+	if ( validationResult === 'OK' ) {
+		return _.omit( state, Object.keys( additionalState ) );
+	} else {
+		return objectAssign( {}, state, additionalState );
+	}
+}
+
+function validationMessages( state, action ) {
+	if ( typeof state === 'undefined' ) {
+		state = {};
+	}
+	switch ( action.type ) {
+		case 'FINISH_AMOUNT_VALIDATION':
+			return addStateIfStatusIsNotOk( state, action.payload.status, { amount: action.payload.message } );
+		default:
+			return state;
+	}
+}
+
+module.exports = validationMessages;

--- a/app/js/lib/redux_validation.js
+++ b/app/js/lib/redux_validation.js
@@ -7,9 +7,8 @@ var objectAssign = require( 'object-assign' ),
 		validationFunction: null,
 		actionCreationFunction: null,
 		fields: null,
-
-		// internal properties
 		previousFieldValues: {},
+
 		dispatchIfChanged: function ( formValues, store ) {
 			var selectedValues = _.pick( formValues, this.fields ),
 				validationResult;
@@ -44,14 +43,15 @@ var objectAssign = require( 'object-assign' ),
 	 * @param {Array} fieldNames Names of the state values from formContent that will be validated
 	 * @return {ValidationDispatcher}
 	 */
-	createValidationDispatcher = function ( validator, actionCreationFunction, fieldNames ) {
+	createValidationDispatcher = function ( validator, actionCreationFunction, fieldNames, initalValues ) {
 		if ( typeof validator === 'object' ) {
 			validator = validator.validate.bind( validator );
 		}
 		return objectAssign( Object.create( ValidationDispatcher ), {
 			validationFunction: validator,
 			actionCreationFunction: actionCreationFunction,
-			fields: fieldNames
+			fields: fieldNames,
+			previousFieldValues: initalValues || {}
 		} );
 	},
 

--- a/app/js/lib/store.js
+++ b/app/js/lib/store.js
@@ -3,6 +3,7 @@ var Redux = require( 'redux' ),
 	formPagination = require( './reducers/form_pagination' ),
 	formContent = require( './reducers/form_content' ),
 	validity = require( './reducers/validity' ),
+	validationMessages = require( './reducers/validation_messages' ),
 	middlewares = [ reduxPromise ];
 
 /* jshint ignore:start */ // Ignore console.log calls
@@ -36,6 +37,6 @@ if ( process.env.REDUX_LOG === 'on' ) {
 module.exports = Redux.createStore( Redux.combineReducers( {
 	formPagination: formPagination,
 	formContent: formContent,
-	validity: validity
+	validity: validity,
+	validationMessages: validationMessages
 } ), undefined, Redux.applyMiddleware.apply( this, middlewares ) );
-

--- a/app/js/lib/view_handler/error_box.js
+++ b/app/js/lib/view_handler/error_box.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var objectAssign = require( 'object-assign' ),
+	_ = require( 'lodash' ),
+
+	FieldNameTranslator = {
+		fieldNames: {},
+		translate: function ( fieldName ) {
+			return this.fieldNames[ fieldName ] ? this.fieldNames[ fieldName ] : fieldName;
+		}
+	},
+
+	ErrorBox = {
+		el: null,
+		fieldNameTranslator: null,
+		update: function ( validationMessages ) {
+			if ( _.isEmpty( validationMessages ) ) {
+				this.el.hide();
+				return;
+			}
+			this.el.show();
+			this.el.find( '.fields' ).text(
+				Object.keys( validationMessages )
+					.map( this.fieldNameTranslator.translate.bind( this.fieldNameTranslator ) )
+					.join( ', ' )
+			);
+		}
+	},
+
+	createHandler = function ( boxContainer, fieldNameTranslations ) {
+		var translator = objectAssign( Object.create( FieldNameTranslator ), {
+			fieldNames: fieldNameTranslations || {}
+		} );
+		return objectAssign( Object.create( ErrorBox ), {
+			el: boxContainer,
+			fieldNameTranslator: translator
+		} );
+	};
+
+module.exports = {
+	createHandler: createHandler
+};

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -9,6 +9,7 @@ module.exports = {
 	Store: require( './lib/store' ),
 	View: {
 		createClearAmountHandler: require( './lib/view_handler/clear_amount' ).createHandler,
+		createErrorBoxHandler:  require( './lib/view_handler/error_box' ).createHandler,
 		createFormPageVisibilityHandler: require( './lib/view_handler/form_page_visibility' ).createHandler,
 		createFormPageHighlightHandler: require( './lib/view_handler/form_page_highlight' ).createHandler
 	},

--- a/app/js/tests/reducers/test_validation_messages.js
+++ b/app/js/tests/reducers/test_validation_messages.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var test = require( 'tape' ),
+	deepFreeze = require( 'deep-freeze' ),
+	validationMessages = require( '../../lib/reducers/validation_messages' );
+
+function createValidPayload() {
+	return {
+		status: 'OK'
+	};
+}
+
+function createInvalidPayload() {
+	return {
+		status: 'ERR',
+		message: 'there was an error'
+	};
+}
+
+test( 'FINISH_AMOUNT_VALIDATION with valid payload does not change state', function ( t ) {
+	var beforeState = {};
+
+	deepFreeze( beforeState );
+	t.deepEqual( validationMessages( beforeState, { type: 'FINISH_AMOUNT_VALIDATION', payload: createValidPayload() } ), beforeState );
+	t.end();
+} );
+
+test( 'FINISH_AMOUNT_VALIDATION with invalid payload does gets error message from payload', function ( t ) {
+	var beforeState = {},
+		expectedState = {
+			amount: 'there was an error'
+		};
+
+	deepFreeze( beforeState );
+	t.deepEqual( validationMessages( beforeState, { type: 'FINISH_AMOUNT_VALIDATION', payload: createInvalidPayload() } ), expectedState );
+	t.end();
+} );
+
+test( 'switching from invalid to valid removes error message', function ( t ) {
+	var beforeState = {
+			amount: 'there was an error'
+		},
+		expectedState = {};
+
+	deepFreeze( beforeState );
+	t.deepEqual( validationMessages( beforeState, { type: 'FINISH_AMOUNT_VALIDATION', payload: createValidPayload() } ), expectedState );
+	t.end();
+} );

--- a/app/js/tests/reducers/test_validity.js
+++ b/app/js/tests/reducers/test_validity.js
@@ -13,7 +13,7 @@ function createValidPayload() {
 function createInvalidPayload() {
 	return {
 		status: 'ERR',
-		messages: [ 'there was an error' ]
+		message: 'there was an error'
 	};
 }
 

--- a/app/js/tests/view_handlers/test_error_box.js
+++ b/app/js/tests/view_handlers/test_error_box.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var test = require( 'tape' ),
+	sinon = require( 'sinon' ),
+	errorBoxHandler = require( '../../lib/view_handler/error_box' )
+	;
+
+test( 'When there are no messages, box is hidden', function ( t ) {
+	var box = {
+			hide: sinon.spy()
+		},
+		handler = errorBoxHandler.createHandler( box );
+
+	handler.update( {} );
+	t.ok( box.hide.calledOnce, 'error box should be hidden' );
+	t.end();
+} );
+
+test( 'When there are messages, ', function ( t ) {
+	var subElement = {
+			text: sinon.spy()
+		},
+		box = {
+			show: sinon.spy(),
+			find: sinon.stub().returns( subElement )
+		},
+		handler = errorBoxHandler.createHandler( box ),
+		errorMessages = { amount: 'This will be discarded', paymentType: 'irrelevant' };
+
+	handler.update( errorMessages );
+
+	t.test( '    box is shown', function ( t ) {
+		t.ok( box.show.calledOnce, 'error box should be shown' );
+		t.end();
+	} );
+
+	t.test( '    text is inserted in \'.fields\' subelement', function ( t ) {
+		t.ok( box.find.calledWith( '.fields' ) );
+		t.ok( subElement.text.calledOnce, 'text in subelement should be set' );
+		t.ok( subElement.text.calledWith( 'amount, paymentType' ), 'text in subelement should contain element names' );
+		t.end();
+	} );
+
+	t.end();
+} );

--- a/app/templates/Form1.html.twig
+++ b/app/templates/Form1.html.twig
@@ -5,6 +5,12 @@
  TODO Remove this when JavaScript works.
 #}
 <!-- <html> -->
+
+<div id="validation-errors" class="errorbox" style="display: none">
+    <strong>Bei der Prüfung Ihrer Eingaben wurden Probleme bemerkt</strong>.
+    Bitte überprüfen Sie Ihre Angaben in folgenden Feldern: <strong class="fields">keine</strong>
+</div>
+
 <form name="donForm" id="donForm" method="POST" action="#">
 
     <!-- steps-overview -->
@@ -453,7 +459,8 @@
                             personalData: $( "#personal-data,#donation-submit2" )
                         } ),
                         formPageHighlight: WMDE.View.createFormPageHighlightHandler( $( 'ul.step-list li' ) ),
-                        clearAmount: WMDE.View.createClearAmountHandler( $( 'input[name=betrag_auswahl]' ), $( '#amount-8' ) )
+                        clearAmount: WMDE.View.createClearAmountHandler( $( 'input[name=betrag_auswahl]' ), $( '#amount-8' ) ),
+                        errorBox: WMDE.View.createErrorBoxHandler( $( '#validation-errors' ), { amount: 'Betrag' } )
                     };
                 },
                 newValidators: function() {
@@ -510,6 +517,7 @@
                         viewHandlers.formPageVisibility.update( state.formPagination );
                         viewHandlers.formPageHighlight.update( state.formPagination );
                         viewHandlers.clearAmount.update( state.formContent );
+                        viewHandlers.errorBox.update( state.validationMessages );
                     } );
                 },
                 init: function( store, actions ) {

--- a/app/templates/Form1.html.twig
+++ b/app/templates/Form1.html.twig
@@ -468,7 +468,8 @@
                         WMDE.ReduxValidation.createValidationDispatcher(
                                 WMDE.FormValidation.createAmountValidator( '{$ basepath $}/validate-amount' ),
                                 WMDE.Actions.newFinishAmountValidationAction,
-                                [ 'amount', 'paymentType' ]
+                                [ 'amount', 'paymentType' ],
+                                { amount: 0, paymentType: 'BEZ' }
                         )
                     ];
                 },

--- a/web/skin/10h16/_styles/styles.css
+++ b/web/skin/10h16/_styles/styles.css
@@ -617,7 +617,7 @@ div.errorbox {
 	-moz-border-radius: 2px;
 	border-radius: 2px;
 	background: #f3a5a5;
-	margin: 0 250px 0 128px;
+	margin: 0 250px 10px 128px;
 }
 div.successbox {
 	color: #333;


### PR DESCRIPTION
Add reducer that stores the validation messages and the source field in
the global state.

Add view handler that displays the names of the invalid fields. Messages
are not displayed at the moment, similar to the old application.

This is based on #232 , which must be merged first.