### PR TITLE
Allow expired token for PayPal notification

### DIFF
--- a/src/DataAccess/DoctrineDonationAuthorizer.php
+++ b/src/DataAccess/DoctrineDonationAuthorizer.php
@@ -25,7 +25,12 @@ class DoctrineDonationAuthorizer implements DonationAuthorizer {
 		$this->accessToken = $accessToken;
 	}
 
-	public function canModifyDonation( int $donationId ): bool {
+	/**
+	 * Check if donation exists, has matching token and token is not expired
+	 * @param int $donationId
+	 * @return bool
+	 */
+	public function userCanModifyDonation( int $donationId ): bool {
 		try {
 			$donation = $this->getDonationById( $donationId );
 		}
@@ -37,6 +42,24 @@ class DoctrineDonationAuthorizer implements DonationAuthorizer {
 		return $donation !== null
 			&& $this->updateTokenMatches( $donation )
 			&& $this->tokenHasNotExpired( $donation );
+	}
+
+	/**
+	 * Check if donation exists and has matching token
+	 * @param int $donationId
+	 * @return bool
+	 */
+	public function systemCanModifyDonation( int $donationId ): bool {
+		try {
+			$donation = $this->getDonationById( $donationId );
+		}
+		catch ( ORMException $ex ) {
+			// TODO: might want to log failure here
+			return false;
+		}
+
+		return $donation !== null
+		&& $this->updateTokenMatches( $donation );
 	}
 
 	/**

--- a/src/Infrastructure/DonationAuthorizer.php
+++ b/src/Infrastructure/DonationAuthorizer.php
@@ -13,7 +13,12 @@ interface DonationAuthorizer {
 	/**
 	 * Should return false on infrastructure failure.
 	 */
-	public function canModifyDonation( int $donationId ): bool;
+	public function userCanModifyDonation( int $donationId ): bool;
+
+	/**
+	 * Should return false on infrastructure failure.
+	 */
+	public function systemCanModifyDonation( int $donationId ): bool;
 
 	/**
 	 * Should return false on infrastructure failure.

--- a/src/UseCases/AddComment/AddCommentUseCase.php
+++ b/src/UseCases/AddComment/AddCommentUseCase.php
@@ -41,7 +41,7 @@ class AddCommentUseCase {
 	}
 
 	private function requestIsAllowed( AddCommentRequest $addCommentRequest ): bool {
-		return $this->authorizationService->canModifyDonation( $addCommentRequest->getDonationId() );
+		return $this->authorizationService->userCanModifyDonation( $addCommentRequest->getDonationId() );
 	}
 
 	private function newCommentFromRequest( AddCommentRequest $request ): Comment {

--- a/src/UseCases/CancelDonation/CancelDonationUseCase.php
+++ b/src/UseCases/CancelDonation/CancelDonationUseCase.php
@@ -30,7 +30,7 @@ class CancelDonationUseCase {
 	}
 
 	public function cancelDonation( CancelDonationRequest $cancellationRequest ): CancelDonationResponse {
-		if ( !$this->authorizationService->canModifyDonation( $cancellationRequest->getDonationId() ) ) {
+		if ( !$this->authorizationService->userCanModifyDonation( $cancellationRequest->getDonationId() ) ) {
 			return $this->newFailureResponse( $cancellationRequest );
 		}
 

--- a/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
+++ b/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
@@ -89,7 +89,7 @@ class HandlePayPalPaymentNotificationUseCase {
 			return false;
 		}
 
-		if ( !$this->authorizationService->canModifyDonation( $request->getDonationId() ) ) {
+		if ( !$this->authorizationService->systemCanModifyDonation( $request->getDonationId() ) ) {
 			return false;
 		}
 

--- a/tests/Fixtures/FailingDonationAuthorizer.php
+++ b/tests/Fixtures/FailingDonationAuthorizer.php
@@ -12,7 +12,11 @@ use WMDE\Fundraising\Frontend\Infrastructure\DonationAuthorizer;
  */
 class FailingDonationAuthorizer implements DonationAuthorizer {
 
-	public function canModifyDonation( int $donationId ): bool {
+	public function userCanModifyDonation( int $donationId ): bool {
+		return false;
+	}
+
+	public function systemCanModifyDonation( int $donationId ): bool {
 		return false;
 	}
 

--- a/tests/Fixtures/SucceedingDonationAuthorizer.php
+++ b/tests/Fixtures/SucceedingDonationAuthorizer.php
@@ -12,7 +12,11 @@ use WMDE\Fundraising\Frontend\Infrastructure\DonationAuthorizer;
  */
 class SucceedingDonationAuthorizer implements DonationAuthorizer {
 
-	public function canModifyDonation( int $donationId ): bool {
+	public function userCanModifyDonation( int $donationId ): bool {
+		return true;
+	}
+
+	public function systemCanModifyDonation( int $donationId ): bool {
 		return true;
 	}
 

--- a/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
@@ -46,7 +46,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit_Framework_TestCase {
 	public function testWhenNoDonations() {
 		$this->specify( 'update authorization fails', function() {
 			$authorizer = $this->newAuthorizationServiceWithDonations( self::CORRECT_UPDATE_TOKEN );
-			$this->assertFalse( $authorizer->canModifyDonation( self::MEANINGLESS_DONATION_ID ) );
+			$this->assertFalse( $authorizer->userCanModifyDonation( self::MEANINGLESS_DONATION_ID ) );
 		} );
 
 		$this->specify( 'access authorization fails', function() {
@@ -67,7 +67,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit_Framework_TestCase {
 			'given correct donation id and correct token, update authorization succeeds',
 			function() use ( $donation ) {
 				$authorizer = $this->newAuthorizationServiceWithDonations( self::CORRECT_UPDATE_TOKEN, null, $donation );
-				$this->assertTrue( $authorizer->canModifyDonation( $donation->getId() ) );
+				$this->assertTrue( $authorizer->userCanModifyDonation( $donation->getId() ) );
 			}
 		);
 
@@ -75,7 +75,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit_Framework_TestCase {
 			'given wrong donation id and correct token, update authorization fails',
 			function() use ( $donation ) {
 				$authorizer = $this->newAuthorizationServiceWithDonations( self::CORRECT_UPDATE_TOKEN, null, $donation );
-				$this->assertFalse( $authorizer->canModifyDonation( self::ID_OF_WRONG_DONATION ) );
+				$this->assertFalse( $authorizer->userCanModifyDonation( self::ID_OF_WRONG_DONATION ) );
 			}
 		);
 
@@ -83,7 +83,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit_Framework_TestCase {
 			'given correct donation id and wrong token, update authorization fails',
 			function() use ( $donation ) {
 				$authorizer = $this->newAuthorizationServiceWithDonations( self::WRONG__UPDATE_TOKEN, null, $donation );
-				$this->assertFalse( $authorizer->canModifyDonation( $donation->getId() ) );
+				$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
 			}
 		);
 
@@ -124,7 +124,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit_Framework_TestCase {
 			'given correct donation id and a token, update authorization fails',
 			function() use ( $donation ) {
 				$authorizer = $this->newAuthorizationServiceWithDonations( self::MEANINGLESS_TOKEN, null, $donation );
-				$this->assertFalse( $authorizer->canModifyDonation( $donation->getId() ) );
+				$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
 			}
 		);
 
@@ -145,10 +145,18 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit_Framework_TestCase {
 		$donation->setDataObject( $donationData );
 
 		$this->specify(
-			'given correct donation id and a token, update authorization fails',
+			'given correct donation id and a token, update authorization fails for users',
 			function() use ( $donation ) {
 				$authorizer = $this->newAuthorizationServiceWithDonations( self::CORRECT_UPDATE_TOKEN, null, $donation );
-				$this->assertFalse( $authorizer->canModifyDonation( $donation->getId() ) );
+				$this->assertFalse( $authorizer->userCanModifyDonation( $donation->getId() ) );
+			}
+		);
+
+		$this->specify(
+			'given correct donation id and a token, update authorization succeeds for system',
+			function() use ( $donation ) {
+				$authorizer = $this->newAuthorizationServiceWithDonations( self::CORRECT_UPDATE_TOKEN, null, $donation );
+				$this->assertTrue( $authorizer->systemCanModifyDonation( $donation->getId() ) );
 			}
 		);
 	}
@@ -165,7 +173,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->specify( 'update authorization fails', function() use ( $authorizer ) {
-			$this->assertFalse( $authorizer->canModifyDonation( self::MEANINGLESS_DONATION_ID ) );
+			$this->assertFalse( $authorizer->userCanModifyDonation( self::MEANINGLESS_DONATION_ID ) );
 		} );
 
 		$this->specify( 'access authorization fails', function() use ( $authorizer ) {


### PR DESCRIPTION
Some PayPal donations come in long after the update token has expired.
Introduced the new DonationAuthorizer interface method
systemCanUpdateDonation that only checks for the existence of donation
and matching token and does not check token expiry.

This is for https://phabricator.wikimedia.org/T135608