### PR TITLE
Handle recurring Paypal Payments

### DIFF
--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -98,11 +98,7 @@ class DonationConfirmationHtmlPresenter {
 		);
 	}
 
-	/**
-	 * @param Donor|null $donor
-	 * @return array
-	 */
-	private function getMembershipFormPersonValues( $donor ) {
+	private function getMembershipFormPersonValues( Donor $donor = null ): array {
 		if ( $donor === null ) {
 			return [];
 		}
@@ -122,7 +118,7 @@ class DonationConfirmationHtmlPresenter {
 		];
 	}
 
-	private function getMembershipFormBankDataValues( PaymentMethod $paymentMethod ) {
+	private function getMembershipFormBankDataValues( PaymentMethod $paymentMethod ): array {
 		if ( !$paymentMethod instanceof DirectDebitPayment ) {
 			return [];
 		}

--- a/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
+++ b/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
@@ -54,6 +54,10 @@ class HandlePayPalPaymentNotificationUseCase {
 			return $this->handleRequestWithoutDonation( $request );
 		}
 
+		if ( $donation->isBooked() && $request->isRecurringPaymentCompletion() ) {
+			return $this->handleRequestWithoutDonation( $request );
+		}
+
 		return $this->handleRequestForDonation( $request, $donation );
 	}
 
@@ -92,7 +96,6 @@ class HandlePayPalPaymentNotificationUseCase {
 		if ( !$this->authorizationService->canModifyDonation( $request->getDonationId() ) ) {
 			return false;
 		}
-
 		if ( $this->donationWasBookedWithDifferentTransactionId( $donation, $request ) ) {
 			$childDonation = $this->createChildDonation( $donation, $request );
 			return $childDonation !== null;
@@ -143,8 +146,7 @@ class HandlePayPalPaymentNotificationUseCase {
 	}
 
 	private function transactionIsSubscriptionRelatedButNotAPayment( PayPalNotificationRequest $request ): bool {
-		$transactionType = $request->getTransactionType();
-		return strpos( $transactionType, 'subscr_' ) === 0 && $transactionType !== 'subscr_payment';
+		return $request->isForRecurringPayment() && !$request->isRecurringPaymentCompletion();
 	}
 
 	private function newPayPalDataFromRequest( PayPalNotificationRequest $request ): PayPalData {

--- a/src/UseCases/HandlePayPalPaymentNotification/PayPalNotificationRequest.php
+++ b/src/UseCases/HandlePayPalPaymentNotification/PayPalNotificationRequest.php
@@ -251,4 +251,12 @@ class PayPalNotificationRequest {
 		return $this->paymentStatus === 'Completed' || $this->paymentStatus === 'Processed';
 	}
 
+	public function isRecurringPaymentCompletion(): bool {
+		return $this->transactionType === 'subscr_payment';
+	}
+
+	public function isForRecurringPayment(): bool {
+		return strpos( $this->transactionType, 'subscr_' ) === 0;
+	}
+
 }

--- a/tests/Fixtures/DonationRepositorySpy.php
+++ b/tests/Fixtures/DonationRepositorySpy.php
@@ -12,13 +12,19 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\GetDonationException;
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class DonationRepositorySpy implements DonationRepository {
+class DonationRepositorySpy extends FakeDonationRepository {
 
 	private $storeDonationCalls = [];
 	private $getDonationCalls = [];
 
+	public function __construct( Donation ...$donations ) {
+		parent::__construct( ...$donations );
+		$this->storeDonationCalls = []; // remove calls coming from initialization
+	}
+
 	public function storeDonation( Donation $donation ) {
-		$this->storeDonationCalls[] = $donation;
+		$this->storeDonationCalls[] = clone( $donation ); // protect against the donation being changed later
+		parent::storeDonation( $donation );
 	}
 
 	/**
@@ -36,6 +42,7 @@ class DonationRepositorySpy implements DonationRepository {
 	 */
 	public function getDonationById( int $id ) {
 		$this->getDonationCalls[] = $id;
+		return parent::getDonationById( $id );
 	}
 
 	/**


### PR DESCRIPTION
PayPal notfication use case can now handle recurring payments. When the
payment comes in for the first time, the donation status is set to
booked. All subsequent payments for the donation will create a new
donation.

Merged commit 1133238d73a2bf6c395b53fc69786993317dd79d is accidentally included again due to botched rebase.

This solves https://phabricator.wikimedia.org/T135225
