### PR TITLE
Make JS formContent more generic

### DIFF
--- a/app/js/lib/reducers/donation_form_content.js
+++ b/app/js/lib/reducers/donation_form_content.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var formContentLib = require( './form_content' ),
+	objectAssign = require( 'object-assign' ),
+	initialState = {
+		amount: 0,
+		isCustomAmount: false,
+		paymentType: 'BEZ',
+		paymentPeriodInMonths: 0, // 0, 1, 3, 6 or 12, 0 = non-recurring payment
+		debitType: 'sepa', // sepa and "non-sepa"
+		iban: '',
+		bic: '',
+		accountNumber: '',
+		bankCode: '',
+		bankName: '',
+		addressType: 'person', // person, firma and anonym
+		salutation: 'Frau',
+		title: '',
+		firstName: '',
+		lastName: '',
+		company: '',
+		street: '',
+		postcode: '',
+		city: '',
+		country: 'DE',
+		email: ''
+	};
+
+module.exports = function donationFormContent( state, action ) {
+		if ( typeof state === 'undefined' ) {
+			state = initialState;
+		}
+		switch ( action.type ) {
+			case 'INITIALIZE_CONTENT':
+				if ( formContentLib.stateContainsUnknownKeys( action.payload, initialState ) ) {
+					throw new Error(
+						'Initial state contains unknown keys: ' +
+						formContentLib.getInvalidKeys( action.payload, initialState ).join( ', ' )
+					);
+				}
+				return objectAssign( {}, state, action.payload );
+			default:
+				return formContentLib.formContent( state, action );
+		}
+	};
+

--- a/app/js/lib/reducers/form_content.js
+++ b/app/js/lib/reducers/form_content.js
@@ -1,43 +1,17 @@
 'use strict';
 
 var objectAssign = require( 'object-assign' ),
-	_ = require( 'lodash' ),
-	initialState = {
-		amount: 0,
-		isCustomAmount: false,
-		paymentType: 'BEZ',
-		paymentPeriodInMonths: 0, // 0, 1, 3, 6 or 12, 0 = non-recurring payment
-		debitType: 'sepa', // sepa and "non-sepa"
-		iban: '',
-		bic: '',
-		accountNumber: '',
-		bankCode: '',
-		bankName: '',
-		addressType: 'person', // person, firma and anonym
-		salutation: 'Frau',
-		title: '',
-		firstName: '',
-		lastName: '',
-		company: '',
-		street: '',
-		postcode: '',
-		city: '',
-		country: 'DE',
-		email: ''
-	};
+	_ = require( 'lodash' );
 
 /**
  * Return object keys that are not defined in initial state
  *
  * @param {Object} state
+ * @param {Object} initialState
  * @returns {Array}
  */
-function getInvalidKeys( state ) {
+function getInvalidKeys( state, initialState ) {
 	return _.keys( _.omit( state, _.keys( initialState ) ) );
-}
-
-function stateContainsUnknownKeys( state ) {
-	return !_.isEmpty( getInvalidKeys( state ) );
 }
 
 function clearFieldsIfAddressTypeChanges( newState, payload ) {
@@ -66,50 +40,46 @@ function clearFieldsIfAddressTypeChanges( newState, payload ) {
 	}
 }
 
-module.exports = function formContent( state, action ) {
-	var newAmount, newState;
-	if ( typeof state === 'undefined' ) {
-		state = initialState;
-	}
-	switch ( action.type ) {
-		case 'SELECT_AMOUNT':
-			newAmount = action.payload.amount === null ? state.amount : action.payload.amount;
-			return objectAssign( {}, state, {
-				amount: newAmount,
-				isCustomAmount: false
-			} );
-		case 'INPUT_AMOUNT':
-			return objectAssign( {}, state, {
-				amount: action.payload.amount,
-				isCustomAmount: true
-			} );
-		case 'CHANGE_CONTENT':
-			if ( !_.has( state, action.payload.contentName ) ) {
-				throw new Error( 'Unsupported form content name: ' + action.payload.contentName );
-			}
-			newState = _.clone( state );
-			clearFieldsIfAddressTypeChanges( newState, action.payload );
-			newState[ action.payload.contentName ] = action.payload.value;
-			return newState;
-		case 'FINISH_BANK_DATA_VALIDATION':
-			if ( action.payload.status !== 'OK' ) {
+module.exports = {
+	stateContainsUnknownKeys: function ( state, initialState ) {
+		return !_.isEmpty( getInvalidKeys( state, initialState ) );
+	},
+	getInvalidKeys: getInvalidKeys,
+	formContent: function ( state, action ) {
+		var newAmount, newState;
+		switch ( action.type ) {
+			case 'SELECT_AMOUNT':
+				newAmount = action.payload.amount === null ? state.amount : action.payload.amount;
+				return objectAssign( {}, state, {
+					amount: newAmount,
+					isCustomAmount: false
+				} );
+			case 'INPUT_AMOUNT':
+				return objectAssign( {}, state, {
+					amount: action.payload.amount,
+					isCustomAmount: true
+				} );
+			case 'CHANGE_CONTENT':
+				if ( !_.has( state, action.payload.contentName ) ) {
+					throw new Error( 'Unsupported form content name: ' + action.payload.contentName );
+				}
+				newState = _.clone( state );
+				clearFieldsIfAddressTypeChanges( newState, action.payload );
+				newState[ action.payload.contentName ] = action.payload.value;
+				return newState;
+			case 'FINISH_BANK_DATA_VALIDATION':
+				if ( action.payload.status !== 'OK' ) {
+					return state;
+				}
+				return objectAssign( {}, state, {
+					iban: action.payload.iban || '',
+					bic: action.payload.bic || '',
+					accountNumber: action.payload.account || '',
+					bankCode: action.payload.bankCode || '',
+					bankName: action.payload.bankName || ''
+				} );
+			default:
 				return state;
-			}
-			return objectAssign( {}, state, {
-				iban: action.payload.iban || '',
-				bic: action.payload.bic || '',
-				accountNumber: action.payload.account || '',
-				bankCode: action.payload.bankCode || '',
-				bankName: action.payload.bankName || ''
-			} );
-		case 'INITIALIZE_CONTENT':
-			if ( stateContainsUnknownKeys( action.payload ) ) {
-				throw new Error(
-					'Initial state contains unknown keys: ' + getInvalidKeys( action.payload ).join( ', ' )
-				);
-			}
-			return objectAssign( {}, state, action.payload );
-		default:
-			return state;
+		}
 	}
 };

--- a/app/js/lib/redux_validation.js
+++ b/app/js/lib/redux_validation.js
@@ -48,8 +48,9 @@ var objectAssign = require( 'object-assign' ),
 	ValidationDispatcherCollection = {
 		dispatchers: [],
 		store: null,
+		formContentName: '',
 		onUpdate: function () {
-			var formContent = this.store.getState().formContent,
+			var formContent = this.store.getState()[ this.formContentName ],
 				i;
 			for ( i = 0; i < this.dispatchers.length; i++ ) {
 				this.dispatchers[ i ].dispatchIfChanged( formContent, this.store );
@@ -82,11 +83,13 @@ var objectAssign = require( 'object-assign' ),
 	 *
 	 * @param {Object} store Redux store
 	 * @param {ValidationDispatcher[]} dispatchers
+	 * @param {string} formContentName Field name for the store to access form contents, e.g. 'donationFormContent' or 'membershipFormContent'
 	 */
-	createValidationDispatcherCollection = function ( store, dispatchers ) {
+	createValidationDispatcherCollection = function ( store, dispatchers, formContentName ) {
 		var collection = objectAssign( Object.create( ValidationDispatcherCollection ), {
 				store: store,
-				dispatchers: dispatchers
+				dispatchers: dispatchers,
+				formContentName: formContentName
 			} );
 		store.subscribe( collection.onUpdate.bind( collection ) );
 		return collection;

--- a/app/js/lib/store.js
+++ b/app/js/lib/store.js
@@ -1,7 +1,7 @@
 var Redux = require( 'redux' ),
 	reduxPromise = require( 'redux-promise' ),
 	formPagination = require( './reducers/form_pagination' ),
-	formContent = require( './reducers/form_content' ),
+	donationFormContent = require( './reducers/donation_form_content' ),
 	validity = require( './reducers/validity' ),
 	validationMessages = require( './reducers/validation_messages' ),
 	middlewares = [ reduxPromise ];
@@ -36,7 +36,7 @@ if ( process.env.REDUX_LOG === 'on' ) {
 
 module.exports = Redux.createStore( Redux.combineReducers( {
 	formPagination: formPagination,
-	formContent: formContent,
+	donationFormContent: donationFormContent,
 	validity: validity,
 	validationMessages: validationMessages
 } ), undefined, Redux.applyMiddleware.apply( this, middlewares ) );

--- a/app/js/lib/store_update_handling.js
+++ b/app/js/lib/store_update_handling.js
@@ -18,16 +18,17 @@ module.exports = {
 	 * @param {Function} validatorFactoryFunction
 	 * @param {store.Store} store
 	 * @param {Object} initialValues - initial values for the validation dispatchers so they don't fire on initialization
+	 * @param {string} formContentName Field name for the store to access form contents, e.g. 'donationFormContent' or 'membershipFormContent'
 	 */
-	connectValidatorsToStore: function ( validatorFactoryFunction, store, initialValues ) {
-		var completeInitialValues = _.extend( {}, store.getState().formContent, initialValues ),
+	connectValidatorsToStore: function ( validatorFactoryFunction, store, initialValues, formContentName ) {
+		var completeInitialValues = _.extend( {}, store.getState()[ formContentName ], initialValues ),
 			validators = validatorFactoryFunction( completeInitialValues );
-		reduxValidation.createValidationDispatcherCollection( store, validators );
+		reduxValidation.createValidationDispatcherCollection( store, validators, formContentName );
 	},
-	connectComponentsToStore: function ( components, store ) {
+	connectComponentsToStore: function ( components, store, formContentName ) {
 		store.subscribe( function () {
 			var state = store.getState(),
-				formContent = state.formContent;
+				formContent = state[ formContentName ];
 
 			// TODO check if formContent has changed before executing update actions
 			components.forEach( function ( component ) {

--- a/app/js/tests/reducers/test_donation_form_content.js
+++ b/app/js/tests/reducers/test_donation_form_content.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var test = require( 'tape' ),
+	deepFreeze = require( 'deep-freeze' ),
+	donationFormContent = require( '../../lib/reducers/donation_form_content' );
+
+test( 'INITIALIZE_CONTENT changes multiple fields', function ( t ) {
+	var stateBefore = { paymentType: 'PPL', amount: 0, recurringPayment: 0 },
+		expectedState = { paymentType: 'BEZ', amount: '25,00', recurringPayment: 0 },
+		action = { type: 'INITIALIZE_CONTENT', payload: { amount: '25,00', paymentType: 'BEZ' } };
+
+	deepFreeze( stateBefore );
+	t.deepEqual( donationFormContent( stateBefore, action ), expectedState );
+	t.end();
+} );
+
+test( 'INITIALIZE_CONTENT throws an error if a field name is not allowed', function ( t ) {
+	var action = { type: 'INITIALIZE_CONTENT', payload: {
+		amount: '25,00',
+		paymentType: 'BEZ',
+		unknownField: 'supercalifragilistic'
+	} };
+
+	t.throws( function () {
+		donationFormContent( {}, action );
+	}, /unknownField/ );
+	t.end();
+} );

--- a/app/js/tests/reducers/test_form_content.js
+++ b/app/js/tests/reducers/test_form_content.js
@@ -2,7 +2,7 @@
 
 var test = require( 'tape' ),
 	deepFreeze = require( 'deep-freeze' ),
-	formContent = require( '../../lib/reducers/form_content' );
+	formContent = require( '../../lib/reducers/form_content' ).formContent;
 
 test( 'SELECT_AMOUNT sets amount and isCustomAmount', function ( t ) {
 	var stateBefore = { amount: 99, isCustomAmount: true },
@@ -132,29 +132,6 @@ test( 'FINISH_BANK_DATA_VALIDATION does not modify state data when status is not
 
 	deepFreeze( stateBefore );
 	t.equal( formContent( stateBefore, action ), stateBefore );
-	t.end();
-} );
-
-test( 'INITIALIZE_CONTENT changes multiple fields', function ( t ) {
-	var stateBefore = { paymentType: 'PPL', amount: 0, recurringPayment: 0 },
-		expectedState = { paymentType: 'BEZ', amount: '25,00', recurringPayment: 0 },
-		action = { type: 'INITIALIZE_CONTENT', payload: { amount: '25,00', paymentType: 'BEZ' } };
-
-	deepFreeze( stateBefore );
-	t.deepEqual( formContent( stateBefore, action ), expectedState );
-	t.end();
-} );
-
-test( 'INITIALIZE_CONTENT throws an error if a field name is not allowed', function ( t ) {
-	var action = { type: 'INITIALIZE_CONTENT', payload: {
-		amount: '25,00',
-		paymentType: 'BEZ',
-		unknownField: 'supercalifragilistic'
-	} };
-
-	t.throws( function () {
-		formContent( {}, action );
-	}, /unknownField/ );
 	t.end();
 } );
 

--- a/app/js/tests/test_redux_validation.js
+++ b/app/js/tests/test_redux_validation.js
@@ -117,7 +117,7 @@ test( 'ValidationDispatcherCollection listens to store updates', function ( t ) 
 			subscribe: sinon.spy()
 		};
 
-	reduxValidation.createValidationDispatcherCollection( storeSpy, [] );
+	reduxValidation.createValidationDispatcherCollection( storeSpy, [], 'dummy' );
 
 	t.ok( storeSpy.subscribe.calledOnce, 'mapper subscribes to store updates' );
 	t.end();
@@ -125,17 +125,19 @@ test( 'ValidationDispatcherCollection listens to store updates', function ( t ) 
 
 test( 'ValidationDispatcherCollection update method calls dispatchers', function ( t ) {
 	var formContent = { amount: 42 },
+		state = { donationForm: formContent },
 		storeSpy = {
 			subscribe: sinon.spy(),
-			getState: sinon.stub().returns( formContent )
+			getState: sinon.stub().returns( state )
 		},
 		validatorSpy = { dispatchIfChanged: sinon.spy() },
-		collection = reduxValidation.createValidationDispatcherCollection( storeSpy, [ validatorSpy ] );
+		collection = reduxValidation.createValidationDispatcherCollection( storeSpy, [ validatorSpy ], 'donationForm' );
 
 	collection.onUpdate();
 
 	t.ok( storeSpy.getState.calledOnce, 'onUpdate gets state from the store' );
 	t.ok( validatorSpy.dispatchIfChanged.calledOnce, 'dispatchers are called' );
+	t.ok( validatorSpy.dispatchIfChanged.calledWith( formContent, storeSpy ), 'dispatchers are called' );
 	t.end();
 } );
 

--- a/app/js/tests/test_store_update_handling.js
+++ b/app/js/tests/test_store_update_handling.js
@@ -30,7 +30,7 @@ test( 'connect validators to store updates', function ( t ) {
 		storeData = { formContent: { test: 'dummy store contents' } },
 		store = createFakeStore( storeData );
 
-	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, {} );
+	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, {}, 'formContent' );
 	store.fakeUpdate();
 
 	t.ok( validator.dispatchIfChanged.calledOnce, 'validator dispatch method is only called once' );
@@ -48,8 +48,8 @@ test( 'initial values are passed to validator factory and merged with initial st
 		store = createFakeStore( storeData ),
 		initialValues = { paymentType: 'BTC' };
 
-	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, {} );
-	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, initialValues );
+	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, {}, 'formContent' );
+	storeUpdateHandling.connectValidatorsToStore( validatorFactory, store, initialValues, 'formContent' );
 
 	t.ok(
 		validatorFactory.firstCall.calledWith( initialStoreFormContent ),
@@ -69,7 +69,7 @@ test( 'connect components to store updates', function ( t ) {
 		storeData = { formContent: { test: 'dummy store contents' } },
 		store = createFakeStore( storeData );
 
-	storeUpdateHandling.connectComponentsToStore( [ component ], store );
+	storeUpdateHandling.connectComponentsToStore( [ component ], store, 'formContent' );
 	store.fakeUpdate();
 
 	t.ok( component.render.calledOnce, 'render method of component is called once' );

--- a/app/templates/DonationForm.html.twig
+++ b/app/templates/DonationForm.html.twig
@@ -69,7 +69,8 @@
                 WMDE.Components.createRadioComponent( store, $( '#country' ), 'country' ),
                 WMDE.Components.createTextComponent( store, $( '#email' ), 'email' )
             ],
-            store
+            store,
+            'donationFormContent'    
         );
 
         WMDE.StoreUpdates.connectValidatorsToStore(
@@ -96,7 +97,8 @@
                 ];
             },
             store,
-            initialFormValues
+            initialFormValues,
+            'donationFormContent'
         );
 
         // Connect view handlers to changes in specific parts in the global state, designated by 'stateKey'
@@ -128,40 +130,40 @@
                     },
                     {
                         viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '.periode-2-list' ), /^(1|3|6|12)$/ ),
-                        stateKey: 'formContent.paymentPeriodInMonths'
+                        stateKey: 'donationFormContent.paymentPeriodInMonths'
                     },
                     {
                         viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '#bank-data' ), 'BEZ' ),
-                        stateKey: 'formContent.paymentType'
+                        stateKey: 'donationFormContent.paymentType'
                     },
                     {
                         viewHandler: WMDE.View.createSimpleVisibilitySwitcher( $( '#finishFormSubmit2' ), /^MCP|PPL|UEB/ ),
-                        stateKey: 'formContent.paymentType'
+                        stateKey: 'donationFormContent.paymentType'
                     },
                     {
                         viewHandler: WMDE.View.createSimpleVisibilitySwitcher( $( '#continueFormSubmit2' ), 'BEZ' ),
-                        stateKey: 'formContent.paymentType'
+                        stateKey: 'donationFormContent.paymentType'
                     },
                     {
                         viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '.slide-sepa' ), 'sepa' ),
-                        stateKey: 'formContent.debitType'
+                        stateKey: 'donationFormContent.debitType'
                     },
                     {
                         viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '.slide-non-sepa' ), 'non-sepa' ),
-                        stateKey: 'formContent.debitType'
+                        stateKey: 'donationFormContent.debitType'
                     },
                     // Show only the right data fields for personal data
                     {
                         viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '.personal-data-person' ), 'person' ),
-                        stateKey: 'formContent.addressType'
+                        stateKey: 'donationFormContent.addressType'
                     },
                     {
                         viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '.personal-data-company' ), 'firma' ),
-                        stateKey: 'formContent.addressType'
+                        stateKey: 'donationFormContent.addressType'
                     },
                     {
                         viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '.personal-data-full' ), /firma|person/ ),
-                        stateKey: 'formContent.addressType'
+                        stateKey: 'donationFormContent.addressType'
                     },
                     {
                         viewHandler: WMDE.View.createDisplayAddressHandler( {
@@ -172,7 +174,7 @@
                             country: $( '.confirm-country' ),
                             email: $( '.confirm-email' )
                         } ),
-                        stateKey: 'formContent'
+                        stateKey: 'donationFormContent'
                     }
                 ],
                 store


### PR DESCRIPTION
The formContent reducer now acts as a generic reducer for different form contents, i.e. donation and membership.

Adapted all places that used the hard-wired 'formContent' key to use a configurable access key.

This PR is based in #365, please merge that first.