### PR TITLE
add border to invalid fields

### DIFF
--- a/web/skin/10h16/_styles/styles.css
+++ b/web/skin/10h16/_styles/styles.css
@@ -148,6 +148,7 @@ input[type=number]:focus,
 input[type=tel]:focus,
 input[type=text]:focus { border: 1px solid #77bfef; }
 
+input[type=text].invalid { -webkit-box-shadow: 0 0 4px 2px rgba( 250, 87, 87, 1 ); -moz-box-shadow: 0 0 4px 2px rgba( 250, 87, 87, 1 ); box-shadow: 0 0 4px 2px rgba( 250, 87, 87, 1 ); }
 input[type=tel] + .validation,
 input[type=text] + .validation { margin-left: -30px; margin-right: 14px; font-size: 1.2em; vertical-align: middle; }
 input[type=tel] ~ .validation-explanation,


### PR DESCRIPTION
Fix for [phab:T139049](https://phabricator.wikimedia.org/T139049)

The `required` attribute was [removed](http://localhost/mediawiki/index.php?title=Web%3ASpendenseite-HK2013%2Frewrite%2FDonationForm_PersonalData&type=revision&diff=8165&oldid=8157) from the template. The style change adds the box shadow to invalid fields to "simulate" that behaviour.