### PR TITLE
Cache requests to the CMS wiki on the filesystem

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -81,7 +81,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\Repositories\LoggingMembershipAppli
 use WMDE\Fundraising\Frontend\Infrastructure\Repositories\LoggingSubscriptionRepository;
 use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
 use WMDE\Fundraising\Frontend\Infrastructure\TokenGenerator;
-use WMDE\Fundraising\Frontend\Infrastructure\TwigCachePurger;
+use WMDE\Fundraising\Frontend\Infrastructure\AllOfTheCachePurger;
 use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
 use WMDE\Fundraising\Frontend\Presentation\Content\PageContentModifier;
 use WMDE\Fundraising\Frontend\Infrastructure\ModifyingPageRetriever;
@@ -694,7 +694,7 @@ class FunFunFactory {
 
 	public function newPurgeCacheUseCase(): PurgeCacheUseCase {
 		return new PurgeCacheUseCase(
-			new TwigCachePurger( $this->getTwig() ),
+			new AllOfTheCachePurger( $this->getTwig(), $this->getPageCache() ),
 			$this->config['purging-secret']
 		);
 	}

--- a/src/Factories/TwigFactory.php
+++ b/src/Factories/TwigFactory.php
@@ -23,22 +23,22 @@ class TwigFactory {
 	const DEFAULT_TEMPLATE_DIR = 'app/templates';
 
 	private $config;
+	private $cachePath;
 
-	public function __construct( array $config ) {
+	public function __construct( array $config, string $cachePath ) {
 		$this->config = $config;
+		$this->cachePath = $cachePath;
 	}
 
 	public function create( array $loaders, array $extensions ): Twig_Environment {
 		$options = [];
 
 		if ( $this->config['enable-cache'] ) {
-			$options['cache'] = __DIR__ . '/../../var/cache';
+			$options['cache'] = $this->cachePath;
 		}
 
-		$loader = new \Twig_Loader_Chain( $loaders );
-
 		$twig = new Twig_Environment(
-			$loader,
+			new \Twig_Loader_Chain( $loaders ),
 			$options
 		);
 
@@ -46,12 +46,11 @@ class TwigFactory {
 			$twig->addExtension( $ext );
 		}
 
-		$lexer = new Twig_Lexer( $twig, [
+		$twig->setLexer( new Twig_Lexer( $twig, [
 			'tag_comment'   => [ '{#', '#}' ],
 			'tag_block'     => [ '{%', '%}' ],
 			'tag_variable'  => [ '{$', '$}' ]
-		] );
-		$twig->setLexer( $lexer );
+		] ) );
 
 		return $twig;
 	}

--- a/src/Infrastructure/AllOfTheCachePurger.php
+++ b/src/Infrastructure/AllOfTheCachePurger.php
@@ -4,16 +4,21 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Infrastructure;
 
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\FlushableCache;
+
 /**
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class TwigCachePurger implements CachePurger {
+class AllOfTheCachePurger implements CachePurger {
 
 	private $twigEnvironment;
+	private $pageCache;
 
-	public function __construct( \Twig_Environment $twigEnvironment ) {
+	public function __construct( \Twig_Environment $twigEnvironment, Cache $pageCache ) {
 		$this->twigEnvironment = $twigEnvironment;
+		$this->pageCache = $pageCache;
 	}
 
 	/**
@@ -22,6 +27,10 @@ class TwigCachePurger implements CachePurger {
 	public function purgeCache() {
 		$this->twigEnvironment->clearCacheFiles();
 		$this->twigEnvironment->clearTemplateCache();
+
+		if ( $this->pageCache instanceof FlushableCache ) {
+			$this->pageCache->flushAll();
+		}
 	}
 
 }

--- a/tests/Integration/Factories/TwigFactoryTest.php
+++ b/tests/Integration/Factories/TwigFactoryTest.php
@@ -22,7 +22,7 @@ class TwigFactoryTest extends \PHPUnit_Framework_TestCase {
 			'loaders' => [
 				'array' => [ 'variableReplacement.twig' => '{$ testvar $}' ]
 			]
-		] );
+		], '/tmp/fun' );
 		$twig = $factory->create( [ $factory->newArrayLoader() ], [] );
 		$result = $twig->render( 'variableReplacement.twig', [ 'testvar' => 'Meeow!' ] );
 		$this->assertSame( 'Meeow!', $result );
@@ -43,7 +43,7 @@ class TwigFactoryTest extends \PHPUnit_Framework_TestCase {
 		$thirdLoader = $this->createMock( Twig_LoaderInterface::class );
 		$thirdLoader->expects( $this->never() )->method( $this->anything() );
 
-		$factory = new TwigFactory( [ 'enable-cache' => false ] );
+		$factory = new TwigFactory( [ 'enable-cache' => false ], '/tmp/fun' );
 		$twig = $factory->create( [ $firstLoader, $secondLoader, $thirdLoader ], [] );
 		$result = $twig->render( 'Canis_silvestris' );
 		$this->assertSame( 'Meeow!', $result );
@@ -56,7 +56,7 @@ class TwigFactoryTest extends \PHPUnit_Framework_TestCase {
 					'template-dir' => __DIR__ . '/../../templates'
 				]
 			]
-		] );
+		], '/tmp/fun' );
 		$loader = $factory->newFileSystemLoader();
 		$this->assertSame( [ __DIR__ . '/../../templates' ], $loader->getPaths() );
 	}
@@ -68,11 +68,11 @@ class TwigFactoryTest extends \PHPUnit_Framework_TestCase {
 					'template-dir' => 'tests/templates'
 				]
 			]
-		] );
+		], '/tmp/fun' );
 		$loader = $factory->newFileSystemLoader();
 		$realPath = realpath( $loader->getPaths()[0] );
 		$this->assertFalse( $realPath === false, 'path does not exist' );
-		$this->assertSame( $realPath, realPath( __DIR__ . '/../../templates' ) );
+		$this->assertSame( $realPath, realpath( __DIR__ . '/../../templates' ) );
 	}
 
 }

--- a/tests/Integration/UseCases/AddComment/AddCommentUseCaseTest.php
+++ b/tests/Integration/UseCases/AddComment/AddCommentUseCaseTest.php
@@ -10,6 +10,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\FailingDonationAuthorizer;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\FakeDonationRepository;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\SucceedingDonationAuthorizer;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\ThrowingDonationRepository;
+use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 use WMDE\Fundraising\Frontend\UseCases\AddComment\AddCommentRequest;
 use WMDE\Fundraising\Frontend\UseCases\AddComment\AddCommentUseCase;
 use WMDE\Fundraising\Frontend\UseCases\AddComment\AddCommentValidationResult;

--- a/web/index.dev.php
+++ b/web/index.dev.php
@@ -5,7 +5,7 @@
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 
-declare(strict_types = 1);
+declare( strict_types = 1 );
 
 error_reporting( E_ALL | E_STRICT );
 ini_set( 'display_errors', '1' );
@@ -46,7 +46,7 @@ $app['dbs'] = $app->share( function ( $app ) {
 $app->register(
 	new Silex\Provider\WebProfilerServiceProvider(),
 	[
-		'profiler.cache_dir' => __DIR__ . '/../app/cache/profiler',
+		'profiler.cache_dir' => $ffFactory->getCachePath() . '/profiler',
 		'profiler.mount_prefix' => '/_profiler',
 	]
 );

--- a/web/index.php
+++ b/web/index.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare( strict_types = 1 );
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -15,6 +15,8 @@ $ffFactory = call_user_func( function() {
 
 	return new \WMDE\Fundraising\Frontend\Factories\FunFunFactory( $configReader->getConfig() );
 } );
+
+$ffFactory->enablePageCache();
 
 /**
  * @var \Silex\Application $app


### PR DESCRIPTION
Fixes https://phabricator.wikimedia.org/T138964
and https://phabricator.wikimedia.org/T139468

Tested manually. Not sure how to write sane automated tests for this.

The cache is only used when the app gets initialized via the non-dev
entry point. Currently the twig cache is used by the dev-entry point
unless you disable it in your config (which is also used by the non-
dev one). We presumably want to also change that.

Twig cache was moved from var/cache to var/cache/twig.

Profiler cache was moved from /app/cache/profiler to var/cache/profiler.
Might want to change this to var/profiler. Not really a cache is it?