### PR TITLE
Moved logger construction out of factory

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -4,19 +4,52 @@ declare( strict_types = 1 );
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\BufferHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+use WMDE\Fundraising\Frontend\Infrastructure\ConfigReader;
+
+/**
+ * @var FunFunFactory $ffFactory
+ */
 $ffFactory = call_user_func( function() {
 	$prodConfigPath = __DIR__ . '/../app/config/config.prod.json';
 
-	$configReader = new \WMDE\Fundraising\Frontend\Infrastructure\ConfigReader(
+	$configReader = new ConfigReader(
 		new \FileFetcher\SimpleFileFetcher(),
 		__DIR__ . '/../app/config/config.dist.json',
 		is_readable( $prodConfigPath ) ? $prodConfigPath : null
 	);
 
-	return new \WMDE\Fundraising\Frontend\Factories\FunFunFactory( $configReader->getConfig() );
+	return new FunFunFactory( $configReader->getConfig() );
 } );
 
 $ffFactory->enablePageCache();
+
+$ffFactory->setLogger( call_user_func( function() use ( $ffFactory ) {
+	$logger = new Logger( 'WMDE Fundraising Frontend logger' );
+
+	$streamHandler = new StreamHandler(
+		$ffFactory->getLoggingPath() . '/' . ( new \DateTime() )->format( 'Y-m-d\TH:i:s\Z' ) . '.log'
+	);
+
+	$bufferHandler = new BufferHandler( $streamHandler, 500, Logger::DEBUG, true, true );
+	$streamHandler->setFormatter( new LineFormatter( "%message%\n" ) );
+	$logger->pushHandler( $bufferHandler );
+
+	$errorHandler = new StreamHandler(
+		$ffFactory->getLoggingPath() . '/error.log',
+		Logger::ERROR
+	);
+
+	$errorHandler->setFormatter( new JsonFormatter() );
+	$logger->pushHandler( $errorHandler );
+
+	return $logger;
+} ) );
 
 /**
  * @var \Silex\Application $app


### PR DESCRIPTION
Only behaviour change for now is that the tests will no longer use a logger.
We can set one up in TestEnvironment if we want to though.

Like this we can set up different logging for production and for the dev
entry point. Presumably we want those to write to different loggs. Also,
right now the non-dev entry point is logging every request, which we presumably
do not want to do.