### PR TITLE
Always dispatch validation finish action

### DIFF
--- a/app/js/lib/form_validation.js
+++ b/app/js/lib/form_validation.js
@@ -24,9 +24,9 @@ var jQuery = require( 'jquery' ),
 					return { status: 'OK' };
 			}
 
-			// Return error status if not all required fields have been filled
+			// Return incomplete status if not all required fields have been filled
 			if ( this.formValuesHaveEmptyRequiredFields( formValues, requiredFields ) ) {
-				return { status: 'ERR' };
+				return { status: 'INCOMPLETE' };
 			}
 
 			return this.sendFunction( this.validationUrl, formValues, null, 'json' );

--- a/app/js/lib/redux_validation.js
+++ b/app/js/lib/redux_validation.js
@@ -38,9 +38,6 @@ var objectAssign = require( 'object-assign' ),
 
 			this.previousFieldValues = selectedValues;
 			validationResult = this.validationFunction( selectedValues );
-			if ( validationResult === null ) {
-				return;
-			}
 			return store.dispatch( this.actionCreationFunction( validationResult ) );
 		}
 	},

--- a/app/js/tests/test_form_validation.js
+++ b/app/js/tests/test_form_validation.js
@@ -71,7 +71,7 @@ test( 'Given a private adddress, address validation sends values to server', fun
 } );
 
 test( 'Given an incomplete private adddress, address validation sends no values to server', function ( t ) {
-	var negativeResult = { status: 'ERR' },
+	var negativeResult = { status: 'INCOMPLETE' },
 		postFunctionSpy = sinon.spy(),
 		addressValidator = validation.createAddressValidator(
 			'http://spenden.wikimedia.org/validate-address',
@@ -92,7 +92,7 @@ test( 'Given an incomplete private adddress, address validation sends no values 
 	validationResult = addressValidator.validate( formData );
 
 	t.ok( !postFunctionSpy.called, 'post function is not called' );
-	t.deepEqual( validationResult, negativeResult, 'validation function returns error' );
+	t.deepEqual( validationResult, negativeResult, 'validation function returns expected status' );
 	t.end();
 } );
 

--- a/app/js/tests/test_redux_validation.js
+++ b/app/js/tests/test_redux_validation.js
@@ -66,27 +66,6 @@ test( 'ValidationDispatcher calls validationFunction and dispatches action only 
 	t.end();
 } );
 
-test( 'When validationFunction returns null, ValidationDispatcher does nothing', function ( t ) {
-	var initialData = {},
-		testData = { importantField: 'just some data', ignoredData: 'this won\'t be validated' },
-		validationFunction = sinon.stub().returns( null ),
-		actionCreationFunction = sinon.stub(),
-		dispatcher = reduxValidation.createValidationDispatcher(
-			validationFunction,
-			actionCreationFunction,
-			[ 'importantField' ],
-			initialData
-		),
-		testStore = { dispatch: sinon.spy() };
-
-	dispatcher.dispatchIfChanged( testData, testStore );
-
-	t.ok( validationFunction.calledOnce, 'validation function is called once' );
-	t.notOk( actionCreationFunction.called, 'action is not created' );
-	t.notOk( testStore.dispatch.called, 'no action is dispatched' );
-	t.end();
-} );
-
 test( 'createValidationDispatcher accepts validator object as validation function', function ( t ) {
 	var validatorSpy = {
 			// use internal delegation to check if 'this' is bound correctly


### PR DESCRIPTION
The "null" state, originally introduced to avoid error messages showing
up, was too confusing and leads to the wrong value in `validity` when
a field is made empty after the form has been validated.

Incomplete forms that should not be sent to the server should return an
"INCOMPLETE" status (validity store checks for an "OK" status) and no
error messages.