### PR TITLE
Preserve MembershipApplication creation timestamp

### DIFF
--- a/src/DataAccess/DoctrineMembershipApplicationRepository.php
+++ b/src/DataAccess/DoctrineMembershipApplicationRepository.php
@@ -39,7 +39,9 @@ class DoctrineMembershipApplicationRepository implements MembershipApplicationRe
 				$this->entityManager->persist( $doctrineApplication );
 			}
 			else {
-				$doctrineApplication->setCreationTime( new \DateTime() ); // TODO
+				// merge would override the timestamp with null value, so we need to get it from the entity
+				$oldApplication = $this->entityManager->find( DoctrineApplication::class, $doctrineApplication->getId() );
+				$doctrineApplication->setCreationTime( $oldApplication->getCreationTime() );
 				$this->entityManager->merge( $doctrineApplication );
 			}
 


### PR DESCRIPTION
The `creationTime` timestamp was previously updated on every update through `DoctrineMembershipApplicationRepository::storeApplication`. Now it's preserved on update. 
On creation, it's set by the `Timestampable` annotation, no changes there.