### PR TITLE
Scrub wiki comments from templates

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -602,7 +602,12 @@ class FunFunFactory {
 
 	private function newPageContentModifier(): PageContentModifier {
 		return new PageContentModifier(
-			$this->getLogger()
+			$this->getLogger(),
+			[
+				'/<!--\s*NewPP limit report.*?-->/s' => '',
+				'/<!--\s*Transclusion expansion time report.*?-->/s' => '',
+				'/<!--\s*Saved in parser cache with key.*?-->/s' => ''
+			]
 		);
 	}
 


### PR DESCRIPTION
The app output should not contain comments that were generated by the
Mediawiki CMS.