### PR TITLE
Make comment private when changing status from moderation or cancelled

### DIFF
--- a/src/Domain/Model/Donation.php
+++ b/src/Domain/Model/Donation.php
@@ -103,7 +103,7 @@ class Donation {
 	}
 
 	public function addComment( DonationComment $comment ) {
-		if ( $this->comment !== null ) {
+		if ( $this->hasComment() ) {
 			throw new RuntimeException( 'Can only add a single comment to a donation' );
 		}
 
@@ -149,7 +149,23 @@ class Donation {
 			throw new RuntimeException( 'Only incomplete donations can be confirmed as booked' );
 		}
 
+		if ( $this->hasComment() && ( $this->needsModeration() || $this->isCancelled() ) ) {
+			$this->makeCommentPrivate();
+		}
+
 		$this->status = self::STATUS_EXTERNAL_BOOKED;
+	}
+
+	private function makeCommentPrivate() {
+		$this->comment = new DonationComment(
+			$this->comment->getCommentText(),
+			false,
+			$this->comment->getAuthorDisplayName()
+		);
+	}
+
+	public function hasComment(): bool {
+		return $this->comment !== null;
 	}
 
 	private function statusAllowsForBooking(): bool {

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -206,7 +206,7 @@ class ValidDonation {
 		return $bankData->freeze()->assertNoNullFields();
 	}
 
-	public static function newComment(): DonationComment {
+	public static function newPublicComment(): DonationComment {
 		return new DonationComment(
 			self::COMMENT_TEXT,
 			self::COMMENT_IS_PUBLIC,

--- a/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -189,7 +189,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCommentGetPersistedAndRetrieved() {
 		$donation = ValidDonation::newDirectDebitDonation();
-		$donation->addComment( ValidDonation::newComment() );
+		$donation->addComment( ValidDonation::newPublicComment() );
 
 		$repository = $this->newRepository();
 		$repository->storeDonation( $donation );
@@ -201,7 +201,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit_Framework_TestCase {
 
 	public function testPersistingDonationWithoutCommentCausesCommentToBeCleared() {
 		$donation = ValidDonation::newDirectDebitDonation();
-		$donation->addComment( ValidDonation::newComment() );
+		$donation->addComment( ValidDonation::newPublicComment() );
 
 		$repository = $this->newRepository();
 		$repository->storeDonation( $donation );


### PR DESCRIPTION
Finishes https://phabricator.wikimedia.org/T137328

Please verify the logic is correct. What I did is check if the status is either
moderation or cancelled, as opposed to checking if the status is not external
incomplete as described in the ticket. I suspect these are equivalent, though
am not sure as the later is not very explicit.