### PR TITLE
Made empty value check more strict

### DIFF
--- a/src/Validation/RequiredFieldValidator.php
+++ b/src/Validation/RequiredFieldValidator.php
@@ -11,7 +11,7 @@ namespace WMDE\Fundraising\Frontend\Validation;
 class RequiredFieldValidator {
 
 	public function validate( $value ): ValidationResult {
-		if ( empty( $value ) ) {
+		if ( $value === '' ) {
 			return new ValidationResult( new ConstraintViolation( $value, 'field_required' ) );
 		}
 


### PR DESCRIPTION
Not 100% sure if it is too strict now. For instance, is this code intended to
handle null as an empty value? I can't think of any places where we not always
put a string into this...

The old behaviour was definitly not good tho. It would for instance identify
the string "0" as being empty. (yay PHP!)