### PR TITLE
add content for donation cancellation confirmation

### DIFF
--- a/app/templates/Donation_Cancellation_Confirmation.twig
+++ b/app/templates/Donation_Cancellation_Confirmation.twig
@@ -1,1 +1,18 @@
-TODO
+<div id="greenBox" class="inhalt boxShadow">
+
+	<div class="text">
+		<h2>{$ 'donation-cancellation-header'|trans({}) $}</h2>
+		<p>
+			{$ 'donation-cancellation-text'|trans( { '%donation.id%': donation.id } )|raw $}
+		</p>
+		<ul>
+			<li>
+				Zum <a href="/">Spendenformular</a>
+			</li>
+			<li>
+				Zur <a href="https://www.wikimedia.de/">Homepage von Wikimedia Deutschland</a>
+			</li>
+		</ul>
+	</div>
+
+</div>

--- a/app/translations/messages.de_DE.json
+++ b/app/translations/messages.de_DE.json
@@ -3,5 +3,7 @@
   "mail_subject_membership": "Ihre Mitgliedschaft bei Wikimedia Deutschland",
   "mail_subject_confirm_donation": "Ihre Spende für Freies Wissen",
   "mail_subject_confirm_cancellation": "TODODODODODODODODODODO",
-  "recurringDonation": "Wie gewünscht werden wir die Buchung jeden Monat wiederholen.|Wie gewünscht werden wir die Buchung alle %interval% Monate wiederholen."
+  "recurringDonation": "Wie gewünscht werden wir die Buchung jeden Monat wiederholen.|Wie gewünscht werden wir die Buchung alle %interval% Monate wiederholen.",
+  "donation-cancellation-header": "Ihre Spende wurde storniert",
+  "donation-cancellation-text": "Der Spendenvorgang mit der Nummer %donation.id% wurde storniert. Wenn Sie noch Fragen haben oder uns auf Probleme hinweisen möchten, wenden Sie sich bitte an <a href=\"mailto:spenden@wikimedia.de?subject=Online-Spende%20%donation.id%\">spenden@wikimedia.de</a>."
 }


### PR DESCRIPTION
This adds content to the donation cancellation confirmation page. The response model only needs to provide the donation ID.