### PR TITLE
Initial form state

### DIFF
--- a/app/js/lib/actions.js
+++ b/app/js/lib/actions.js
@@ -28,6 +28,19 @@ module.exports = {
 		};
 	},
 
+	/**
+	 * Set initial form content
+	 *
+	 * @param {{Object}} initialContent
+	 * @returns {{type: string, payload: *}}
+	 */
+	newInitializeContentAction: function ( initialContent ) {
+		return {
+			type: 'INITIALIZE_CONTENT',
+			payload: initialContent
+		};
+	},
+
 	newChangeContentAction: function ( contentName, newValue ) {
 		return {
 			type: 'CHANGE_CONTENT',

--- a/app/js/lib/form_validation.js
+++ b/app/js/lib/form_validation.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var jQuery = require( 'jquery' ),
-	objectAsssign = require( 'object-assign' ),
+	objectAssign = require( 'object-assign' ),
 
 	AmountValidator = {
 		validationUrl: '',
@@ -22,7 +22,7 @@ var jQuery = require( 'jquery' ),
 	 * @return {AmountValidator}
 	 */
 	createAmountValidator = function ( validationUrl, postFunction ) {
-		return objectAsssign( Object.create( AmountValidator ), {
+		return objectAssign( Object.create( AmountValidator ), {
 			validationUrl: validationUrl,
 			postFunction: postFunction || jQuery.post
 		} );

--- a/app/js/lib/reducers/form_content.js
+++ b/app/js/lib/reducers/form_content.js
@@ -9,9 +9,18 @@ var objectAssign = require( 'object-assign' ),
 		paymentPeriodInMonths: 0 // 0, 1, 3, 6 or 12, 0 = non-recurring payment
 	};
 
-function stateContainsInvalidKeys( state ) {
-	var invalidKeys = _.omit( state, _.keys( initialState ) );
-	return !_.isEmpty( invalidKeys );
+/**
+ * Return object keys that are not defined in initial state
+ *
+ * @param {Object} state
+ * @returns {Array}
+ */
+function getInvalidKeys( state ) {
+	return _.keys( _.omit( state, _.keys( initialState ) ) );
+}
+
+function stateContainsUnknownKeys( state ) {
+	return !_.isEmpty( getInvalidKeys( state ) );
 }
 
 module.exports = function formContent( state, action ) {
@@ -39,10 +48,9 @@ module.exports = function formContent( state, action ) {
 			newState[ action.payload.contentName ] = action.payload.value;
 			return newState;
 		case 'INITIALIZE_CONTENT':
-			if ( stateContainsInvalidKeys( action.payload ) ) {
+			if ( stateContainsUnknownKeys( action.payload ) ) {
 				throw new Error(
-					'Initial state contains invalid keys: ' +
-					_.omit( state, _.keys( initialState ) ).join( ', ' )
+					'Initial state contains unknown keys: ' + getInvalidKeys( action.payload ).join( ', ' )
 				);
 			}
 			return objectAssign( {}, state, action.payload );

--- a/app/js/lib/reducers/form_content.js
+++ b/app/js/lib/reducers/form_content.js
@@ -9,6 +9,11 @@ var objectAssign = require( 'object-assign' ),
 		paymentPeriodInMonths: 0 // 0, 1, 3, 6 or 12, 0 = non-recurring payment
 	};
 
+function stateContainsInvalidKeys( state ) {
+	var invalidKeys = _.omit( state, _.keys( initialState ) );
+	return !_.isEmpty( invalidKeys );
+}
+
 module.exports = function formContent( state, action ) {
 	var newAmount, newState;
 	if ( typeof state === 'undefined' ) {
@@ -33,6 +38,14 @@ module.exports = function formContent( state, action ) {
 			newState = _.clone( state );
 			newState[ action.payload.contentName ] = action.payload.value;
 			return newState;
+		case 'INITIALIZE_CONTENT':
+			if ( stateContainsInvalidKeys( action.payload ) ) {
+				throw new Error(
+					'Initial state contains invalid keys: ' +
+					_.omit( state, _.keys( initialState ) ).join( ', ' )
+				);
+			}
+			return objectAssign( {}, state, action.payload );
 		default:
 			return state;
 	}

--- a/app/js/lib/redux_validation.js
+++ b/app/js/lib/redux_validation.js
@@ -41,9 +41,10 @@ var objectAssign = require( 'object-assign' ),
 	 * 			The method will be bound to the object.
 	 * @param {Function} actionCreationFunction
 	 * @param {Array} fieldNames Names of the state values from formContent that will be validated
+	 * @param {Object} initialValues Initial form state. Only the keys and values from fieldNames will be used
 	 * @return {ValidationDispatcher}
 	 */
-	createValidationDispatcher = function ( validator, actionCreationFunction, fieldNames, initalValues ) {
+	createValidationDispatcher = function ( validator, actionCreationFunction, fieldNames, initialValues ) {
 		if ( typeof validator === 'object' ) {
 			validator = validator.validate.bind( validator );
 		}
@@ -51,7 +52,7 @@ var objectAssign = require( 'object-assign' ),
 			validationFunction: validator,
 			actionCreationFunction: actionCreationFunction,
 			fields: fieldNames,
-			previousFieldValues: initalValues || {}
+			previousFieldValues: _.pick( initialValues || {}, fieldNames )
 		} );
 	},
 

--- a/app/js/lib/redux_validation.js
+++ b/app/js/lib/redux_validation.js
@@ -1,8 +1,17 @@
 'use strict';
 
+/**
+ *
+ * @module redux_validation
+ */
+
 var objectAssign = require( 'object-assign' ),
 	_ = require( 'lodash' ),
 
+	/**
+	 *
+	 * @class ValidationDispatcher
+	 */
 	ValidationDispatcher = {
 		validationFunction: null,
 		actionCreationFunction: null,

--- a/app/js/lib/store_update_handling.js
+++ b/app/js/lib/store_update_handling.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Connect store updates to validators, components and view handlers
+ *
+ * @module store_update_handling
+ * @requires redux_validation
+ */
+
+/**
+ * Create validation dispatchers
+ *
+ * @callback validatorFactoryFunction
+ * @param {Object} initialValues - initial values for the validation dispatchers so they don't fire on initialization
+ * @return {redux_validation.ValidationDispatcher[]}
+ */
+
+var reduxValidation = require( './redux_validation' ),
+	_ = require( 'lodash' );
+
+module.exports = {
+	/**
+	 * @param {validatorFactoryFunction} validatorFactoryFunction
+	 * @param {store.Store} store
+	 * @param {Object} initialValues - initial values for the validation dispatchers so they don't fire on initialization
+	 */
+	connectValidatorsToStore: function ( validatorFactoryFunction, store, initialValues ) {
+		var completeInitialValues = _.extend( {}, store.getState().formContent, initialValues ),
+			validators = validatorFactoryFunction( completeInitialValues );
+		reduxValidation.createValidationDispatcherCollection( store, validators );
+	},
+	connectComponentsToStore: function ( components, store ) {
+		store.subscribe( function () {
+			var state = store.getState(),
+				formContent = state.formContent;
+
+			// TODO check if formContent has changed before executing update actions
+			components.forEach( function ( component ) {
+				component.render( formContent );
+			} );
+		} );
+	},
+	connectViewHandlersToStore: function ( viewHandlers, store ) {
+		store.subscribe( function () {
+			var state = store.getState();
+			// TODO check if state has changed before executing update actions
+
+			viewHandlers.forEach( function ( viewHandlerConfig ) {
+				viewHandlerConfig.viewHandler.update.call(
+					viewHandlerConfig.viewHandler,
+					state[ viewHandlerConfig.stateKey ]
+				);
+			} );
+		} );
+	}
+};

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -1,6 +1,6 @@
 // main module to expose all submodules
 /**
- * Uppercase keys designate namespaces, lowercase keys designate global objects
+ * Uppercase keys designate namespaces, lowercase keys designate global objects/functions
  */
 module.exports = {
 	FormFieldAccessors: require( './lib/form_field_accessors' ),
@@ -8,6 +8,7 @@ module.exports = {
 	ReduxValidation: require( './lib/redux_validation' ),
 	Components: require( './lib/form_components' ),
 	Store: require( './lib/store' ),
+	StoreUpdates: require( './lib/store_update_handling' ),
 	View: {
 		createClearAmountHandler: require( './lib/view_handler/clear_amount' ).createHandler,
 		createErrorBoxHandler:  require( './lib/view_handler/error_box' ).createHandler,

--- a/app/js/tests/reducers/test_form_content.js
+++ b/app/js/tests/reducers/test_form_content.js
@@ -69,7 +69,7 @@ test( 'INITIALIZE_CONTENT throws an error if a field name is not allowed', funct
 
 	t.throws( function () {
 		formContent( {}, action );
-	} );
+	}, /unknownField/ );
 	t.end();
 } );
 

--- a/app/js/tests/reducers/test_form_content.js
+++ b/app/js/tests/reducers/test_form_content.js
@@ -11,7 +11,6 @@ test( 'SELECT_AMOUNT sets amount and isCustomAmount', function ( t ) {
 	deepFreeze( stateBefore );
 	t.deepEqual( formContent( stateBefore, { type: 'SELECT_AMOUNT', payload: { amount: 5 } } ), expectedState );
 	t.end();
-
 } );
 
 test( 'SELECT_AMOUNT keeps amount if selected amount is null', function ( t ) {
@@ -21,7 +20,6 @@ test( 'SELECT_AMOUNT keeps amount if selected amount is null', function ( t ) {
 	deepFreeze( stateBefore );
 	t.deepEqual( formContent( stateBefore, { type: 'SELECT_AMOUNT', payload: { amount: null } } ), expectedState );
 	t.end();
-
 } );
 
 test( 'INPUT_AMOUNT sets amount and isCustomAount', function ( t ) {
@@ -31,7 +29,6 @@ test( 'INPUT_AMOUNT sets amount and isCustomAount', function ( t ) {
 	deepFreeze( stateBefore );
 	t.deepEqual( formContent( stateBefore, { type: 'INPUT_AMOUNT', payload: { amount: '42.23' } } ), expectedState );
 	t.end();
-
 } );
 
 test( 'CHANGE_CONTENT changes the field', function ( t ) {
@@ -42,5 +39,37 @@ test( 'CHANGE_CONTENT changes the field', function ( t ) {
 	deepFreeze( stateBefore );
 	t.deepEqual( formContent( stateBefore, action ), expectedState );
 	t.end();
-
 } );
+
+test( 'CHANGE_CONTENT throws an error if the field name is not allowed', function ( t ) {
+	var action = { type: 'CHANGE_CONTENT', payload: { value: 'supercalifragilistic', contentName: 'unknownField' } };
+
+	t.throws( function () {
+		formContent( {}, action );
+	} );
+	t.end();
+} );
+
+test( 'INITIALIZE_CONTENT changes multiple fields', function ( t ) {
+	var stateBefore = { paymentType: 'PPL', amount: 0, recurringPayment: 0 },
+		expectedState = { paymentType: 'BEZ', amount: '25,00', recurringPayment: 0 },
+		action = { type: 'INITIALIZE_CONTENT', payload: { amount: '25,00', paymentType: 'BEZ' } };
+
+	deepFreeze( stateBefore );
+	t.deepEqual( formContent( stateBefore, action ), expectedState );
+	t.end();
+} );
+
+test( 'INITIALIZE_CONTENT throws an error if a field name is not allowed', function ( t ) {
+	var action = { type: 'INITIALIZE_CONTENT', payload: {
+		amount: '25,00',
+		paymentType: 'BEZ',
+		unknownField: 'supercalifragilistic'
+	} };
+
+	t.throws( function () {
+		formContent( {}, action );
+	} );
+	t.end();
+} );
+

--- a/app/js/tests/test_actions.js
+++ b/app/js/tests/test_actions.js
@@ -55,3 +55,13 @@ test( 'newChangeContentAction returns action object', function ( t ) {
 	t.deepEqual( actions.newChangeContentAction( 'email', 'nyan@awesomecats.com' ), expectedAction );
 	t.end();
 } );
+
+test( 'newInitializeContentAction returns action object', function ( t ) {
+	var expectedAction = {
+		type: 'INITIALIZE_CONTENT',
+		payload: { paymentType: 'BEZ', amount: '50,00' }
+	};
+	t.deepEqual( actions.newInitializeContentAction( { paymentType: 'BEZ', amount: '50,00' } ), expectedAction );
+	t.end();
+} );
+

--- a/app/js/tests/test_redux_validation.js
+++ b/app/js/tests/test_redux_validation.js
@@ -27,9 +27,15 @@ test( 'ValidationDispatcher calls validationFunction and dispatches action only 
 	var successResult = { status: 'OK' },
 		dummyAction = { type: 'TEST_VALIDATION' },
 		testData = { importantField: 'just some data', ignoredData: 'this won\'t be validated' },
+		initialData = {},
 		validationFunction = sinon.stub().returns( successResult ),
 		actionCreationFunction = sinon.stub().returns( dummyAction ),
-		dispatcher = reduxValidation.createValidationDispatcher( validationFunction, actionCreationFunction, [ 'importantField' ] ),
+		dispatcher = reduxValidation.createValidationDispatcher(
+			validationFunction,
+			actionCreationFunction,
+			[ 'importantField' ],
+			initialData
+		),
 		testStore = { dispatch: sinon.spy() };
 
 	dispatcher.dispatchIfChanged( testData, testStore );
@@ -64,25 +70,18 @@ test( 'createValidationDispatcher accepts validator object as validation functio
 		},
 		testData = { importantField: 'just some data which will be ignored' },
 		actionCreationFunction = sinon.stub(),
-		dispatcher = reduxValidation.createValidationDispatcher( validatorSpy, actionCreationFunction, [ 'importantField' ] ),
+		dispatcher = reduxValidation.createValidationDispatcher(
+			validatorSpy,
+			actionCreationFunction,
+			[ 'importantField' ],
+			{}
+		),
 		testStore = { dispatch: sinon.spy() };
 
 	dispatcher.dispatchIfChanged( testData, testStore );
 
 	t.ok( validatorSpy.validatorDelegate.calledOnce, 'validate function is called once' );
 	t.ok( validatorSpy.validatorDelegate.calledWith( testData ), 'validation function is called with test data' );
-	t.end();
-} );
-
-test( 'createValidationDispatcher can set initial values from object', function ( t ) {
-	var initialDataBag = { importantField: 'initial data', ignoredData: 'this won\'t be added to initial data' },
-		validationFunction = sinon.stub(),
-		actionCreationFunction = sinon.stub(),
-		dispatcher = reduxValidation.createValidationDispatcher( validationFunction, actionCreationFunction, [ 'importantField' ], initialDataBag ),
-		expectedPreviousFieldValues = { importantField: 'initial data' };
-
-	t.deepEqual( dispatcher.previousFieldValues, expectedPreviousFieldValues, 'Previous field values should only contain selected values' );
-
 	t.end();
 } );
 

--- a/app/js/tests/test_redux_validation.js
+++ b/app/js/tests/test_redux_validation.js
@@ -74,6 +74,18 @@ test( 'createValidationDispatcher accepts validator object as validation functio
 	t.end();
 } );
 
+test( 'createValidationDispatcher can set initial values from object', function ( t ) {
+	var initialDataBag = { importantField: 'initial data', ignoredData: 'this won\'t be added to initial data' },
+		validationFunction = sinon.stub(),
+		actionCreationFunction = sinon.stub(),
+		dispatcher = reduxValidation.createValidationDispatcher( validationFunction, actionCreationFunction, [ 'importantField' ], initialDataBag ),
+		expectedPreviousFieldValues = { importantField: 'initial data' };
+
+	t.deepEqual( dispatcher.previousFieldValues, expectedPreviousFieldValues, 'Previous field values should only contain selected values' );
+
+	t.end();
+} );
+
 test( 'ValidationDispatcherCollection listens to store updates', function ( t ) {
 	var storeSpy = {
 			subscribe: sinon.spy()

--- a/app/js/tests/test_store_update_handling.js
+++ b/app/js/tests/test_store_update_handling.js
@@ -1,0 +1,97 @@
+'use strict';
+
+var test = require( 'tape' ),
+	sinon = require( 'sinon' ),
+	storeUpdateHandling = require( '../lib/store_update_handling' )
+	;
+
+function createFakeStore( storeData ) {
+	return {
+		subscribe: sinon.spy(),
+		getState: sinon.stub().returns( storeData ),
+		// Call all callback functions that were registered through calls to `subscribe`
+		fakeUpdate: function () {
+			var subscribeCalls = this.subscribe.args;
+			subscribeCalls.forEach( function ( subscribeArguments ) {
+				// get the first argument to the `subscribe` call
+				var updateCallback = subscribeArguments[ 0 ];
+				// call the callback, using its own context
+				updateCallback.call( updateCallback );
+			} );
+		}
+	};
+}
+
+test( 'connect validators to store updates', function ( t ) {
+	var validator = {
+			dispatchIfChanged: sinon.spy()
+		},
+		validatorFactory = sinon.stub().returns( [ validator ] ),
+		storeData = { formContent: { test: 'dummy store contents' } },
+		store = createFakeStore( storeData );
+
+	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, {} );
+	store.fakeUpdate();
+
+	t.ok( validator.dispatchIfChanged.calledOnce, 'validator dispatch method is only called once' );
+	t.ok( validator.dispatchIfChanged.calledWith( storeData.formContent ), 'validator dispatch method is called with the form contents' );
+	t.end();
+} );
+
+test( 'initial values are passed to validator factory and merged with initial store formContent values', function ( t ) {
+	var validator = {
+			dispatchIfChanged: sinon.spy()
+		},
+		validatorFactory = sinon.stub().returns( [ validator ] ),
+		initialStoreFormContent = { paymentType: 'PPL' },
+		storeData = { formContent: initialStoreFormContent },
+		store = createFakeStore( storeData ),
+		initialValues = { paymentType: 'BTC' };
+
+	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, {} );
+	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, initialValues );
+
+	t.ok(
+		validatorFactory.firstCall.calledWith( initialStoreFormContent ),
+		'validator factory is called with initial values from store'
+	);
+	t.ok(
+		validatorFactory.secondCall.calledWith( initialValues ),
+		'validator factory is called with initial values from store'
+	);
+	t.end();
+} );
+
+test( 'connect components to store updates', function ( t ) {
+	var component = {
+			render: sinon.spy()
+		},
+		storeData = { formContent: { test: 'dummy store contents' } },
+		store = createFakeStore( storeData );
+
+	storeUpdateHandling.connectComponentsToStore( [ component ], store );
+	store.fakeUpdate();
+
+	t.ok( component.render.calledOnce, 'render method of component is called once' );
+	t.ok( component.render.calledWith( storeData.formContent ), 'render method is called with the form contents' );
+	t.end();
+} );
+
+test( 'connect view handlers to store updates', function ( t ) {
+	var viewHandler = {
+			update: sinon.spy()
+		},
+		viewHandlerConfig = {
+			viewHandler: viewHandler,
+			stateKey: 'numberOfCats'
+		},
+		storeData = { numberOfCats: 42, numberOfDogs: 23 },
+		store = createFakeStore( storeData );
+
+	storeUpdateHandling.connectViewHandlersToStore( [ viewHandlerConfig ], store );
+	store.fakeUpdate();
+
+	t.ok( viewHandler.update.calledOnce, 'view handler update method is only called once' );
+	t.ok( viewHandler.update.calledWith( 42 ), 'view handler get passed only selected state parts' );
+	t.end();
+} );

--- a/app/templates/DonationForm.html.twig
+++ b/app/templates/DonationForm.html.twig
@@ -23,13 +23,16 @@
     TODO
 </div>
 
-
 <script>
+
+    // The following line is a Twig template placeholder to generate initial values
+    var initialFormValues = {$ initialFormValues|default( 'undefined' )|json_encode|raw $} || {};
+
     // Initialize the form
     $(function(){
 
         var FormFactory = {
-                newViewHandlers: function() {
+                newViewHandlers: function () {
                     return {
                         formPageVisibility: WMDE.View.createFormPageVisibilityHandler( {
                             payment: $( "#paymentPage" ),
@@ -40,13 +43,13 @@
                         errorBox: WMDE.View.createErrorBoxHandler( $( '#validation-errors' ), { amount: 'Betrag' } )
                     };
                 },
-                newValidators: function() {
+                newValidators: function ( initialValues ) {
                     return [
                         WMDE.ReduxValidation.createValidationDispatcher(
                                 WMDE.FormValidation.createAmountValidator( '{$ basepath $}/validate-amount' ),
                                 WMDE.Actions.newFinishAmountValidationAction,
                                 [ 'amount', 'paymentType' ],
-                                { amount: 0, paymentType: 'BEZ' }
+                                initialValues
                         )
                     ];
                 },
@@ -89,8 +92,10 @@
                         store.dispatch( actions.newNextPageAction() );
                     } );
                 },
-                connectValidatorsToStore: function ( store ) {
-                    WMDE.ReduxValidation.createValidationDispatcherCollection( store, this.newValidators() );
+                connectValidatorsToStore: function ( store, initialValues ) {
+                    var completeInitialValues = $.extend( {}, store.getState().formContent, initialValues ),
+                        validators = this.newValidators( completeInitialValues );
+                    WMDE.ReduxValidation.createValidationDispatcherCollection( store, validators );
                 },
                 connectViewHandlersToStore: function ( store ) {
                     var viewHandlers = this.newViewHandlers();
@@ -116,15 +121,15 @@
 
                     } );
                 },
-                init: function( store, actions ) {
+                init: function( store, actions, initialFormValues ) {
                     this.connectElementEventsToActions(store, actions );
-                    this.connectValidatorsToStore( store );
+                    this.connectValidatorsToStore( store, initialFormValues );
                     this.connectViewHandlersToStore( store );
                     this.connectComponentsToStore( store );
                 }
             };
 
-        FormFactory.init( WMDE.Store, WMDE.Actions );
+        FormFactory.init( WMDE.Store, WMDE.Actions, initialFormValues );
 
         // Initialize form pages
         WMDE.Store.dispatch( WMDE.Actions.newAddPageAction( 'payment' ) );

--- a/app/templates/DonationForm.html.twig
+++ b/app/templates/DonationForm.html.twig
@@ -25,116 +25,101 @@
 
 <script>
 
-    // The following line is a Twig template placeholder to generate initial values
-    var initialFormValues = {$ initialFormValues|default( 'undefined' )|json_encode|raw $} || {};
+    // The following line is a Twig template placeholder to generate initial values (defaults to empty object)
+    var initialFormValues = {% if initialFormValues %}{$ initialFormValues|json_encode|raw $}{% else %}{}{% endif %};
 
     // Initialize the form
-    $(function(){
+    $( function () {
+        var store = WMDE.Store,
+            actions = WMDE.Actions;
 
-        var FormFactory = {
-                newViewHandlers: function () {
-                    return {
-                        formPageVisibility: WMDE.View.createFormPageVisibilityHandler( {
+        WMDE.StoreUpdates.connectComponentsToStore(
+            [
+                WMDE.Components.createRadioComponent( store, $( '.payment-type-select' ), 'paymentType' ),
+                WMDE.Components.createRadioComponent( store, $( '.interval-type-select' ), 'paymentPeriodInMonths' ),
+                WMDE.Components.createRadioComponent( store, $( '.payment-period-select' ), 'paymentPeriodInMonths' )
+            ],
+            store
+        );
+
+        WMDE.StoreUpdates.connectValidatorsToStore(
+            function ( initialValues ) {
+                return [
+                    WMDE.ReduxValidation.createValidationDispatcher(
+                            WMDE.FormValidation.createAmountValidator( '{$ basepath $}/validate-amount' ),
+                            actions.newFinishAmountValidationAction,
+                            [ 'amount', 'paymentType' ],
+                            initialValues
+                    )
+                ];
+            },
+            store,
+            initialFormValues
+        );
+
+        // Connect view handlers to changes in specific parts in the global state, designated by 'stateKey'
+        WMDE.StoreUpdates.connectViewHandlersToStore(
+                [
+                    {
+                        viewHandler: WMDE.View.createFormPageVisibilityHandler( {
                             payment: $( "#paymentPage" ),
                             personalData: $( "#personalDataPage" ),
                             bankConfirmation: $( '#bankConfirmationPage' )
                         } ),
-                        clearAmount: WMDE.View.createClearAmountHandler( $( '.amount-select' ), $( '.amount-input' ) ),
-                        errorBox: WMDE.View.createErrorBoxHandler( $( '#validation-errors' ), { amount: 'Betrag' } )
-                    };
-                },
-                newValidators: function ( initialValues ) {
-                    return [
-                        WMDE.ReduxValidation.createValidationDispatcher(
-                                WMDE.FormValidation.createAmountValidator( '{$ basepath $}/validate-amount' ),
-                                WMDE.Actions.newFinishAmountValidationAction,
-                                [ 'amount', 'paymentType' ],
-                                initialValues
-                        )
-                    ];
-                },
-                newComponents: function ( store ) {
-                    return [
-                        WMDE.Components.createRadioComponent( store, $( '.payment-type-select' ), 'paymentType' ),
-                        WMDE.Components.createRadioComponent( store, $( '.interval-type-select' ), 'paymentPeriodInMonths' ),
-                        WMDE.Components.createRadioComponent( store, $( '.payment-period-select' ), 'paymentPeriodInMonths' )
-                    ];
-                },
-                connectElementEventsToActions: function( store, actions ) {
+                        stateKey: 'formPagination'
+                    },
+                    {
+                        viewHandler: WMDE.View.createClearAmountHandler( $( '.amount-select' ), $( '.amount-input' ) ),
+                        stateKey: 'formContent'
+                    },
+                    {
+                        viewHandler: WMDE.View.createErrorBoxHandler( $( '#validation-errors' ), { amount: 'Betrag' } ),
+                        stateKey: 'validationMessages'
+                    }
+                ],
+                store
+        );
 
-                    // we can't put amount selection into a component because we need to distinguish between
-                    // selected and custom amount in the state
-                    $( '.amount-select' ).change( function( evt ) {
-                        store.dispatch( actions.newSelectAmountAction( evt.target.value ) );
-                    } );
+        // connect DOM elements to actions
 
-                    $( '.amount-input' ).change( function( evt ) {
-                        store.dispatch( actions.newInputAmountAction( evt.target.value ) );
-                    } ).focus( function( evt ) {
-                        // This method will clear the selection (important for usability),
-                        // but keep the form data valid when the custom amount field is empty
-                        var newAmount;
-                        if ( evt.target.value ) {
-                            newAmount = evt.target.value;
-                        }
-                        else {
-                            newAmount = $( '.amount-select:checked' ).val();
-                        }
-                        store.dispatch( actions.newInputAmountAction( newAmount) );
-                    } ).blur( function( evt ) {
-                        // When the custom amount field is empty, simulate a selection to restore previous selection
-                        if ( !evt.target.value ) {
-                            store.dispatch( actions.newSelectAmountAction( null ) );
-                        }
-                    } );
+        // we can't put amount selection into a component because we need to distinguish between
+        // selected and custom amount in the state
+        $( '.amount-select' ).change( function( evt ) {
+            store.dispatch( actions.newSelectAmountAction( evt.target.value ) );
+        } );
 
-                    $( '#donation-submit1 button' ).click( function () {
-                        store.dispatch( actions.newNextPageAction() );
-                    } );
-                },
-                connectValidatorsToStore: function ( store, initialValues ) {
-                    var completeInitialValues = $.extend( {}, store.getState().formContent, initialValues ),
-                        validators = this.newValidators( completeInitialValues );
-                    WMDE.ReduxValidation.createValidationDispatcherCollection( store, validators );
-                },
-                connectViewHandlersToStore: function ( store ) {
-                    var viewHandlers = this.newViewHandlers();
-                    store.subscribe( function() {
-                        var state = store.getState();
-                        // TODO check if state has changed before executing update actions
+        $( '.amount-input' ).change( function( evt ) {
+            store.dispatch( actions.newInputAmountAction( evt.target.value ) );
+        } ).focus( function( evt ) {
+            // This method will clear the selection (important for usability),
+            // but keep the form data valid when the custom amount field is empty
+            var newAmount;
+            if ( evt.target.value ) {
+                newAmount = evt.target.value;
+            }
+            else {
+                newAmount = $( '.amount-select:checked' ).val();
+            }
+            store.dispatch( actions.newInputAmountAction( newAmount) );
+        } ).blur( function( evt ) {
+            // When the custom amount field is empty, simulate a selection to restore previous selection
+            if ( !evt.target.value ) {
+                store.dispatch( actions.newSelectAmountAction( null ) );
+            }
+        } );
 
-                        viewHandlers.formPageVisibility.update( state.formPagination );
-                        viewHandlers.clearAmount.update( state.formContent );
-                        viewHandlers.errorBox.update( state.validationMessages );
-                    } );
-                },
-                connectComponentsToStore: function( store ) {
-                    var components = this.newComponents( store );
-                    store.subscribe( function() {
-                        var state = store.getState(),
-                            formContent = state.formContent;
+        $( '#donation-submit1 button' ).click( function () {
+            store.dispatch( actions.newNextPageAction() );
+        } );
 
-                        // TODO check if formContent has changed before executing update actions
-                        components.map( function ( component ) {
-                            component.render( formContent );
-                        } );
-
-                    } );
-                },
-                init: function( store, actions, initialFormValues ) {
-                    this.connectElementEventsToActions(store, actions );
-                    this.connectValidatorsToStore( store, initialFormValues );
-                    this.connectViewHandlersToStore( store );
-                    this.connectComponentsToStore( store );
-                }
-            };
-
-        FormFactory.init( WMDE.Store, WMDE.Actions, initialFormValues );
 
         // Initialize form pages
-        WMDE.Store.dispatch( WMDE.Actions.newAddPageAction( 'payment' ) );
-        WMDE.Store.dispatch( WMDE.Actions.newAddPageAction( 'personalData' ) );
-        WMDE.Store.dispatch( WMDE.Actions.newAddPageAction( 'bankConfirmation' ) );
+        store.dispatch( actions.newAddPageAction( 'payment' ) );
+        store.dispatch( actions.newAddPageAction( 'personalData' ) );
+        store.dispatch( actions.newAddPageAction( 'bankConfirmation' ) );
+
+        // Set initial form values
+        store.dispatch( actions.newInitializeContentAction( initialFormValues ) );
 
     } );
 </script>

--- a/doc/HOWTO_Create_a_form.md
+++ b/doc/HOWTO_Create_a_form.md
@@ -9,12 +9,17 @@ the validity of those values, validation messages, which parts are displayed and
 the **Store**. To change the state, an **Action** is dispatched to the store, where it is handled by **Reducers** -
 [pure functions][pure_function] that have an initial state and the action as input and a changed state as output.
 
+Each action is created with an **Action Creators** - a function that makes sure the action object is created correctly. 
+Many actions have **payloads** - data that will be processed by the reducer functions. The payload given through the parameters of the action creator.
+
 **Form components** are wrappers for form fields that send the form field value to the store with a `CHANGE_CONTENT` action 
 and set the form field value when they receive form content updates from the store. This ensures that the store always 
 has the current form field values and that form fields that are duplicated across form pages are in sync.  
 
 The **view handler** classes are listening to changes in the state and update the HTML. They are more diverse than 
-form components and do not dispatch actions.  
+form components and do not dispatch actions.
+
+For easier HTML updates both view handlers and components get a jQuery object passed in to their factory functions.
 
 **Validators** are also listening to changes in the state. If a value changes, they call a validation function and
 dispatch a "validation finished" action to the store, which then stores the validation result and validation error
@@ -31,152 +36,135 @@ messages with its reducers. The changed validation state may trigger other view 
 
 The library that provides the `WMDE` namespace object must be present (included with a `<script>` tag). See the README on how to generate the library file.
 
-In the form code, insert the following skeleton object. Its empty functions will be filled in the following sections.
+In the form code, insert the following initialization code. Its **TODO** parts will be explained and filled in the following sections.
 
 ```JavaScript
-var FormFactory = {
-        connectElementEventsToActions: function ( store, actions ) {
-            // TODO insert code here
-        },
-        newValidators: function () {
-            return [
-                // TODO insert validators here
-            ];
-        },
-        connectValidatorsToStore: function ( store ) {
-            WMDE.ReduxValidation.createValidationDispatcherCollection( store, this.newValidators() );
-        },
-        newViewHandlers: function () {
-            return {
-                // TODO insert view handlers here
-            };
-        },
-        connectViewHandlersToStore: function ( store ) {
-            var viewHandlers = this.newViewHandlers();
-            store.subscribe( function() {
-                var state = store.getState();
-                    // TODO call update methods of view handlers here
-            } );
-        },
-        newComponents: function ( store ) {
-            return [
-                // TODO insert form components here
-            ];
-        },
-        connectComponentsToStore: function ( store ) {
-             var components = this.newComponents( store );
-             store.subscribe( function() {
-                var state = store.getState(),
-                    formContent = state.formContent;
 
-                // TODO check if formContent has changed before executing update actions
-                components.map( function ( component ) {
-                    component.render( formContent );
-                } );
+var initialFormValues = {% if initialFormValues %}{$ initialFormValues|json_encode|raw $}{% else %}{}{% endif %};
 
-            } );
-        },
-        init: function ( store, actions ) {
-            this.connectElementEventsToActions( store, actions );
-            this.connectValidatorsToStore( store );
-            this.connectComponentsToStore( store, actions );
-            this.connectViewHandlersToStore( store );
-        }
-    };
+var store = WMDE.Store, // store object
+    actions = WMDE.Actions; // action creators namespace
+WMDE.StoreUpdates.connectComponentsToStore(
+    [
+        // TODO create components
+    ],
+    store
+);
 
-FormFactory.init( WMDE.Store, WMDE.Actions );
+WMDE.StoreUpdates.connectValidatorsToStore(
+    function ( initialValues ) {
+        return [
+            // TODO create validators
+        ];
+    },
+    store,
+    initialFormValues
+ );
+         
+WMDE.StoreUpdates.connectViewHandlersToStore(
+        [
+            // TODO add view handler objects
+        ],
+        store
+);
+
+store.dispatch( actions.newInitializeContentAction( initialFormValues ) );
+
+// TODO Connect user events and form values to actions
 ```
 
-The `init` method should only be called when the document has fully loaded.
+`initialFormValues` is an object with the initial form field values, as expected by the `form_content` reducer.
+It can be filled server-side which is the reason why it's embedded in Twig template code that also returns a default
+empty object hwen it's not set server side.
 
 ### Setting up form components
 
 For every form input element (or group for elements in case of checkboxes and radio buttons), set up a form component 
-in the method body of `newComponents`:
+in components array argument to the `initializeForm` function:
  
 ```JavaScript
-newComponents: function ( store ) {
-    return [
+WMDE.StoreUpdates.connectComponentsToStore(
+    [
         WMDE.Components.createRadioComponent( store, $( '.payment-type-select' ), 'paymentType' ),
         WMDE.Components.createTextComponent( store, $( '.first-name' ), 'firstName' )
-    ];
-},
+    ],
+    store
+);
 ```
 
-The second argument to the factory function is a jQuery object for the form field. The third argument to the factory 
-function is the key for storing the value in the global state (as part of the `formContent` object).
+Each `createXXXComponent` factory function has three arguments:
+1. the store
+2. a jQuery object for the form field. 
+3. the key for storing the value in the global state (as part of the `formContent` object).
 
 You can find all the available components in [`app/js/lib/form_components.js`](../app/js/lib/form_components.js).
 
-### Connecting user events and form values to actions
-Fill the `connectElementEventsToActions` method body with code that binds DOM events to Redux actions. 
-Only connect DOM events that aren't handled by the form components. You can find all the available actions in
-[`app/js/lib/actions.js`](../app/js/lib/actions.js).
-
-```JavaScript
-connectElementEventsToActions: function( store, actions ) {
-     $( '#donation-submit1 button' ).click( function () {
-        store.dispatch( actions.newNextPageAction() );
-    } );
-},
-```
-
-The `newNextPageAction` function is an **Action Creator** - a function that makes sure the correct action object is created
-correctly. Many actions have **payloads** - data that will be processed by the reducer functions. 
-The payload given through the parameters of the action creator.
-
 ### Setting up validation
 
-Fill the `newValidators` method body with instances of `ValidationDispatcher` classes. A `ValidationDispatcher` calls a validation function with values from the store and dispatches an action to store the validation result. It only does this when the values from the store change.
+Fill the validators function body with instances of `ValidationDispatcher` classes. A `ValidationDispatcher` calls a validation function with values from the store and dispatches an action to store the validation result. It only does this when the values from the store change.
 
-The `createValidationDispatcher` factory function has three arguments:
+The `createValidationDispatcher` factory function has four arguments:
 
 1. The **validation function** to call. The function has to have one parameter - an object of the values to validate. The "validation function" argument can also be an object that has a `validate` method.
 2. The action creator to call with the validation result.
 3. An array of field names from the `formContent` part of the global store. The field names will be used to construct the value object for the validation function.
+4. The `initialValues` parameter, which is passed on from the factory function
 
 ```JavaScript
-newValidators: function() {
-    return [
-        WMDE.ReduxValidation.createValidationDispatcher(
-            WMDE.FormValidation.createAmountValidator( '{$ basepath $}/validate-amount' ),
-            WMDE.Actions.newFinishAmountValidationAction,
-            [ 'amount', 'paymentType' ]
-        )
-    ];
-},
+WMDE.StoreUpdates.connectValidatorsToStore(
+    function ( initialValues ) {
+        return [
+            WMDE.ReduxValidation.createValidationDispatcher(
+                WMDE.FormValidation.createAmountValidator( '{$ basepath $}/validate-amount' ),
+                WMDE.Actions.newFinishAmountValidationAction,
+                [ 'amount', 'paymentType' ],
+                initialValues
+            )
+        ];
+    },
+    store,
+    initialFormValues
+);
 ```
 
-Actions names for storing validation results should follow the naming pattern of `FINISH_XXX_VALIDATION`.
+Actions names for storing validation results should follow the naming pattern of `FINISH_XXX_VALIDATION`, 
+their action creation functions should follow the pattern `newFinishXXXValidationAction`
 
 You can find available validation functions and classes in [`app/lib/form_validation.js`](../app/lib/form_validation.js)
 
 ### Setting up the view handlers
 
-First, you need to connect the view handlers to actual DOM elements in the `newViewHandlers` method:
+Fill out the view handlers array with new instances of view handlers
 
 ```JavaScript
-newViewHandlers: function() {
-    return {
-        formPageHighlight: WMDE.View.createFormPageHighlightHandler( $( 'ul.step-list li' ) ),
-        clearAmount: WMDE.View.createClearAmountHandler( $( 'input[name=betrag_auswahl]' ), $( '#amount-8' ) )
-    };
-},
+WMDE.StoreUpdates.connectViewHandlersToStore(
+    [
+        {
+            viewHandler: WMDE.View.createClearAmountHandler( $( '.amount-select' ), $( '.amount-input' ) ),
+            stateKey: 'formContent'
+        },
+        {
+            viewHandler: WMDE.View.createErrorBoxHandler( $( '#validation-errors' ), { amount: 'Betrag' } ),
+            stateKey: 'validationMessages'
+        }
+    ],
+    store
+);
 ```
+
+The `viewHandler` key of each object contains an instance of a view handler. The `stateKey` key of each object contains the key of the subsection of the global state that will be passed to the view handler.
 
 For a list of available view handlers see the [`app/js/lib/view_handlers`](../app/js/lib/view_handlers) directory.
 
-The `update` method of each view handler needs to be connected to the correct part of the global state. This is done in the `connectViewHandlersToStore` method:
+### Connecting user events and form values to actions
+Add code that binds DOM events to Redux actions. 
+Only connect DOM events that aren't handled by the form components. You can find all the available actions in
+[`app/js/lib/actions.js`](../app/js/lib/actions.js).
 
 ```JavaScript
-connectViewHandlersToStore: function ( store ) {
-    var viewHandlers = this.newViewHandlers();
-    store.subscribe( function() {
-        var state = store.getState();
-        viewHandlers.formPageHighlight.update( state.formPagination );
-        viewHandlers.clearAmount.update( state.formContent );
-    } );
-},
+ $( '#donation-submit1 button' ).click( function () {
+    store.dispatch( actions.newNextPageAction() );
+} );
 ```
 
 [redux]: http://redux.js.org/


### PR DESCRIPTION
It's now possible to initialize the form values with initial values
(which will be generated by the backend in a future commit).

Improved validation code to for easier handling of initial state.
Validation needs to know about initial state to allow for invalid values
as initial state (e.g. empty fields).

This is one step for task https://phabricator.wikimedia.org/T129227