### PR TITLE
remove reference to form field accessor

### DIFF
--- a/app/js/main.js
+++ b/app/js/main.js
@@ -3,7 +3,6 @@
  * Uppercase keys designate namespaces, lowercase keys designate global objects/functions
  */
 module.exports = {
-	FormFieldAccessors: require( './lib/form_field_accessors' ),
 	FormValidation: require( './lib/form_validation' ),
 	ReduxValidation: require( './lib/redux_validation' ),
 	Components: require( './lib/form_components' ),


### PR DESCRIPTION
`npm run build-js` fails with the reference to `FormFieldAccessors` still being present.