### PR TITLE
Made PHPUnit output non-verbose

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         verbose="true">
+         verbose="false">
     <testsuites>
         <testsuite name="FundraisingFrontend-unit">
             <directory>tests/Unit</directory>


### PR DESCRIPTION
This way we no longer get the "incomplete bla foobar" stuff cluttering the output