### PR TITLE
Fix JS issues with bank data validation

### DIFF
--- a/web/res/js/donationForm.js
+++ b/web/res/js/donationForm.js
@@ -66,7 +66,7 @@ $( function () {
 				WMDE.ReduxValidation.createValidationDispatcher(
 					WMDE.FormValidation.createBankDataValidator( initData.data( 'validate-iban-url' ), initData.data( 'generate-iban-url' ) ),
 					actions.newFinishBankDataValidationAction,
-					[ 'iban', 'accountNumber', 'bankCode', 'debitType' ],
+					[ 'iban', 'accountNumber', 'bankCode' ],
 					initialValues
 				),
 				WMDE.ReduxValidation.createValidationDispatcher(

--- a/web/res/js/membershipForm.js
+++ b/web/res/js/membershipForm.js
@@ -82,7 +82,7 @@ $( function () {
 						initData.data( 'generate-iban-url' )
 					),
 					actions.newFinishBankDataValidationAction,
-					[ 'iban', 'accountNumber', 'bankCode', 'debitType' ],
+					[ 'iban', 'accountNumber', 'bankCode' ],
 					initialValues
 				),
 				WMDE.ReduxValidation.createValidationDispatcher(

--- a/web/skin/10h16/_js/spenden.wikimedia.js
+++ b/web/skin/10h16/_js/spenden.wikimedia.js
@@ -19,7 +19,7 @@ $(function() {
         if ($toggle.hasClass('active')) {
           $($toggle.attr('data-slide-rel'))
               .removeClass('opened')
-              .slideUp(600, checkInvisibleInput)
+              .slideUp( 600 )
               .animate(
                   {opacity: 0},
                   {queue: false, duration: 600}
@@ -29,7 +29,7 @@ $(function() {
         } else {
           $($toggle.attr('data-slide-rel'))
               .addClass('opened')
-              .slideDown(600, checkInvisibleInput)
+              .slideDown( 600 )
               .animate(
                   {opacity: 1},
                   {queue: false, duration: 600}
@@ -42,15 +42,6 @@ $(function() {
       });
     }
 
-
-    /* check invisible input elems */
-    function checkInvisibleInput() {
-      // remove required attribute for hidden inputs
-      $(':input.required:hidden').removeAttr('required');
-      $(':input.required:visible').prop('required', true);
-    }
-
-
     /* tab toggle */
     /* Was only used in some old forms, may be deleted if not used by March 2016 */
     function initTabToggle() {
@@ -58,8 +49,6 @@ $(function() {
 
         $($(this).attr('data-tab-group-rel')).find('.tab').addClass('no-display');
         $($(this).attr('data-tab-rel')).removeClass('no-display');
-
-        checkInvisibleInput();
 
         e.preventDefault();
       });


### PR DESCRIPTION
- first commit excludes some fields from triggering the validation
- second commit gets rid of setting/unsetting the `required` attribute which was used for HTML5 form validation

[phab:T140476](https://phabricator.wikimedia.org/T140476)