### PR TITLE
Refactording of bad/white word retrieval

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -80,7 +80,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\TokenGenerator;
 use WMDE\Fundraising\Frontend\Infrastructure\TwigCachePurger;
 use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
 use WMDE\Fundraising\Frontend\Presentation\Content\PageContentModifier;
-use WMDE\Fundraising\Frontend\Presentation\Content\WikiContentProvider;
+use WMDE\Fundraising\Frontend\Infrastructure\ModifyingPageRetriever;
 use WMDE\Fundraising\Frontend\Presentation\CreditCardUrlConfig;
 use WMDE\Fundraising\Frontend\Presentation\CreditCardUrlGenerator;
 use WMDE\Fundraising\Frontend\Presentation\DonationConfirmationPageSelector;
@@ -529,7 +529,7 @@ class FunFunFactory {
 	}
 
 	private function newWikiContentProvider() {
-		return new WikiContentProvider(
+		return new ModifyingPageRetriever(
 			$this->newPageRetriever(),
 			$this->newPageContentModifier(),
 			$this->config['cms-wiki-title-prefix']
@@ -741,11 +741,11 @@ class FunFunFactory {
 		return $policyValidator;
 	}
 
-	private function loadWordsFromWiki( WikiContentProvider $contentProvider, string $pageName ): array {
+	private function loadWordsFromWiki( PageRetriever $contentProvider, string $pageName ): array {
 		if ( $pageName === '' ) {
 			return [ ];
 		}
-		$content = $contentProvider->getContent( $pageName, 'raw' );
+		$content = $contentProvider->fetchPage( $pageName, 'raw' );
 		$words = array_map( 'trim', explode( "\n", $content ) );
 
 		return array_filter( $words );

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -68,6 +68,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\MembershipApplicationTokenFetcher;
 use WMDE\Fundraising\Frontend\Infrastructure\MembershipApplicationTracker;
 use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
 use WMDE\Fundraising\Frontend\Infrastructure\PageRetriever;
+use WMDE\Fundraising\Frontend\Infrastructure\PageRetrieverBasedStringList;
 use WMDE\Fundraising\Frontend\Infrastructure\PaymentNotificationVerifier;
 use WMDE\Fundraising\Frontend\Infrastructure\PayPalPaymentNotificationVerifier;
 use WMDE\Fundraising\Frontend\Infrastructure\RandomTokenGenerator;
@@ -722,33 +723,14 @@ class FunFunFactory {
 		return $this->pimple['twig_factory'];
 	}
 
-	private function getTextPolicyValidator( $policyName ) {
-		$policyValidator = new TextPolicyValidator();
-
+	private function getTextPolicyValidator( $policyName ): TextPolicyValidator {
 		$contentProvider = $this->newWikiContentProvider();
 		$textPolicyConfig = $this->config['text-policies'][$policyName];
 
-		// TODO: this is not the place to retrieve resources over the network
-		$policyValidator->addBadWordsFromArray( $this->loadWordsFromWiki(
-			$contentProvider,
-			$textPolicyConfig['badwords'] ?? ''
-		) );
-		$policyValidator->addWhiteWordsFromArray( $this->loadWordsFromWiki(
-			$contentProvider,
-			$textPolicyConfig['whitewords'] ?? ''
-		) );
-
-		return $policyValidator;
-	}
-
-	private function loadWordsFromWiki( PageRetriever $contentProvider, string $pageName ): array {
-		if ( $pageName === '' ) {
-			return [ ];
-		}
-		$content = $contentProvider->fetchPage( $pageName, 'raw' );
-		$words = array_map( 'trim', explode( "\n", $content ) );
-
-		return array_filter( $words );
+		return new TextPolicyValidator(
+			new PageRetrieverBasedStringList( $contentProvider, $textPolicyConfig['badwords'] ?? '' ),
+			new PageRetrieverBasedStringList( $contentProvider, $textPolicyConfig['whitewords'] ?? '' )
+		);
 	}
 
 	public function newCancelDonationUseCase( string $updateToken ): CancelDonationUseCase {

--- a/src/Factories/TwigFactory.php
+++ b/src/Factories/TwigFactory.php
@@ -11,8 +11,8 @@ use Twig_Extension_StringLoader;
 use Twig_Lexer;
 use Twig_Loader_Array;
 use Twig_Loader_Filesystem;
+use WMDE\Fundraising\Frontend\Infrastructure\PageRetriever;
 use WMDE\Fundraising\Frontend\Presentation\Content\TwigPageLoader;
-use WMDE\Fundraising\Frontend\Presentation\Content\WikiContentProvider;
 
 /**
  * @license GNU GPL v2+
@@ -56,11 +56,11 @@ class TwigFactory {
 		return $twig;
 	}
 
-	public function newWikiPageLoader( WikiContentProvider $provider ) {
+	public function newWikiPageLoader( PageRetriever $pageRetriever ) {
 		if ( !$this->config['loaders']['wiki']['enabled'] ) {
 			return null;
 		}
-		return new TwigPageLoader( $provider, $this->config['loaders']['wiki']['rawpages'] ?? [] );
+		return new TwigPageLoader( $pageRetriever, $this->config['loaders']['wiki']['rawpages'] ?? [] );
 	}
 
 	public function newFileSystemLoader() {

--- a/src/Infrastructure/ArrayBasedStringList.php
+++ b/src/Infrastructure/ArrayBasedStringList.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class ArrayBasedStringList implements StringList {
+
+	private $arrayOfString;
+
+	public function __construct( array $arrayOfString ) {
+		$this->arrayOfString = $arrayOfString;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function toArray(): array {
+		return $this->arrayOfString;
+	}
+
+}

--- a/src/Infrastructure/ModifyingPageRetriever.php
+++ b/src/Infrastructure/ModifyingPageRetriever.php
@@ -2,15 +2,15 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Presentation\Content;
+namespace WMDE\Fundraising\Frontend\Infrastructure;
 
-use WMDE\Fundraising\Frontend\Infrastructure\PageRetriever;
+use WMDE\Fundraising\Frontend\Presentation\Content\PageContentModifier;
 
 /**
  * @license GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >
  */
-class WikiContentProvider {
+class ModifyingPageRetriever implements PageRetriever {
 
 	private $pageRetriever;
 	private $contentModifier;
@@ -22,15 +22,16 @@ class WikiContentProvider {
 		$this->pageTitlePrefix = $pageTitlePrefix;
 	}
 
-	public function getContent( string $pageName, string $fetchMode = 'render' ): string {
-		$prefixedPageName = $this->getPrefixedPageTitle( $pageName );
-		$normalizedPageName = $this->normalizePageName( $prefixedPageName );
+	public function fetchPage( string $pageName, string $fetchMode ): string {
+		$normalizedPageName = $this->normalizePageName( $this->getPrefixedPageTitle( $pageName ) );
+
 		$content = $this->pageRetriever->fetchPage( $normalizedPageName, $fetchMode );
 		$content = $this->contentModifier->getProcessedContent( $content, $normalizedPageName );
 
 		return $content;
 	}
 
+	// TODO: seems misplaced. Should likely either be handled near input, or before sending to API or similar
 	private function normalizePageName( string $title ): string {
 		return ucfirst( str_replace( ' ', '_', trim( $title ) ) );
 	}

--- a/src/Infrastructure/PageRetrieverBasedStringList.php
+++ b/src/Infrastructure/PageRetrieverBasedStringList.php
@@ -1,0 +1,31 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+class PageRetrieverBasedStringList implements StringList {
+
+	private $pageRetriever;
+	private $pageName;
+
+	public function __construct( PageRetriever $pageRetriever, string $pageName ) {
+		$this->pageRetriever = $pageRetriever;
+		$this->pageName = $pageName;
+	}
+
+	public function toArray(): array {
+		if ( $this->pageName === '' ) {
+			return [];
+		}
+
+		$content = $this->pageRetriever->fetchPage( $this->pageName, 'raw' );
+
+		return array_filter( array_map( 'trim', explode( "\n", $content ) ) );
+	}
+
+}

--- a/src/Infrastructure/StringList.php
+++ b/src/Infrastructure/StringList.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Jeroen De Dauw < jeroendedauw@gmail.com >
+ */
+interface StringList {
+
+	/**
+	 * @return string[]
+	 */
+	public function toArray(): array;
+
+}

--- a/src/Presentation/Content/PageContentModifier.php
+++ b/src/Presentation/Content/PageContentModifier.php
@@ -20,6 +20,7 @@ class PageContentModifier {
 	}
 
 	public function getProcessedContent( string $content, string $pageName ): string {
+		// TODO: this seems misplaced and presumably should go into ApiBasedPageRetriever
 		# full HTML document usually indicates an error (e.g. access denied)
 		if ( preg_match( '/^<!DOCTYPE html/', $content ) ) {
 			$this->logger->debug( __METHOD__ . ': fail, got error page', [ $content, $pageName ] );

--- a/src/Presentation/Content/TwigPageLoader.php
+++ b/src/Presentation/Content/TwigPageLoader.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Presentation\Content;
 
 use Twig_Error_Loader;
+use WMDE\Fundraising\Frontend\Infrastructure\PageRetriever;
 
 /**
  * @license GNU GPL v2+
@@ -12,13 +13,13 @@ use Twig_Error_Loader;
  */
 class TwigPageLoader implements \Twig_LoaderInterface {
 
-	private $contentProvider;
+	private $pageRetriever;
 	private $pageCache = [];
 	private $errorCache = [];
 	private $rawPagesList = [];
 
-	public function __construct( WikiContentProvider $contentProvider, array $rawPagesList = [] ) {
-		$this->contentProvider = $contentProvider;
+	public function __construct( PageRetriever $pageRetriever, array $rawPagesList = [] ) {
+		$this->pageRetriever = $pageRetriever;
 		$this->rawPagesList = $rawPagesList;
 	}
 
@@ -49,7 +50,7 @@ class TwigPageLoader implements \Twig_LoaderInterface {
 		if ( isset( $this->errorCache[$title] ) ) {
 			throw new Twig_Error_Loader( "Wiki page $title not found." );
 		}
-		$content = $this->contentProvider->getContent( $title, $fetchMode );
+		$content = $this->pageRetriever->fetchPage( $title, $fetchMode );
 		if ( $content !== '' ) {
 			$this->pageCache[$title] = $content;
 			return $content;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T138964

This allows us to add caching in a sane way. Will do that in a separate PR. Thoughts on where to cache? We approach is in the data access layer, which would be `ApiBasedPageRetriever`. Or perhaps at the other end, and just cache the word lists. The later approach will not have caching for other users of `ApiBasedPageRetriever`, though perhaps that is not desired. (The only user now is the twig templating, which already has caching.)