### PR TITLE
Fix data field

### DIFF
--- a/src/DataAccess/DoctrineDonationRepository.php
+++ b/src/DataAccess/DoctrineDonationRepository.php
@@ -186,7 +186,7 @@ class DoctrineDonationRepository implements DonationRepository {
 
 	private function getDataFieldsFromDonor( Donor $personalInfo = null ): array {
 		if ( $personalInfo === null ) {
-			return [ 'addresstyp' => 'anonym' ];
+			return [ 'adresstyp' => 'anonym' ];
 		}
 
 		return array_merge(
@@ -242,7 +242,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		return [
 			'ext_payment_id' => $ccData->getTransactionId(),
 			'ext_payment_status' => $ccData->getTransactionStatus(),
-			'ext_payment_timestamp' => $ccData->getTransactionTimestamp(),
+			'ext_payment_timestamp' => $ccData->getTransactionTimestamp()->format( \DateTime::ATOM ),
 			'mcp_amount' => $ccData->getAmount()->getEuroString(),
 			'ext_payment_account' => $ccData->getCustomerId(),
 			'mcp_sessionid' => $ccData->getSessionId(),
@@ -459,7 +459,7 @@ class DoctrineDonationRepository implements DonationRepository {
 			return ( new CreditCardTransactionData() )
 				->setTransactionId( $data['ext_payment_id'] )
 				->setTransactionStatus( $data['ext_payment_status'] )
-				->setTransactionTimestamp( $data['ext_payment_timestamp'] )
+				->setTransactionTimestamp( new \DateTime( $data['ext_payment_timestamp'] ) )
 				->setAmount( Euro::newFromString( $data['mcp_amount'] ) )
 				->setCustomerId( $data['ext_payment_account'] )
 				->setSessionId( $data['mcp_sessionid'] )

--- a/src/DataAccess/DoctrineMembershipApplicationRepository.php
+++ b/src/DataAccess/DoctrineMembershipApplicationRepository.php
@@ -82,11 +82,6 @@ class DoctrineMembershipApplicationRepository implements MembershipApplicationRe
 		$this->setApplicantFields( $doctrineApplication, $application->getApplicant() );
 		$this->setPaymentFields( $doctrineApplication, $application->getPayment() );
 
-		$doctrineApplication->encodeAndSetData( array_merge(
-			$doctrineApplication->getDecodedData(),
-			$this->getDataMap( $application )
-		) );
-
 		$doctrineApplication->setStatus( $this->getDoctrineStatus( $application ) );
 	}
 
@@ -120,65 +115,6 @@ class DoctrineMembershipApplicationRepository implements MembershipApplicationRe
 		$application->setPaymentBankName( $bankData->getBankName() );
 		$application->setPaymentBic( $bankData->getBic() );
 		$application->setPaymentIban( $bankData->getIban()->toString() );
-	}
-
-	private function getDataMap( MembershipApplication $application ): array {
-		return array_merge(
-			[
-				'membership_type' => $this->getDoctrineMembershipType( $application ),
-				'membership_fee' => $application->getPayment()->getAmount()->getEuroFloat(),
-				'member_agree' => '1',
-			],
-			$this->getDataFieldsFromApplicant( $application->getApplicant() ),
-			$this->getDataFieldsFromBankData( $application->getPayment()->getBankData() )
-		);
-	}
-
-	private function getDataFieldsFromBankData( BankData $bankData ): array {
-		return [
-			'iban' => $bankData->getIban()->toString(),
-			'bic' => $bankData->getBic(),
-			'account_number' => $bankData->getAccount(),
-			'bank_code' => $bankData->getBankCode(),
-			'bank_name' => $bankData->getBankName(),
-		];
-	}
-
-	private function getDataFieldsFromApplicant( MembershipApplicant $applicant ): array {
-		return array_merge(
-			$this->getDataFieldsFromPersonName( $applicant->getPersonName() ),
-			$this->getDataFieldsFromAddress( $applicant->getPhysicalAddress() ),
-			[
-				'email' => (string)$applicant->getEmailAddress(),
-				'phone' => (string)$applicant->getPhoneNumber(),
-				'dob' => $applicant->getDateOfBirth() === null ? null : $applicant->getDateOfBirth()->format( 'Y-m-d' )
-			]
-		);
-	}
-
-	private function getDataFieldsFromPersonName( PersonName $name ): array {
-		return [
-			'anrede' => $name->getSalutation(),
-			'titel' => $name->getTitle(),
-			'vorname' => $name->getFirstName(),
-			'nachname' => $name->getLastName(),
-			'firma' => $name->getCompanyName(),
-			'account_holder' => $name->getFirstName() . ' ' . $name->getLastName()
-		];
-	}
-
-	private function getDataFieldsFromAddress( PhysicalAddress $address ): array {
-		return [
-			'strasse' => $address->getStreetAddress(),
-			'plz' => $address->getPostalCode(),
-			'ort' => $address->getCity(),
-			'country' => $address->getCountryCode(),
-		];
-	}
-
-	private function getDoctrineMembershipType( MembershipApplication $application ): string {
-		return $application->getType() === MembershipApplication::ACTIVE_MEMBERSHIP
-			? 'active' : 'sustaining';
 	}
 
 	private function getDoctrineStatus( MembershipApplication $application ): int {

--- a/tests/Data/ValidMembershipApplication.php
+++ b/tests/Data/ValidMembershipApplication.php
@@ -140,35 +140,6 @@ class ValidMembershipApplication {
 		$application->setPaymentBic( self::PAYMENT_BIC );
 		$application->setPaymentIban( self::PAYMENT_IBAN );
 
-		$application->encodeAndSetData( [
-			'anrede' => self::APPLICANT_SALUTATION,
-			'titel' => self::APPLICANT_TITLE,
-			'vorname' => self::APPLICANT_FIRST_NAME,
-			'nachname' => self::APPLICANT_LAST_NAME,
-			'firma' => '',
-
-			'strasse' => self::APPLICANT_STREET_ADDRESS,
-			'plz' => self::APPLICANT_POSTAL_CODE,
-			'ort' => self::APPLICANT_CITY,
-			'country' => self::APPLICANT_COUNTRY_CODE,
-
-			'email' => self::APPLICANT_EMAIL_ADDRESS,
-			'phone' => self::APPLICANT_PHONE_NUMBER,
-			'dob' => self::APPLICANT_DATE_OF_BIRTH,
-
-			'membership_type' => self::MEMBERSHIP_TYPE,
-			'membership_fee' => self::PAYMENT_AMOUNT_IN_EURO,
-
-			'account_holder' => 'Potato The Great',
-			'bank_name' => self::PAYMENT_BANK_NAME,
-			'iban' => self::PAYMENT_IBAN,
-			'bic' => self::PAYMENT_BIC,
-			'account_number' => self::PAYMENT_BANK_ACCOUNT,
-			'bank_code' => self::PAYMENT_BANK_CODE,
-
-			'member_agree' => '1',
-		] );
-
 		return $application;
 	}
 

--- a/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -6,7 +6,9 @@ namespace WMDE\Fundraising\Frontend\Tests;
 
 use Doctrine\ORM\EntityManager;
 use WMDE\Fundraising\Entities\Donation;
+use WMDE\Fundraising\Entities\MembershipApplication;
 use WMDE\Fundraising\Frontend\DataAccess\DoctrineDonationRepository;
+use WMDE\Fundraising\Frontend\DataAccess\DoctrineMembershipApplicationRepository;
 use WMDE\Fundraising\Frontend\Domain\Repositories\DonationRepository;
 
 /**
@@ -23,11 +25,11 @@ class SerializedDataHandlingTest extends \PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
-		$this->repository = new DoctrineDonationRepository( $this->entityManager );
 	}
 
-	/** @dataProvider DonationDataProvider */
+	/** @dataProvider donationDataProvider */
 	public function testDataFieldOfDonationIsInteractedWithCorrectly( $paymentType, $data ) {
+		$this->repository = new DoctrineDonationRepository( $this->entityManager );
 		$this->storeDonation( $paymentType, $data );
 
 		$donation = $this->repository->getDonationById( 1 );
@@ -309,6 +311,73 @@ class SerializedDataHandlingTest extends \PHPUnit_Framework_TestCase {
 		$dd->setPaymentType( $paymentType );
 		$dd->encodeAndSetData( $data );
 		$this->entityManager->persist( $dd );
+		$this->entityManager->flush();
+	}
+
+	/** @dataProvider encodedMembershipDataProvider */
+	public function testDataFieldOfMembershipApplicationIsInteractedWithCorrectly( $data ) {
+		$this->repository = new DoctrineMembershipApplicationRepository( $this->entityManager );
+		$this->storeMembershipApplication( $data );
+
+		$donation = $this->repository->getApplicationById( 1 );
+		$this->repository->storeApplication( $donation );
+
+		/** @var MembershipApplication $dma */
+		$dma = $this->entityManager->find( MembershipApplication::class, 1 );
+		$this->assertEquals( $data, $dma->getDecodedData() );
+	}
+
+	public function encodedMembershipDataProvider() {
+		return [
+			[
+				[
+					'member_agree' => '1',
+					'membership_fee_custom' => '',
+					'confirmationPage' => '10h16 Bestätigung-BEZ',
+					'confirmationPageCampaign' => 'MT15_WMDE_02',
+					'token' => '7998466$225c4e182d5b0f3d0e802624826200d21c900267',
+					'utoken' => 'c73d8d1b3e61a73f50bd37d0bf39f3930d77f02b',
+				]
+			],
+
+			[
+				[
+					'member_agree' => '1',
+					'membership_fee_custom' => '',
+					'confirmationPage' => '10h16 Bestätigung-BEZ',
+					'confirmationPageCampaign' => 'MT15_WMDE_02',
+					'token' => '1676175$26905b01f48c8c471f0617217540a8c82fdde52c',
+					'utoken' => '87bd8cedc7843525b87f287b1e3299f667eb7a22',
+				]
+			],
+
+			[
+				[
+					'member_agree' => '1',
+					'membership_fee_custom' => '',
+					'confirmationPage' => '10h16 Bestätigung',
+					'confirmationPageCampaign' => 'MT15_WMDE_02',
+					'token' => '3246619$c4e64cc3c49d8f8b8a0bdcf5788a029563ed9598',
+					'utoken' => '134bf8fce220de781d7b093711f36b5323ccfee5',
+				]
+			]
+		];
+	}
+
+	private function storeMembershipApplication( array $data ) {
+		$membershipAppl = new MembershipApplication();
+
+		$membershipAppl->setApplicantSalutation( 'Frau' );
+		$membershipAppl->setApplicantTitle( 'Dr.' );
+		$membershipAppl->setApplicantFirstName( 'Martha' );
+		$membershipAppl->setApplicantLastName( 'Muster' );
+		$membershipAppl->setCity( 'Smalltown' );
+		$membershipAppl->setPostcode( '12345' );
+		$membershipAppl->setAddress( 'Erlenkamp 12' );
+		$membershipAppl->setApplicantEmailAddress( 'martha.muster@mydomain.com' );
+
+		$membershipAppl->encodeAndSetData( $data );
+		$this->entityManager->persist( $membershipAppl );
 		$this->entityManager->flush();
 	}
 

--- a/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests;
+
+use Doctrine\ORM\EntityManager;
+use WMDE\Fundraising\Entities\Donation;
+use WMDE\Fundraising\Frontend\DataAccess\DoctrineDonationRepository;
+use WMDE\Fundraising\Frontend\Domain\Repositories\DonationRepository;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class SerializedDataHandlingTest extends \PHPUnit_Framework_TestCase {
+
+	/** @var EntityManager */
+	private $entityManager;
+
+	/** @var DonationRepository */
+	private $repository;
+
+	public function setUp() {
+		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
+		$this->repository = new DoctrineDonationRepository( $this->entityManager );
+	}
+
+	/** @dataProvider DonationDataProvider */
+	public function testDataFieldOfDonationIsInteractedWithCorrectly( $paymentType, $data ) {
+		$this->storeDonation( $paymentType, $data );
+
+		$donation = $this->repository->getDonationById( 1 );
+		$this->repository->storeDonation( $donation );
+
+		/** @var Donation $dd */
+		$dd = $this->entityManager->find( Donation::class, 1 );
+		$this->assertEquals( $data, $dd->getDecodedData() );
+	}
+
+	public function donationDataProvider() {
+		return [
+			[
+				'UEB',
+				[
+					'id' => 1839605,
+					'betrag' => '24.00',
+					'periode' => 12,
+					'anrede' => 'Herr',
+					'titel' => '',
+					'vorname' => 'Max',
+					'nachname' => 'Muster',
+					'plz' => '12345',
+					'ort' => 'Smalltown',
+					'country' => 'DE',
+					'strasse' => 'Erlenkamp 12',
+					'email' => 'max.muster@mydomain.com',
+					'eintrag' => 'anonym',
+					'kommentar' => null,
+					'info' => 0,
+					'adresstyp' => 'person',
+					'dob' => null,
+					'phone' => null,
+					'source' => 'de.wikipedia.org',
+					'tracking' => 'dewiki/wikipedia:spenden',
+					'confirmationPage' => '10h16 Bestätigung-UEB',
+					'utoken' => '03a448b5ceafb19b954d25688a72973b002ba012',
+					'uexpiry' => '2016-05-17 15:42:02',
+					'layout' => 'form=10h16_Form1',
+					'user_agent' => 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:37.0) Gecko/20100101 Firefox/37.0',
+					'log' => [
+						'2016-05-17 11:42:02' => 'ueb-code generated (1 tries in 0.02 secs)',
+					],
+					'name' => 'Max Muster',
+
+					// these fields did not exist in the original data set
+					'skin' => '',
+					'color' => '',
+					'firma' => '',
+
+					// these values were stored as strings
+					'impCount' => 0,
+					'bImpCount' => 0,
+				]
+			],
+			[
+				'BEZ',
+				[
+					'id' => '1839609',
+					'betrag' => '20.00',
+					'periode' => 0,
+					'anrede' => 'Herr',
+					'titel' => '',
+					'vorname' => 'Max',
+					'nachname' => 'Muster',
+					'plz' => '12345',
+					'ort' => 'Smalltown',
+					'country' => 'DE',
+					'strasse' => 'Erlenkamp 12',
+					'email' => 'max.muster@mydomain.com',
+					'eintrag' => 'anonym',
+					'kommentar' => null,
+					'info' => 1,
+					'adresstyp' => 'person',
+					'dob' => null,
+					'phone' => null,
+					'source' => 'de.wikipedia.org',
+					'tracking' => 'dewiki/wikipedia:spenden',
+					'confirmationPage' => '10h16 Bestätigung-BEZ',
+					'utoken' => 'ec7c3e8ae5413efe76a3e497455bae9841a85c01',
+					'uexpiry' => '2038-05-17 15:58:53',
+					'layout' => 'form=10h16_Form1',
+					'user_agent' => 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) ' .
+						'Chrome/50.0.2661.102 Safari/537.36',
+					'bankname' => 'Testbank',
+					'bic' => 'INGDDEFFXXX',
+					'iban' => 'DE12500105170648489890',
+					'konto' => '0648489890',
+					'blz' => '50010517',
+					'log' => [
+						'2016-05-17 11:59:21' => 'sepa-mandat confirmed',
+					],
+					'name' => 'Max Muster',
+					'token' => 'ec7c3e8ae5413efe76a3e497455bae9841a85c01',
+					'firma' => '',
+					'skin' => '',
+					'color' => '',
+
+					// these values were stored as strings
+					'impCount' => 0,
+					'bImpCount' => 0,
+				],
+			],
+			[
+				'MCP',
+				[
+					'id' => '1839659',
+					'betrag' => '5.00',
+					'periode' => 0,
+					'anrede' => 'Herr',
+					'titel' => '',
+					'vorname' => 'Max',
+					'nachname' => 'Muster',
+					'plz' => '12345',
+					'ort' => 'Smalltown',
+					'country' => 'DE',
+					'strasse' => 'Erlenkamp 12',
+					'email' => 'max.muster@mydomain.com',
+					'eintrag' => 'anonym',
+					'kommentar' => null,
+					'info' => 0,
+					'adresstyp' => 'person',
+					'dob' => null,
+					'phone' => null,
+					'source' => 'de.wikipedia.org',
+					'tracking' => 'dewiki/wikipedia:spenden',
+					'confirmationPage' => '10h16 Bestätigung',
+					'utoken' => '6daf07db933ebe146e4596261ca8d5f27e8e2170',
+					'uexpiry' => '2016-05-17 19:35:14',
+					'layout' => 'form=10h16_Form1',
+					'user_agent' => 'Mozilla/5.0 (Windows NT 10.0; rv:46.0) Gecko/20100101 Firefox/46.0',
+					'ext_payment_id' => 'spenden.wikimedia.de-IDn24btga9au',
+					'ext_payment_status' => 'processed',
+					'ext_payment_account' => 'bc11c979141b208631145ce6f211ab0cdf19b92e',
+					'ext_payment_type' => 'billing',
+					'ext_payment_timestamp' => '2016-05-17T15:36:22+02:00',
+					'mcp_amount' => '5.00',
+					'mcp_currency' => 'EUR',
+					'mcp_country' => 'DE',
+					'mcp_auth' => '542e6b75f5718429aad79c5f0faaed16',
+					'mcp_title' => 'Ihre Spende an Wikipedia',
+					'mcp_sessionid' => 'CC6433ad374048307966bb62230246113042e4fd',
+					'mcp_cc_expiry_date' => '12/2038',
+					'log' => [
+						'2016-05-17 15:36:22' => 'mcp_handler: booked'
+					],
+					'name' => 'Max Muster',
+
+					// these fields did not exist in the original data set
+					'skin' => '',
+					'color' => '',
+					'firma' => '',
+
+					// these values were stored as strings
+					'impCount' => 0,
+					'bImpCount' => 0,
+				]
+			],
+			[
+				'PPL',
+				[
+					'id' => null,
+					'betrag' => '10.00',
+					'periode' => 0,
+					'anrede' => '',
+					'titel' => '',
+					'vorname' => 'Max',
+					'nachname' => 'Muster',
+					'plz' => '12345',
+					'ort' => 'Smalltown',
+					'country' => 'DE',
+					'strasse' => 'Erlenkamp 12',
+					'email' => 'max.muster@mydomain.com',
+					'eintrag' => 'anonym',
+					'kommentar' => null,
+					'info' => 0,
+					'adresstyp' => 'person',
+					'dob' => null,
+					'phone' => null,
+					'source' => 'web',
+					'utoken' => '0e54c50d821f72684ee0f40c6cf4597a07971e02',
+					'uexpiry' => '2016-05-17 18:10:35',
+					'layout' => '',
+					'ext_payment_id' => '72171T32A6H345906',
+					'ext_subscr_id' => 'I-DYP3HRBE7WUA',
+					'ext_payment_status' => 'Completed/subscr_payment',
+					'ext_payment_account' => 'QEEMF34KV3ECL',
+					'ext_payment_type' => 'instant',
+					'ext_payment_timestamp' => '05:10:30 May 17, 2016 PDT',
+					'paypal_payer_id' => 'QEEMF34KV3ECL',
+					'paypal_subscr_id' => 'I-DYP3HRBE7WUA',
+					'paypal_payer_status' => 'verified',
+					'paypal_first_name' => 'Max',
+					'paypal_last_name' => 'Muster',
+					'paypal_mc_gross' => '10.00',
+					'paypal_mc_currency' => 'EUR',
+					'paypal_mc_fee' => '0.47',
+					'user_agent' => 'PayPal IPN ( https://www.paypal.com/ipn )',
+					'name' => 'Max Muster',
+
+					// these fields did not exist in the original data set
+					'skin' => '',
+					'color' => '',
+					'tracking' => '',
+					'firma' => '',
+					'paypal_settle_amount' => '1.23',
+					'paypal_address_name' => 'Max Muster',
+					'paypal_address_status' => 'unconfirmed',
+
+					// these values were stored as strings
+					'impCount' => 0,
+					'bImpCount' => 0,
+				]
+			],
+			[
+				'PPL',
+				[
+					'id' => '1839597',
+					'betrag' => '24.00',
+					'periode' => 12,
+					'anrede' => 'Herr',
+					'country' => 'DE',
+					'eintrag' => 'anonym',
+					'kommentar' => null,
+					'info' => 0,
+					'adresstyp' => 'person',
+					'source' => 'de.wikipedia.org',
+					'tracking' => 'de.wikipedia.org/sidebar',
+					'utoken' => '0463f826b5bf17b298f198c327f54f2557af60bf',
+					'uexpiry' => '2016-05-16 23:22:06',
+					'layout' => 'form=10h16_Form1',
+					'user_agent' => 'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko',
+					'ext_payment_id' => 'V84052263707282L2',
+					'ext_subscr_id' => 'I-RU6JNJC1UV0E',
+					'ext_payment_status' => 'Completed/subscr_payment',
+					'ext_payment_account' => 'AVSBBESGSB8H8',
+					'ext_payment_type' => 'instant',
+					'ext_payment_timestamp' => '10:23:09 May 16, 2016 PDT',
+					'paypal_payer_id' => 'AVSBBESGSB8H8',
+					'paypal_subscr_id' => 'I-RU6JNJC1UV0E',
+					'paypal_payer_status' => 'verified',
+					'paypal_mc_gross' => '24.00',
+					'paypal_mc_currency' => 'EUR',
+					'paypal_mc_fee' => '0.64',
+					'log' => [
+						'2016-05-16 19:23:16' => 'paypal_handler: booked'
+					],
+					'name' => 'Max Muster',
+					'strasse' => 'Erlenkamp 12',
+					'ort' => 'Smalltown',
+					'plz' => '12345',
+					'titel' => '',
+					'email' => 'max.muster@mydomain.com',
+					'vorname' => 'Max',
+					'nachname' => 'Muster',
+					'paypal_first_name' => 'Max',
+					'paypal_last_name' => 'Muster',
+
+					// these fields did not exist in the original data
+					'skin' => '',
+					'color' => '',
+					'firma' => '',
+					'paypal_settle_amount' => '1.23',
+					'paypal_address_name' => 'Max Muster',
+					'paypal_address_status' => 'unconfirmed',
+
+					// these values were stored as strings
+					'impCount' => 0,
+					'bImpCount' => 0,
+				]
+			]
+		];
+	}
+
+	private function storeDonation( string $paymentType, array $data ) {
+		$dd = new Donation();
+		$dd->setDonorEmail( 'max.muster@mydomain.com' );
+		$dd->setAmount( '1.00' );
+		$dd->setPaymentType( $paymentType );
+		$dd->encodeAndSetData( $data );
+		$this->entityManager->persist( $dd );
+		$this->entityManager->flush();
+	}
+
+}


### PR DESCRIPTION
This PR is the outcome of [phab:T135372](https://phabricator.wikimedia.org/T135372). I exported some test data sets from the production database, changed the fields containing personal data and wrote a test that carries out a round-trip to make sure the data stays the same.

It contains some minor fixes and removes the creation of that data field for membership applications completely. The latter will be reintroduced once the [confirmation page tracking](https://phabricator.wikimedia.org/T138209) is in place again.

I wasn't quite sure where to put this, since it is a test that has no relation to anything in `src`. But this whole thing is something we can actually get rid of again once the old application is gone.

The application adds fields which in the old application are only present if set. I guess, we can just ignore this fact.

It stores the banner impression count fields (`impCount`, `bImpCount`) as an integer (previously: `string`). This value is only used in some script and neither in the fundraising application nor in that administration application.