### PR TITLE
Add optional logging to Redux store

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,3 +1,8 @@
 {
-        "preset": "wikimedia"
+    "preset": "wikimedia",
+    "jsDoc": {
+        "checkAnnotations": {
+            "preset": "jsdoc3"
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ If you are working on the JavaScript files and need automatic recompilation when
 
 instead. 
 
+If you want to debug problems in the Redux data flow, set the following variable in the shell environment:
+  
+    export REDUX_LOG=on
+
+Actions and their resulting state will be logged. 
+
 ## Profiling
 
 When accessing the API via `web/index.dev.php`, profiling information will be generated and in

--- a/app/js/lib/store.js
+++ b/app/js/lib/store.js
@@ -2,10 +2,40 @@ var Redux = require( 'redux' ),
 	reduxPromise = require( 'redux-promise' ),
 	formPagination = require( './reducers/form_pagination' ),
 	formContent = require( './reducers/form_content' ),
-	validity = require( './reducers/validity' );
+	validity = require( './reducers/validity' ),
+	middlewares = [ reduxPromise ];
+
+/* jshint ignore:start */ // Ignore console.log calls
+/** @see http://redux.js.org/docs/api/applyMiddleware.html */
+function logger( store ) {
+	var getState = store.getState;
+
+	return function ( next ) {
+		return function ( action ) {
+			var returnValue;
+
+			console.log( 'will dispatch', action );
+
+			// Call the next dispatch method in the middleware chain.
+			returnValue = next( action );
+
+			console.log( 'state after dispatch', getState() );
+
+			// This will likely be the action itself, unless
+			// a middleware further in chain changed it.
+			return returnValue;
+		};
+	};
+}
+
+if ( process.env.REDUX_LOG === 'on' ) {
+	middlewares.push( logger );
+}
+/* jshint ignore:end */
 
 module.exports = Redux.createStore( Redux.combineReducers( {
 	formPagination: formPagination,
 	formContent: formContent,
 	validity: validity
-} ), undefined, Redux.applyMiddleware( reduxPromise ) );
+} ), undefined, Redux.applyMiddleware.apply( this, middlewares ) );
+

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "browserify": "^13.0.0",
     "browserify-shim": "^3.8.12",
     "deep-freeze": "0.0.1",
+    "envify": "^3.4.0",
     "jquery": "^2.2.0",
     "jscs": "^2.10.1",
     "jsdom": "^8.0.4",
@@ -49,7 +50,8 @@
   },
   "browserify": {
     "transform": [
-      "browserify-shim"
+      "browserify-shim",
+      "envify"
     ]
   },
   "browserify-shim": {


### PR DESCRIPTION
Logging can now be turned on by doing

    export REDUX_LOG=on

while compiling on the command line.