### PR TITLE
Ignore local deployment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ app/config/
 
 res/blz.lut2f
 web/res/js/wmde.js
+
+deployment/deployment.retry
+deployment/inventory
+


### PR DESCRIPTION
Ignore all files in `deployment/inventory` because they are meant to be
local to the deploying machine.

Ignore file `deployment/deployment.retry`, which is a file created (and
sometimes not deleted) by Ansible.