### PR TITLE
Fix JS includes and add build step to JS CI

### DIFF
--- a/app/js/lib/reducers/form_content.js
+++ b/app/js/lib/reducers/form_content.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var objectAssign = require( 'object-assign' ),
-	_ = require( 'underscore' ),
+	_ = require( 'lodash' ),
 	initialState = {
 		amount: 0,
 		isCustomAmount: false,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "watch-js": "watchify app/js/main.js -v -s WMDE -o web/res/js/wmde.js",
     "test": "tape 'app/js/tests/**/*.js' | tap-min",
     "cs": "jshint app/js && jscs app/js",
-    "ci": "npm run cs && npm run test"
+    "ci": "npm run cs && npm run test && browserify app/js/main.js -s WMDE -o /dev/null"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add the build step to the CI to catch removed classes that are still in
main.js

Fix broken builds by including a different library.

This addresses the comment by @JeroenDeDauw at
https://github.com/wmde/FundraisingFrontend/pull/337#issuecomment-212120555