### PR TITLE
Add preliminary state graph

### DIFF
--- a/doc/donation_state.dot
+++ b/doc/donation_state.dot
@@ -1,0 +1,15 @@
+digraph G {
+  "New" -> "Moderation" [label="Add comment with bad words"]
+  "New" -> "Cancelled" [label="Cancelled by user or in backend"]
+  "Promise" -> "Moderation" [label="Add comment with bad words"]
+  "External_Incomplete"  -> "Moderation" [label="Add comment with bad words"]
+  "External_Incomplete"  -> "External_Booked" [label="Book donation"]
+  "Moderation" ->  "External_Incomplete" [label="Moderate OK in backend"]
+  "Moderation" ->  "External_Booked" [label="Moderate OK in backend"]
+  "External_Booked" -> "Moderation" [label="Add comment with bad words"]
+  "New" [shape=circle]
+  "Promise"  [shape=circle]
+  "External_Incomplete" [shape=circle]
+  "External_Booked"  [shape=circle]
+  "Moderation" [shape=circle]
+}

--- a/doc/donation_state.dot
+++ b/doc/donation_state.dot
@@ -7,9 +7,9 @@ digraph G {
   "Moderation" ->  "External_Incomplete" [label="Moderate OK in backend"]
   "Moderation" ->  "External_Booked" [label="Moderate OK in backend"]
   "External_Booked" -> "Moderation" [label="Add comment with bad words"]
-  "New" [shape=circle]
-  "Promise"  [shape=circle]
-  "External_Incomplete" [shape=circle]
+  "New" [shape=circle,peripheries=2]
+  "Promise"  [shape=circle,peripheries=2]
+  "External_Incomplete" [shape=circle,peripheries=2]
   "External_Booked"  [shape=circle]
   "Moderation" [shape=circle]
 }


### PR DESCRIPTION
Added state graph as Graphviz file.

The description of states is not complete and also needs the
additional actions when moderated/deleted donations are booked
externally and the guard clauses when a state is restored in the backend (see
https://github.com/wmde/fundraising-backend/blob/bf379296aef2a5ee702aacdc4c91261db6bfc065/application/model/Donation.php#L50-L73
for that).