### PR TITLE
The AddDonation UC now writes its token to a cookie

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -22,6 +22,7 @@ use Monolog\Logger;
 use NumberFormatter;
 use Psr\Log\LoggerInterface;
 use Swift_MailTransport;
+use Swift_NullTransport;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig_Environment;
 use Twig_Extensions_Extension_Intl;
@@ -562,6 +563,13 @@ class FunFunFactory {
 
 	public function setMessenger( Messenger $messenger ) {
 		$this->pimple['messenger'] = $messenger;
+	}
+
+	public function setNullMessenger() {
+		$this->setMessenger( new Messenger(
+			Swift_NullTransport::newInstance(),
+			$this->getOperatorAddress()
+		) );
 	}
 
 	public function getOperatorAddress() {

--- a/tests/Integration/DataAccess/DoctrineTokenAuthorizationCheckerTest.php
+++ b/tests/Integration/DataAccess/DoctrineTokenAuthorizationCheckerTest.php
@@ -46,10 +46,10 @@ class DoctrineTokenAuthorizationCheckerTest extends \PHPUnit_Framework_TestCase 
 
 	public function testWhenDonationWithTokenExists() {
 		$donation = new Donation();
-		$donation->encodeAndSetData( [
-			'utoken' => self::THE_CORRECT_TOKEN,
-			'uexpiry' => $this->getExpiryTimeInTheFuture()
-		] );
+		$donationData = $donation->getDataObject();
+		$donationData->setUpdateToken( self::THE_CORRECT_TOKEN );
+		$donationData->setUpdateTokenExpiry( $this->getExpiryTimeInTheFuture() );
+		$donation->setDataObject( $donationData );
 
 		$this->specify(
 			'given correct donation id and correct token, authorization succeeds',
@@ -95,10 +95,10 @@ class DoctrineTokenAuthorizationCheckerTest extends \PHPUnit_Framework_TestCase 
 
 	public function testWhenUpdateTokenIsExpired() {
 		$donation = new Donation();
-		$donation->encodeAndSetData( [
-			'utoken' => self::THE_CORRECT_TOKEN,
-			'uexpiry' => $this->getExpiryTimeInThePast()
-		] );
+		$donationData = $donation->getDataObject();
+		$donationData->setUpdateToken( self::THE_CORRECT_TOKEN );
+		$donationData->setUpdateTokenExpiry( $this->getExpiryTimeInThePast() );
+		$donation->setDataObject( $donationData );
 
 		$this->specify(
 			'given correct donation id and a token, authorization fails',

--- a/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
+++ b/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
@@ -80,13 +80,10 @@ class CancelDonationUseCaseTest extends \PHPUnit_Framework_TestCase {
 		 */
 		$doctrineDonation = $factory->getEntityManager()->getRepository( DoctrineDonation::class )->find( $donation->getId() );
 
-		$doctrineDonation->encodeAndSetData( array_merge(
-			$doctrineDonation->getDecodedData(),
-			[
-				'utoken' => self::CORRECT_UPDATE_TOKEN,
-				'uexpiry' => date( 'Y-m-d H:i:s', time() + 60 * 60 )
-			]
-		) );
+		$donationData = $doctrineDonation->getDataObject();
+		$donationData->setUpdateToken( self::CORRECT_UPDATE_TOKEN );
+		$donationData->setUpdateTokenExpiry( date( 'Y-m-d H:i:s', time() + 60 * 60 ) );
+		$doctrineDonation->setDataObject( $donationData );
 
 		$factory->getEntityManager()->persist( $doctrineDonation );
 		$factory->getEntityManager()->flush();

--- a/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
+++ b/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
@@ -5,20 +5,18 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\ConfirmSubscription;
 
 use PHPUnit_Framework_MockObject_MockObject;
-use Swift_NullTransport;
+use WMDE\Fundraising\Entities\Donation as DoctrineDonation;
 use WMDE\Fundraising\Frontend\Domain\Model\Donation;
 use WMDE\Fundraising\Frontend\Domain\Model\MailAddress;
 use WMDE\Fundraising\Frontend\Domain\Model\PaymentType;
 use WMDE\Fundraising\Frontend\Domain\Repositories\DonationRepository;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
-use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
 use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
 use WMDE\Fundraising\Frontend\Tests\Data\ValidDonation;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\SucceedingAuthorizer;
 use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 use WMDE\Fundraising\Frontend\UseCases\CancelDonation\CancelDonationRequest;
 use WMDE\Fundraising\Frontend\UseCases\CancelDonation\CancelDonationUseCase;
-use WMDE\Fundraising\Entities\Donation as DoctrineDonation;
 
 /**
  * @covers WMDE\Fundraising\Frontend\UseCases\CancelDonation\CancelDonationUseCase
@@ -45,10 +43,7 @@ class CancelDonationUseCaseTest extends \PHPUnit_Framework_TestCase {
 	private function newFactoryWithNullMailer(): FunFunFactory {
 		$factory = TestEnvironment::newInstance()->getFactory();
 
-		$factory->setMessenger( new Messenger(
-			Swift_NullTransport::newInstance(),
-			$factory->getOperatorAddress()
-		) );
+		$factory->setNullMessenger();
 
 		return $factory;
 	}

--- a/tests/System/MultiRoute/DonationAndCancellationTest.php
+++ b/tests/System/MultiRoute/DonationAndCancellationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\System\MultiRoute;
+
+use Swift_NullTransport;
+use Symfony\Component\HttpKernel\Client;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
+use WMDE\Fundraising\Frontend\Tests\System\Routes\AddDonationRouteTest;
+use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class DonationAndCancellationTest extends WebRouteTestCase {
+
+	const UPDATE_TOKEN_COOKIE_NAME = 'wmde-fundraising-utoken';
+	const DONATION_ID_COOKIE_NAME = 'wmde-fundraising-donation-id';
+
+	public function testWhenCreatingDonation_itCanBeCancelled() {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$factory->setMessenger( new Messenger(
+				Swift_NullTransport::newInstance(),
+				$factory->getOperatorAddress()
+			) );
+
+			$client->request(
+				'POST',
+				'/donation/add',
+				AddDonationRouteTest::newValidFormInput()
+			);
+
+			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+
+			$client->request(
+				'POST',
+				'/donation/cancel',
+				[
+					'sid' => $client->getCookieJar()->get( self::DONATION_ID_COOKIE_NAME )->getValue(),
+					'utoken' => $client->getCookieJar()->get( self::UPDATE_TOKEN_COOKIE_NAME )->getValue(),
+				]
+			);
+
+			$this->assertContains( 'wurde storniert', $client->getResponse()->getContent() );
+		} );
+	}
+
+}

--- a/tests/System/MultiRoute/DonationAndCancellationTest.php
+++ b/tests/System/MultiRoute/DonationAndCancellationTest.php
@@ -4,10 +4,8 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\System\MultiRoute;
 
-use Swift_NullTransport;
 use Symfony\Component\HttpKernel\Client;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
-use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
 use WMDE\Fundraising\Frontend\Tests\System\Routes\AddDonationRouteTest;
 use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
 
@@ -22,10 +20,7 @@ class DonationAndCancellationTest extends WebRouteTestCase {
 
 	public function testWhenCreatingDonation_itCanBeCancelled() {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
-			$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress()
-			) );
+			$factory->setNullMessenger();
 
 			$client->request(
 				'POST',

--- a/tests/System/Routes/AddCommentRouteTest.php
+++ b/tests/System/Routes/AddCommentRouteTest.php
@@ -64,10 +64,12 @@ class AddCommentRouteTest extends WebRouteTestCase {
 		$donation = new Donation();
 		$donation->setAmount( '100' );
 		$donation->setDtNew( new DateTime( '1984-01-01' ) );
-		$donation->encodeAndSetData( [
-			'utoken' => self::CORRECT_UPDATE_TOKEN,
-			'uexpiry' => date( 'Y-m-d H:i:s', time() + 60 * 60 )
-		] );
+
+		$donationData = $donation->getDataObject();
+		$donationData->setUpdateToken( self::CORRECT_UPDATE_TOKEN );
+		$donationData->setUpdateTokenExpiry( date( 'Y-m-d H:i:s', time() + 60 * 60 ) );
+		$donation->setDataObject( $donationData );
+
 		$entityManager->persist( $donation );
 		$entityManager->flush();
 		return $donation;

--- a/tests/System/Routes/AddDonationRouteTest.php
+++ b/tests/System/Routes/AddDonationRouteTest.php
@@ -44,7 +44,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 			$donation = $this->getDonationFromDatabase( $factory );
 
-			$data = unserialize( base64_decode( $donation->getData() ) );
+			$data = $donation->getDecodedData();
 			$this->assertSame( 5.51, $donation->getAmount() );
 			$this->assertSame( 'BEZ', $donation->getPaymentType() );
 			$this->assertSame( 0, $donation->getPeriod() );
@@ -77,17 +77,12 @@ class AddDonationRouteTest extends WebRouteTestCase {
 			$this->assertSame( 'N', $donation->getStatus() );
 			$this->assertSame( true, $donation->getInfo() );
 
-			// TODO: assert tokens are set
-			// $this->assertRegExp( '/[0-9a-f]{32}/', $data['token'] );
-			// $this->assertRegExp( '/[0-9a-f]{32}/', $data['utoken'] );
-			// $this->assertGreaterThan( ( new \DateTime() )->format( 'Y-m-d H:i:s' ), $data['utoken_expiry'] );
-
 			$this->assertContains( '5,51', $response->getContent() );
 			$this->assertContains( 'einmalig', $response->getContent() );
 		} );
 	}
 
-	private function newValidFormInput() {
+	public static function newValidFormInput() {
 		return [
 			'betrag' => '5,51',
 			'zahlweise' => 'BEZ',
@@ -142,7 +137,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 			$donation = $this->getDonationFromDatabase( $factory );
 
-			$data = unserialize( base64_decode( $donation->getData() ) );
+			$data = $donation->getDecodedData();
 			$this->assertSame( 12.34, $donation->getAmount() );
 			$this->assertSame( 'UEB', $donation->getPaymentType() );
 			$this->assertSame( 0, $donation->getPeriod() );
@@ -219,7 +214,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 			$donation = $this->getDonationFromDatabase( $factory );
 
-			$data = unserialize( base64_decode( $donation->getData() ) );
+			$data = $donation->getDecodedData();
 			$this->assertSame( 'DE12500105170648489890', $data['iban'] );
 			$this->assertSame( 'INGDDEFFXXX', $data['bic'] );
 			$this->assertSame( '0648489890', $data['konto'] );

--- a/tests/System/Routes/AddDonationRouteTest.php
+++ b/tests/System/Routes/AddDonationRouteTest.php
@@ -4,12 +4,10 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
 
-use Swift_NullTransport;
 use Symfony\Component\HttpKernel\Client;
 use WMDE\Fundraising\Entities\Donation;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
-use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
 
 /**
  * @licence GNU GPL v2+
@@ -26,10 +24,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 	public function testGivenValidRequest_donationGetsPersisted() {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
-			$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress()
-			) );
+			$factory->setNullMessenger();
 
 			$client->setServerParameter( 'HTTP_REFERER', 'https://en.wikipedia.org/wiki/Karla_Kennichnich' );
 			$client->followRedirects( false );
@@ -121,10 +116,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$factory = null;
 
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
-			$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress()
-			) );
+			$factory->setNullMessenger();
 
 			$client->setServerParameter( 'HTTP_REFERER', 'https://en.wikipedia.org/wiki/Karla_Kennichnich' );
 			$client->followRedirects( false );
@@ -198,10 +190,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 	public function testGivenComplementableBankData_donationStillGetsPersisted() {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
-			$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress()
-			) );
+			$factory->setNullMessenger();
 
 			$client->setServerParameter( 'HTTP_REFERER', 'https://en.wikipedia.org/wiki/Karla_Kennichnich' );
 			$client->followRedirects( false );
@@ -251,10 +240,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 	public function testGivenValidPayPalData_redirectsToPayPal() {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
-			$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress()
-			) );
+			$factory->setNullMessenger();
 			$client->followRedirects( false );
 
 			$client->request(
@@ -280,10 +266,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 	public function testGivenValidCreditCardData_showsIframeEmbeddingPage() {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
-			$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress()
-			) );
+			$factory->setNullMessenger();
 
 			$client->request(
 				'POST',

--- a/tests/System/Routes/AddSubscriptionRouteTest.php
+++ b/tests/System/Routes/AddSubscriptionRouteTest.php
@@ -45,10 +45,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 	// @codingStandardsIgnoreStart
 	protected function onTestEnvironmentCreated( FunFunFactory $factory, array $config ) {
 		// @codingStandardsIgnoreEnd
-		$factory->setMessenger( new Messenger(
-			Swift_NullTransport::newInstance(),
-			$factory->getOperatorAddress()
-		) );
+		$factory->setNullMessenger();
 	}
 
 	public function testValidSubscriptionRequestGetsPersisted() {

--- a/tests/System/Routes/CancelDonationRouteTest.php
+++ b/tests/System/Routes/CancelDonationRouteTest.php
@@ -95,13 +95,10 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 		 */
 		$doctrineDonation = $entityManager->getRepository( DoctrineDonation::class )->find( $donation->getId() );
 
-		$doctrineDonation->encodeAndSetData( array_merge(
-			$doctrineDonation->getDecodedData(),
-			[
-				'utoken' => self::CORRECT_UPDATE_TOKEN,
-				'uexpiry' => date( 'Y-m-d H:i:s', time() + 60 * 60 )
-			]
-		) );
+		$donationData = $doctrineDonation->getDataObject();
+		$donationData->setUpdateToken( self::CORRECT_UPDATE_TOKEN );
+		$donationData->setUpdateTokenExpiry( date( 'Y-m-d H:i:s', time() + 60 * 60 ) );
+		$doctrineDonation->setDataObject( $donationData );
 
 		$entityManager->persist( $doctrineDonation );
 		$entityManager->flush();

--- a/tests/System/Routes/CancelDonationRouteTest.php
+++ b/tests/System/Routes/CancelDonationRouteTest.php
@@ -5,14 +5,12 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
 
 use Doctrine\ORM\EntityManager;
-use Swift_NullTransport;
 use Symfony\Component\HttpKernel\Client;
+use WMDE\Fundraising\Entities\Donation as DoctrineDonation;
 use WMDE\Fundraising\Frontend\Domain\Repositories\DonationRepository;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
-use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
 use WMDE\Fundraising\Frontend\Tests\Data\ValidDonation;
 use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
-use WMDE\Fundraising\Entities\Donation as DoctrineDonation;
 
 /**
  * @licence GNU GPL v2+
@@ -40,10 +38,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 
 	public function testGivenValidUpdateToken_confirmationPageIsShown() {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
-			$factory->setMessenger( new Messenger(
-				Swift_NullTransport::newInstance(),
-				$factory->getOperatorAddress()
-			) );
+			$factory->setNullMessenger();
 
 			$donationId = $this->storeDonation( $factory->getDonationRepository(), $factory->getEntityManager() );
 

--- a/tests/System/Routes/ConfirmSubscriptionRouteTest.php
+++ b/tests/System/Routes/ConfirmSubscriptionRouteTest.php
@@ -7,10 +7,7 @@ namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
 use WMDE\Fundraising\Entities\Address;
 use WMDE\Fundraising\Entities\Subscription;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
-use WMDE\Fundraising\Frontend\Tests\Fixtures\SubscriptionRepositorySpy;
 use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
-use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
-use Swift_NullTransport;
 
 /**
  * @licence GNU GPL v2+
@@ -21,10 +18,7 @@ class ConfirmSubscriptionRouteTest extends WebRouteTestCase {
 	// @codingStandardsIgnoreStart
 	protected function onTestEnvironmentCreated( FunFunFactory $factory, array $config ) {
 		// @codingStandardsIgnoreEnd
-		$factory->setMessenger( new Messenger(
-			Swift_NullTransport::newInstance(),
-			$factory->getOperatorAddress()
-		) );
+		$factory->setNullMessenger();
 	}
 
 	private function newSubscriptionAddress() {

--- a/tests/System/Routes/GetInTouchRouteTest.php
+++ b/tests/System/Routes/GetInTouchRouteTest.php
@@ -4,13 +4,9 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\System\Routes;
 
-use Mediawiki\Api\MediawikiApi;
-use Swift_NullTransport;
-use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Domain\Model\MailAddress;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
-use WMDE\Fundraising\Frontend\Infrastructure\Message;
-use WMDE\Fundraising\Frontend\Tests\Fixtures\ApiPostRequestHandler;
 use WMDE\Fundraising\Frontend\Tests\System\WebRouteTestCase;
 
 /**
@@ -22,10 +18,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 	// @codingStandardsIgnoreStart
 	protected function onTestEnvironmentCreated( FunFunFactory $factory, array $config ) {
 		// @codingStandardsIgnoreEnd
-		$factory->setMessenger( new Messenger(
-			Swift_NullTransport::newInstance(),
-			$factory->getOperatorAddress() )
-		);
+		$factory->setNullMessenger();
 	}
 
 	public function testGivenValidRequest_contactRequestIsProperlyProcessed() {
@@ -78,7 +71,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 	public function testOnException_errorPageIsRendered() {
 		$client = $this->createClient(
 			[],
-			function ( FunFunFactory $factory, array $config ) {
+			function ( FunFunFactory $factory ) {
 				$messenger = $this->getMockBuilder( Messenger::class )
 					->disableOriginalConstructor()
 					->getMock();


### PR DESCRIPTION
Added a test verifying this from an as high level as possible,
to not bind to implementation details and make sure the combination
of the routes works correctly. I'm not sure we're already
providing the interface we want to the clients with regards to
the update token, so that might still need further work.