### PR TITLE
Ignore certain Paypal notifications

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -930,7 +930,8 @@ class FunFunFactory {
 		return new HandlePayPalPaymentNotificationUseCase(
 			$this->getDonationRepository(),
 			$this->newDonationAuthorizer( $updateToken ),
-			$this->newDonationConfirmationMailer()
+			$this->newDonationConfirmationMailer(),
+			$this->getLogger()
 		);
 	}
 

--- a/src/UseCases/HandlePayPalPaymentNotification/PayPalNotificationRequest.php
+++ b/src/UseCases/HandlePayPalPaymentNotification/PayPalNotificationRequest.php
@@ -247,4 +247,8 @@ class PayPalNotificationRequest {
 		return $this;
 	}
 
+	public function isSuccessfulPaymentNotification() {
+		return $this->paymentStatus === 'Completed' || $this->paymentStatus === 'Processed';
+	}
+
 }


### PR DESCRIPTION
Only process payment notifications. Informational notifications that are
not a "success", are ignored. Also changes in subscriptions, that are
successful but not payments are ignored.

This is for https://phabricator.wikimedia.org/T135138

@JeroenDeDauw 1) Any refactoring recommendations? 2) Putting the "Domain Logic" `isSuccessfulPaymentNotification` into the `PayPalNotificationRequest` feels slightly wrong. Maybe that check is also better placed in the use case? 
