### PR TITLE
fix payment notification handlers

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -467,7 +467,7 @@ $app->get(
 
 			$response = CreditCardNotificationResponse::newSuccessResponse(
 				(int)$request->query->get( 'donation_id', '' ),
-				$request->query->get( 'accessToken', '' )
+				$request->query->get( 'token', '' )
  			);
 		} catch ( CreditCardPaymentHandlerException $e ) {
 			$response = CreditCardNotificationResponse::newFailureResponse( $e->getMessage() );

--- a/app/templates/CreditCardPaymentNotification.twig
+++ b/app/templates/CreditCardPaymentNotification.twig
@@ -1,7 +1,7 @@
 {% if successful %}
 status=ok
 url={$ returnUrl $}?donationId={$ donationId $}&accessToken={$ accessToken $}
-target=_self
+target=_top
 forward=1
 {% else %}
 status=error

--- a/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
+++ b/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
@@ -94,10 +94,12 @@ class CreditCardNotificationUseCase {
 	}
 
 	private function sendConfirmationEmail( Donation $donation ) {
-		try {
-			$this->mailer->sendConfirmationMailFor( $donation );
-		} catch ( \RuntimeException $ex ) {
-			// no need to re-throw or return false, this is not a fatal error, only a minor inconvenience
+		if ( $donation->getDonor() !== null ) {
+			try {
+				$this->mailer->sendConfirmationMailFor( $donation );
+			} catch ( \RuntimeException $ex ) {
+				// no need to re-throw or return false, this is not a fatal error, only a minor inconvenience
+			}
 		}
 	}
 

--- a/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
+++ b/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
@@ -144,10 +144,12 @@ class HandlePayPalPaymentNotificationUseCase {
 	}
 
 	private function sendConfirmationEmailFor( Donation $donation ) {
-		try {
-			$this->mailer->sendConfirmationMailFor( $donation );
-		} catch ( \RuntimeException $ex ) {
-			// no need to re-throw or return false, this is not a fatal error, only a minor inconvenience
+		if ( $donation->getDonor() !== null ) {
+			try {
+				$this->mailer->sendConfirmationMailFor( $donation );
+			} catch ( \RuntimeException $ex ) {
+				// no need to re-throw or return false, this is not a fatal error, only a minor inconvenience
+			}
 		}
 	}
 

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -101,6 +101,13 @@ class ValidDonation {
 		);
 	}
 
+	public static function newIncompleteAnonymousPayPalDonation(): Donation {
+		return ( new self() )->createAnonymousDonation(
+			new PayPalPayment( new PayPalData() ),
+			Donation::STATUS_EXTERNAL_INCOMPLETE
+		);
+	}
+
 	public static function newBookedCreditCardDonation() {
 		$creditCardData = new CreditCardTransactionData();
 		$creditCardData->setTransactionId( self::CREDIT_CARD_TRANSACTION_ID );
@@ -113,6 +120,13 @@ class ValidDonation {
 
 	public static function newIncompleteCreditCardDonation(): Donation {
 		return ( new self() )->createDonation(
+			new CreditCardPayment( new CreditCardTransactionData() ),
+			Donation::STATUS_EXTERNAL_INCOMPLETE
+		);
+	}
+
+	public static function newIncompleteAnonymousCreditCardDonation(): Donation {
+		return ( new self() )->createAnonymousDonation(
 			new CreditCardPayment( new CreditCardTransactionData() ),
 			Donation::STATUS_EXTERNAL_INCOMPLETE
 		);
@@ -132,6 +146,17 @@ class ValidDonation {
 			$this->newDonor(),
 			$this->newDonationPayment( $paymentMethod ),
 			self::OPTS_INTO_NEWSLETTER,
+			$this->newTrackingInfo()
+		);
+	}
+
+	private function createAnonymousDonation( PaymentMethod $paymentMethod, string $status ): Donation {
+		return new Donation(
+			null,
+			$status,
+			null,
+			$this->newDonationPayment( $paymentMethod ),
+			false,
 			$this->newTrackingInfo()
 		);
 	}

--- a/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
@@ -87,7 +87,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 			'sessionId' => self::SESSION_ID,
 			'auth' => self::AUTH_ID,
 			'utoken' => self::UPDATE_TOKEN,
-			'accessToken' => self::ACCESS_TOKEN,
+			'token' => self::ACCESS_TOKEN,
 			'title' => self::TITLE,
 			'country' => self::COUNTRY_CODE,
 			'currency' => self::CURRENCY_CODE,

--- a/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
+++ b/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
@@ -106,6 +106,19 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit_Framework_TestCase {
 		$useCase->handleNotification( $request );
 	}
 
+	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent() {
+		$donation = ValidDonation::newIncompleteAnonymousCreditCardDonation();
+		$this->repository->storeDonation( $donation );
+
+		$this->mailer->expects( $this->never() )
+			->method( 'sendConfirmationMailFor' );
+
+		$useCase = $this->newCreditCardNotificationUseCase();
+
+		$request = ValidCreditCardNotificationRequest::newBillingNotification( 1 );
+		$useCase->handleNotification( $request );
+	}
+
 	public function testWhenAuthorizationSucceeds_donationIsStored() {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$this->repository = new DonationRepositorySpy( $donation );

--- a/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
+++ b/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
@@ -177,6 +177,27 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit_Framework_Test
 		$this->assertTrue( $useCase->handleNotification( $request ) );
 	}
 
+	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent() {
+		$donation = ValidDonation::newIncompleteAnonymousPayPalDonation();
+		$fakeRepository = new FakeDonationRepository();
+		$fakeRepository->storeDonation( $donation );
+
+		$mailer = $this->getMailer();
+		$mailer->expects( $this->never() )
+			->method( 'sendConfirmationMailFor' );
+
+		$request = ValidPayPalNotificationRequest::newInstantPaymentForDonation( 1 );
+		$useCase = new HandlePayPalPaymentNotificationUseCase(
+			$fakeRepository,
+			new SucceedingDonationAuthorizer(),
+			$mailer,
+			new NullLogger(),
+			$this->getEventLogger()
+		);
+
+		$this->assertTrue( $useCase->handleNotification( $request ) );
+	}
+
 	public function testWhenAuthorizationSucceeds_donationIsStored() {
 		$donation = ValidDonation::newIncompletePayPalDonation();
 		$repositorySpy = new DonationRepositorySpy( $donation );


### PR DESCRIPTION
This one fixes some bugs in the payment notification handling:
- Don't send confirmation mail for anonymous donations
- Don't show donation confirmation in payment iframe
- Fix access token variable name