### PR TITLE
Log to donation when booking externally

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -52,6 +52,7 @@ use WMDE\Fundraising\Frontend\Domain\Repositories\MembershipApplicationRepositor
 use WMDE\Fundraising\Frontend\Domain\Repositories\SubscriptionRepository;
 use WMDE\Fundraising\Frontend\Domain\SimpleTransferCodeGenerator;
 use WMDE\Fundraising\Frontend\Domain\TransferCodeGenerator;
+use WMDE\Fundraising\Frontend\Infrastructure\BestEffortDonationEventLogger;
 use WMDE\Fundraising\Frontend\Infrastructure\CreditCardService;
 use WMDE\Fundraising\Frontend\Infrastructure\DonationAuthorizationUpdater;
 use WMDE\Fundraising\Frontend\Infrastructure\DonationAuthorizer;
@@ -354,7 +355,10 @@ class FunFunFactory {
 	}
 
 	private function newDonationEventLogger(): DonationEventLogger {
-		return new DoctrineDonationEventLogger( $this->getEntityManager() );
+		return new BestEffortDonationEventLogger(
+			new DoctrineDonationEventLogger( $this->getEntityManager() ),
+			$this->getLogger()
+		);
 	}
 
 	public function newInstaller(): Installer {

--- a/src/Infrastructure/BestEffortDonationEventLogger.php
+++ b/src/Infrastructure/BestEffortDonationEventLogger.php
@@ -1,0 +1,36 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class BestEffortDonationEventLogger implements DonationEventLogger
+{
+	private $donationEventLogger;
+	private $logger;
+
+	public function __construct( DonationEventLogger $donationEventLogger, LoggerInterface $logger )
+	{
+		$this->donationEventLogger = $donationEventLogger;
+		$this->logger = $logger;
+	}
+
+	public function log( int $donationId, string $message )
+	{
+		try {
+			$this->donationEventLogger->log( $donationId, $message );
+		} catch ( DonationEventLogException $e ) {
+			$logContext = [
+				'donationId' => $donationId,
+				'exception' => $e,
+				'message'
+			];
+			$this->logger->error( 'Could not update donation event log', $logContext );
+		}
+	}
+}

--- a/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
+++ b/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
@@ -78,6 +78,7 @@ class CreditCardNotificationUseCase {
 		}
 
 		$this->sendConfirmationEmail( $donation );
+		$this->donationEventLogger->log( $donation->getId(), 'mcp_handler: booked' );
 		return true;
 	}
 

--- a/tests/Unit/Infrastructure/BestEffortDonationEventLoggerTest.php
+++ b/tests/Unit/Infrastructure/BestEffortDonationEventLoggerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use WMDE\Fundraising\Frontend\Infrastructure\BestEffortDonationEventLogger;
+use WMDE\Fundraising\Frontend\Infrastructure\DonationEventLogException;
+use WMDE\Fundraising\Frontend\Infrastructure\DonationEventLogger;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\DonationEventLoggerSpy;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\Infrastructure\BestEffortDonationEventLogger
+ *
+ * @licence GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class BestEffortDonationEventLoggerTest extends \PHPUnit_Framework_TestCase
+{
+
+	const DONATION_ID = 1337;
+	const MESSAGE = 'a semi-important event has occured';
+
+	public function testLogDataIsPassed() {
+		$eventLogger = new DonationEventLoggerSpy();
+		$bestEffortLogger = new BestEffortDonationEventLogger(
+			$eventLogger,
+			$this->getLogger()
+		);
+		$bestEffortLogger->log( self::DONATION_ID, self::MESSAGE );
+		$this->assertCount( 1, $eventLogger->getLogCalls() );
+	}
+
+	public function testWhenNoExceptionOccurs_nothingIsLogged() {
+		$eventLogger = new DonationEventLoggerSpy();
+		$logger = $this->getLogger();
+		$logger->expects( $this->never() )->method( $this->anything() );
+		$bestEffortLogger = new BestEffortDonationEventLogger(
+			$eventLogger,
+			$logger
+		);
+		$bestEffortLogger->log( self::DONATION_ID, self::MESSAGE );
+	}
+
+	public function testWhenEventLoggerThrows_itIsLogged() {
+		$eventLogger = $this->createMock( DonationEventLogger::class );
+		$eventLogger->method( 'log' )->will( $this->throwException( new DonationEventLogException( 'Fire Alarm!' ) ) );
+		$logger = $this->getLogger();
+		$logger->expects( $this->once() )->method( 'error' );
+		$bestEffortLogger = new BestEffortDonationEventLogger(
+			$eventLogger,
+			$logger
+		);
+		$bestEffortLogger->log( self::DONATION_ID, self::MESSAGE );
+	}
+
+	/**
+	 * @return LoggerInterface|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getLogger(): LoggerInterface {
+		return $this->createMock( LoggerInterface::class );
+	}
+}


### PR DESCRIPTION
When a donation is booked through an external provider, add the booking
event to its event log.

Refactored tryToLogDonationEvent to its own class. Otherwise there would
be duplicate code in CreditCardNotificationUseCase and
HandlePayPalPaymentNotificationUseCase.

This is for https://phabricator.wikimedia.org/T135528