### PR TITLE
Improvements to client side validation

### DIFF
--- a/app/js/tests/test_form_validation.js
+++ b/app/js/tests/test_form_validation.js
@@ -29,6 +29,7 @@ test( 'Address validation is valid for anonymous address', function ( t ) {
 		postFunctionSpy = sinon.spy(),
 		addressValidator = validation.createAddressValidator(
 			'http://spenden.wikimedia.org/validate-address',
+			validation.DefaultRequiredFieldsForAddressType,
 			postFunctionSpy
 		),
 		validationResult;
@@ -45,6 +46,7 @@ test( 'Given a private adddress, address validation sends values to server', fun
 		postFunctionSpy = sinon.stub().returns( positiveResult ),
 		addressValidator = validation.createAddressValidator(
 			'http://spenden.wikimedia.org/validate-address',
+			validation.DefaultRequiredFieldsForAddressType,
 			postFunctionSpy
 		),
 		formData = {
@@ -75,6 +77,7 @@ test( 'Given an incomplete private adddress, address validation sends no values 
 		postFunctionSpy = sinon.spy(),
 		addressValidator = validation.createAddressValidator(
 			'http://spenden.wikimedia.org/validate-address',
+			validation.DefaultRequiredFieldsForAddressType,
 			postFunctionSpy
 		),
 		formData = {

--- a/web/res/js/membershipForm.js
+++ b/web/res/js/membershipForm.js
@@ -50,7 +50,10 @@ $( function () {
 					initialValues
 				),
 				WMDE.ReduxValidation.createValidationDispatcher(
-					WMDE.FormValidation.createAddressValidator( initData.data( 'validate-address-url' ) ),
+					WMDE.FormValidation.createAddressValidator(
+						initData.data( 'validate-address-url' ),
+						WMDE.FormValidation.DefaultRequiredFieldsForAddressType
+					),
 					actions.newFinishAddressValidationAction,
 					[
 						'addressType',


### PR DESCRIPTION
Refactored AddressValidator to take a set of field names for each
address type.

Removed account and bank code from error messages (was confusing when
only IBAN and BIC fields were shown).

Add TODOs where the validation message has to be set.

Renamed triggerFieldValidity to triggerValidityCheckForPersonalDataPage

Moved triggerValidityCheckForPersonalDataPage to a more appropriate
place (the event handler).