### PR TITLE
Added logging decorators for our repositories

### DIFF
--- a/src/DataAccess/DoctrineCommentRepository.php
+++ b/src/DataAccess/DoctrineCommentRepository.php
@@ -49,6 +49,7 @@ class DoctrineCommentRepository implements CommentRepository, CommentFinder {
 	}
 
 	private function getDonation( int $limit ): array {
+		// FIXME: catch exception
 		return $this->entityManager->getRepository( Donation::class )->findBy(
 			[
 				'isPublic' => true,

--- a/src/DataAccess/DoctrineSubscriptionRepository.php
+++ b/src/DataAccess/DoctrineSubscriptionRepository.php
@@ -57,9 +57,14 @@ class DoctrineSubscriptionRepository implements SubscriptionRepository {
 	}
 
 	public function findByConfirmationCode( string $confirmationCode ) {
-		return $this->entityManager->getRepository( Subscription::class )->findOneBy( [
-			'confirmationCode' => hex2bin( $confirmationCode )
-		] );
+		try {
+			return $this->entityManager->getRepository( Subscription::class )->findOneBy( [
+				'confirmationCode' => hex2bin( $confirmationCode )
+			] );
+		}
+		catch ( ORMException $e ) {
+			throw new SubscriptionRepositoryException( 'Could not find subscriptions by confirmation code.', $e );
+		}
 	}
 
 }

--- a/src/Domain/Repositories/CommentFinder.php
+++ b/src/Domain/Repositories/CommentFinder.php
@@ -18,6 +18,7 @@ interface CommentFinder {
 	 * @param int $limit
 	 *
 	 * @return CommentWithAmount[]
+	 * TODO: add exception type
 	 */
 	public function getPublicComments( int $limit ): array;
 

--- a/src/Domain/Repositories/GetDonationException.php
+++ b/src/Domain/Repositories/GetDonationException.php
@@ -10,8 +10,8 @@ namespace WMDE\Fundraising\Frontend\Domain\Repositories;
  */
 class GetDonationException extends \RuntimeException {
 
-	public function __construct( \Exception $previous = null ) {
-		parent::__construct( 'Could not get donation', 0, $previous );
+	public function __construct( \Exception $previous = null, $message = 'Could not get donation' ) {
+		parent::__construct( $message, 0, $previous );
 	}
 
 }

--- a/src/Domain/Repositories/StoreDonationException.php
+++ b/src/Domain/Repositories/StoreDonationException.php
@@ -10,8 +10,8 @@ namespace WMDE\Fundraising\Frontend\Domain\Repositories;
  */
 class StoreDonationException extends \RuntimeException {
 
-	public function __construct( \Exception $previous = null ) {
-		parent::__construct( 'Could not store donation', 0, $previous );
+	public function __construct( \Exception $previous = null, $message = 'Could not store donation' ) {
+		parent::__construct( $message, 0, $previous );
 	}
 
 }

--- a/src/Domain/Repositories/SubscriptionRepository.php
+++ b/src/Domain/Repositories/SubscriptionRepository.php
@@ -28,12 +28,14 @@ interface SubscriptionRepository {
 	 * @param Subscription $subscription
 	 * @param \DateTime $cutoffDateTime
 	 * @return int
+	 * @throws SubscriptionRepositoryException
 	 */
 	public function countSimilar( Subscription $subscription, \DateTime $cutoffDateTime ): int;
 
 	/**
 	 * @param string $confirmationCode
 	 * @return Subscription|null
+	 * @throws SubscriptionRepositoryException
 	 */
 	public function findByConfirmationCode( string $confirmationCode );
 

--- a/src/Infrastructure/Repositories/LoggingCommentRepository.php
+++ b/src/Infrastructure/Repositories/LoggingCommentRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Repositories;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use WMDE\Fundraising\Frontend\Domain\Model\Comment;
+use WMDE\Fundraising\Frontend\Domain\Repositories\CommentRepository;
+use WMDE\Fundraising\Frontend\Domain\Repositories\StoreCommentException;
+
+/**
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LoggingCommentRepository implements CommentRepository {
+
+	private $repository;
+	private $logger;
+	private $logLevel;
+
+	public function __construct( CommentRepository $repository, LoggerInterface $logger ) {
+		$this->repository = $repository;
+		$this->logger = $logger;
+		$this->logLevel = LogLevel::CRITICAL;
+	}
+
+	/**
+	 * @param Comment $comment
+	 * @throws StoreCommentException
+	 */
+	public function storeComment( Comment $comment ) {
+		try {
+			$this->repository->storeComment( $comment );
+		}
+		catch ( StoreCommentException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			throw $ex;
+		}
+	}
+
+}

--- a/src/Infrastructure/Repositories/LoggingCommentRepository.php
+++ b/src/Infrastructure/Repositories/LoggingCommentRepository.php
@@ -16,6 +16,8 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\StoreCommentException;
  */
 class LoggingCommentRepository implements CommentRepository {
 
+	const CONTEXT_EXCEPTION_KEY = 'exception';
+	
 	private $repository;
 	private $logger;
 	private $logLevel;
@@ -35,7 +37,7 @@ class LoggingCommentRepository implements CommentRepository {
 			$this->repository->storeComment( $comment );
 		}
 		catch ( StoreCommentException $ex ) {
-			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
 			throw $ex;
 		}
 	}

--- a/src/Infrastructure/Repositories/LoggingCommentRepository.php
+++ b/src/Infrastructure/Repositories/LoggingCommentRepository.php
@@ -17,7 +17,7 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\StoreCommentException;
 class LoggingCommentRepository implements CommentRepository {
 
 	const CONTEXT_EXCEPTION_KEY = 'exception';
-	
+
 	private $repository;
 	private $logger;
 	private $logLevel;

--- a/src/Infrastructure/Repositories/LoggingDonationRepository.php
+++ b/src/Infrastructure/Repositories/LoggingDonationRepository.php
@@ -17,6 +17,8 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\StoreDonationException;
  */
 class LoggingDonationRepository implements DonationRepository {
 
+	const CONTEXT_EXCEPTION_KEY = 'exception';
+
 	private $repository;
 	private $logger;
 	private $logLevel;
@@ -39,7 +41,7 @@ class LoggingDonationRepository implements DonationRepository {
 			$this->repository->storeDonation( $donation );
 		}
 		catch ( StoreDonationException $ex ) {
-			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
 			throw $ex;
 		}
 	}
@@ -57,7 +59,7 @@ class LoggingDonationRepository implements DonationRepository {
 			return $this->repository->getDonationById( $id );
 		}
 		catch ( GetDonationException $ex ) {
-			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
 			throw $ex;
 		}
 	}

--- a/src/Infrastructure/Repositories/LoggingDonationRepository.php
+++ b/src/Infrastructure/Repositories/LoggingDonationRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Repositories;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use WMDE\Fundraising\Frontend\Domain\Model\Donation;
+use WMDE\Fundraising\Frontend\Domain\Repositories\DonationRepository;
+use WMDE\Fundraising\Frontend\Domain\Repositories\GetDonationException;
+use WMDE\Fundraising\Frontend\Domain\Repositories\StoreDonationException;
+
+/**
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LoggingDonationRepository implements DonationRepository {
+
+	private $repository;
+	private $logger;
+	private $logLevel;
+
+	public function __construct( DonationRepository $repository, LoggerInterface $logger ) {
+		$this->repository = $repository;
+		$this->logger = $logger;
+		$this->logLevel = LogLevel::CRITICAL;
+	}
+
+	/**
+	 * @see DonationRepository::storeDonation
+	 *
+	 * @param Donation $donation
+	 *
+	 * @throws StoreDonationException
+	 */
+	public function storeDonation( Donation $donation ) {
+		try {
+			$this->repository->storeDonation( $donation );
+		}
+		catch ( StoreDonationException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			throw $ex;
+		}
+	}
+
+	/**
+	 * @see DonationRepository::getDonationById
+	 *
+	 * @param int $id
+	 *
+	 * @return Donation|null
+	 * @throws GetDonationException
+	 */
+	public function getDonationById( int $id ) {
+		try {
+			return $this->repository->getDonationById( $id );
+		}
+		catch ( GetDonationException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			throw $ex;
+		}
+	}
+
+}

--- a/src/Infrastructure/Repositories/LoggingMembershipApplicationRepository.php
+++ b/src/Infrastructure/Repositories/LoggingMembershipApplicationRepository.php
@@ -17,6 +17,8 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\StoreMembershipApplicationExce
  */
 class LoggingMembershipApplicationRepository implements MembershipApplicationRepository {
 
+	const CONTEXT_EXCEPTION_KEY = 'exception';
+	
 	private $repository;
 	private $logger;
 	private $logLevel;
@@ -39,7 +41,7 @@ class LoggingMembershipApplicationRepository implements MembershipApplicationRep
 			$this->repository->storeApplication( $application );
 		}
 		catch ( StoreMembershipApplicationException $ex ) {
-			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
 			throw $ex;
 		}
 	}
@@ -57,7 +59,7 @@ class LoggingMembershipApplicationRepository implements MembershipApplicationRep
 			return $this->repository->getApplicationById( $id );
 		}
 		catch ( GetMembershipApplicationException $ex ) {
-			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
 			throw $ex;
 		}
 	}

--- a/src/Infrastructure/Repositories/LoggingMembershipApplicationRepository.php
+++ b/src/Infrastructure/Repositories/LoggingMembershipApplicationRepository.php
@@ -18,7 +18,7 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\StoreMembershipApplicationExce
 class LoggingMembershipApplicationRepository implements MembershipApplicationRepository {
 
 	const CONTEXT_EXCEPTION_KEY = 'exception';
-	
+
 	private $repository;
 	private $logger;
 	private $logLevel;

--- a/src/Infrastructure/Repositories/LoggingMembershipApplicationRepository.php
+++ b/src/Infrastructure/Repositories/LoggingMembershipApplicationRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Repositories;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use WMDE\Fundraising\Frontend\Domain\Model\MembershipApplication;
+use WMDE\Fundraising\Frontend\Domain\Repositories\GetMembershipApplicationException;
+use WMDE\Fundraising\Frontend\Domain\Repositories\MembershipApplicationRepository;
+use WMDE\Fundraising\Frontend\Domain\Repositories\StoreMembershipApplicationException;
+
+/**
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LoggingMembershipApplicationRepository implements MembershipApplicationRepository {
+
+	private $repository;
+	private $logger;
+	private $logLevel;
+
+	public function __construct( MembershipApplicationRepository $repository, LoggerInterface $logger ) {
+		$this->repository = $repository;
+		$this->logger = $logger;
+		$this->logLevel = LogLevel::CRITICAL;
+	}
+
+	/**
+	 * @see MembershipApplicationRepository::storeApplication
+	 *
+	 * @param MembershipApplication $application
+	 *
+	 * @throws StoreMembershipApplicationException
+	 */
+	public function storeApplication( MembershipApplication $application ) {
+		try {
+			$this->repository->storeApplication( $application );
+		}
+		catch ( StoreMembershipApplicationException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			throw $ex;
+		}
+	}
+
+	/**
+	 * @see MembershipApplicationRepository::getApplicationById
+	 *
+	 * @param int $id
+	 *
+	 * @return MembershipApplication|null
+	 * @throws GetMembershipApplicationException
+	 */
+	public function getApplicationById( int $id ) {
+		try {
+			return $this->repository->getApplicationById( $id );
+		}
+		catch ( GetMembershipApplicationException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ 'exception' => $ex ] );
+			throw $ex;
+		}
+	}
+}

--- a/src/Infrastructure/Repositories/LoggingSubscriptionRepository.php
+++ b/src/Infrastructure/Repositories/LoggingSubscriptionRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Repositories;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use WMDE\Fundraising\Entities\Subscription;
+use WMDE\Fundraising\Frontend\Domain\Repositories\SubscriptionRepository;
+use WMDE\Fundraising\Frontend\Domain\Repositories\SubscriptionRepositoryException;
+
+/**
+ * @license GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LoggingSubscriptionRepository implements SubscriptionRepository {
+
+	const CONTEXT_EXCEPTION_KEY = 'exception';
+
+	private $repository;
+	private $logger;
+	private $logLevel;
+
+	public function __construct( SubscriptionRepository $repository, LoggerInterface $logger ) {
+		$this->repository = $repository;
+		$this->logger = $logger;
+		$this->logLevel = LogLevel::CRITICAL;
+	}
+
+	/**
+	 * @see SubscriptionRepository::storeSubscription
+	 *
+	 * @param Subscription $subscription
+	 *
+	 * @throws SubscriptionRepositoryException
+	 */
+	public function storeSubscription( Subscription $subscription ) {
+		try {
+			$this->repository->storeSubscription( $subscription );
+		}
+		catch ( SubscriptionRepositoryException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
+			throw $ex;
+		}
+	}
+
+	/**
+	 * @see SubscriptionRepository::countSimilar
+	 *
+	 * @param Subscription $subscription
+	 * @param \DateTime $cutoffDateTime
+	 *
+	 * @return int
+	 * @throws SubscriptionRepositoryException
+	 */
+	public function countSimilar( Subscription $subscription, \DateTime $cutoffDateTime ): int {
+		try {
+			return $this->repository->countSimilar( $subscription, $cutoffDateTime );
+		}
+		catch ( SubscriptionRepositoryException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
+			throw $ex;
+		}
+	}
+
+	/**
+	 * @see SubscriptionRepository::findByConfirmationCode
+	 *
+	 * @param string $confirmationCode
+	 *
+	 * @return Subscription|null
+	 * @throws SubscriptionRepositoryException
+	 */
+	public function findByConfirmationCode( string $confirmationCode ) {
+		try {
+			return $this->repository->findByConfirmationCode( $confirmationCode );
+		}
+		catch ( SubscriptionRepositoryException $ex ) {
+			$this->logger->log( $this->logLevel, $ex->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $ex ] );
+			throw $ex;
+		}
+	}
+
+}

--- a/tests/Fixtures/LoggerSpy.php
+++ b/tests/Fixtures/LoggerSpy.php
@@ -1,0 +1,34 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Fixtures;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LoggerSpy extends AbstractLogger {
+
+	private $logCalls = [];
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 *
+	 * @return null
+	 */
+	public function log( $level, $message, array $context = [] ) {
+		$this->logCalls[] = [ $level, $message, $context ];
+	}
+
+	public function getLogCalls(): array {
+		return $this->logCalls;
+	}
+
+}

--- a/tests/Fixtures/LoggerSpy.php
+++ b/tests/Fixtures/LoggerSpy.php
@@ -31,4 +31,12 @@ class LoggerSpy extends AbstractLogger {
 		return $this->logCalls;
 	}
 
+	public function assertNoCalls() {
+		if ( !empty( $this->logCalls ) ) {
+			throw new \RuntimeException(
+				'Logger calls where made while non where expected: ' . var_export( $this->logCalls, true )
+			);
+		}
+	}
+
 }

--- a/tests/Unit/Infrastructure/Repositories/LoggingDonationRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repositories/LoggingDonationRepositoryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure\Repositories;
+
+use Psr\Log\LogLevel;
+use WMDE\Fundraising\Frontend\Domain\Repositories\DonationRepository;
+use WMDE\Fundraising\Frontend\Domain\Repositories\GetDonationException;
+use WMDE\Fundraising\Frontend\Domain\Repositories\StoreDonationException;
+use WMDE\Fundraising\Frontend\Infrastructure\Repositories\LoggingDonationRepository;
+use WMDE\Fundraising\Frontend\Tests\Data\ValidDonation;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\LoggerSpy;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\Infrastructure\Repositories\LoggingDonationRepository
+ *
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class LoggingDonationRepositoryTest extends \PHPUnit_Framework_TestCase {
+
+	public function testWhenGetDonationByIdThrowException_itIsLogged() {
+		$loggingRepo = new LoggingDonationRepository(
+			$this->newThrowingRepository(),
+			new LoggerSpy()
+		);
+
+		$this->expectException( GetDonationException::class );
+		$loggingRepo->getDonationById( 1337 );
+	}
+
+	private function newThrowingRepository(): DonationRepository {
+		$repository = $this->getMock( DonationRepository::class );
+
+		$repository->expects( $this->any() )
+			->method( 'getDonationById' )
+			->willThrowException( new GetDonationException() );
+
+		$repository->expects( $this->any() )
+			->method( 'storeDonation' )
+			->willThrowException( new StoreDonationException() );
+
+		return $repository;
+	}
+
+	public function testWhenGetDonationByIdThrowException_itIsNotFullyCaught() {
+		$logger = new LoggerSpy();
+
+		$loggingRepo = new LoggingDonationRepository(
+			$this->newThrowingRepository(),
+			$logger
+		);
+
+		try {
+			$loggingRepo->getDonationById( 1337 );
+		}
+		catch ( GetDonationException $ex ) {
+		}
+
+		$this->assertExceptionLoggedAsCritical( GetDonationException::class, $logger );
+	}
+
+	private function assertExceptionLoggedAsCritical( string $expectedExceptionType, LoggerSpy $logger ) {
+		$logCalls = $logger->getLogCalls();
+
+		$this->assertCount( 1, $logCalls, 'There should be exactly one log call' );
+		$logCall = $logCalls[0];
+
+		$this->assertSame( LogLevel::CRITICAL, $logCall[0] );
+		$this->assertInternalType( 'array', $logCall[2], 'the third log argument should be an array' );
+		$this->assertArrayHasKey( 'exception', $logCall[2], 'the log context should contain an exception element' );
+		$this->assertInstanceOf( $expectedExceptionType, $logCall[2]['exception'] );
+	}
+
+	public function testWhenStoreDonationThrowException_itIsLogged() {
+		$loggingRepo = new LoggingDonationRepository(
+			$this->newThrowingRepository(),
+			new LoggerSpy()
+		);
+
+		$this->expectException( StoreDonationException::class );
+		$loggingRepo->storeDonation( ValidDonation::newDirectDebitDonation() );
+	}
+
+	public function testWhenStoreDonationThrowException_itIsNotFullyCaught() {
+		$logger = new LoggerSpy();
+
+		$loggingRepo = new LoggingDonationRepository(
+			$this->newThrowingRepository(),
+			$logger
+		);
+
+		try {
+			$loggingRepo->storeDonation( ValidDonation::newDirectDebitDonation() );
+		}
+		catch ( StoreDonationException $ex ) {
+		}
+
+		$this->assertExceptionLoggedAsCritical( StoreDonationException::class, $logger );
+	}
+
+}

--- a/tests/Unit/Infrastructure/Repositories/LoggingDonationRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repositories/LoggingDonationRepositoryTest.php
@@ -10,6 +10,7 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\GetDonationException;
 use WMDE\Fundraising\Frontend\Domain\Repositories\StoreDonationException;
 use WMDE\Fundraising\Frontend\Infrastructure\Repositories\LoggingDonationRepository;
 use WMDE\Fundraising\Frontend\Tests\Data\ValidDonation;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\FakeDonationRepository;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\LoggerSpy;
 
 /**
@@ -71,6 +72,20 @@ class LoggingDonationRepositoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInternalType( 'array', $logCall[2], 'the third log argument should be an array' );
 		$this->assertArrayHasKey( 'exception', $logCall[2], 'the log context should contain an exception element' );
 		$this->assertInstanceOf( $expectedExceptionType, $logCall[2]['exception'] );
+	}
+
+	public function testWhenGetDonationByIdDoesNotThrow_returnValueIsReturnedWithoutLogging() {
+		$logger = new LoggerSpy();
+		$donation = ValidDonation::newDirectDebitDonation();
+		$donation->assignId( 1337 );
+
+		$loggingRepo = new LoggingDonationRepository(
+			new FakeDonationRepository( $donation ),
+			$logger
+		);
+
+		$this->assertSame( $donation, $loggingRepo->getDonationById( 1337 ) );
+		$logger->assertNoCalls();
 	}
 
 	public function testWhenStoreDonationThrowException_itIsLogged() {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T133549

I only created a test for LoggingDonationRepository as I'm not really happy with it. The decorator code is really simple and unlikely will change at some future point. So I'm not sure the maintenance cost of the tests is worth it. They are for sure more complex and verbose than the production code itself.

Question on alternative approach at http://stackoverflow.com/questions/36992540/type-safe-generic-decorator-in-php, though lets not get hung up on perfection here and move things along.