### PR TITLE
Add composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,5 +98,8 @@
 		"phpmd": [
 			"vendor/bin/phpmd src/ text phpmd.xml"
 		]
+	},
+	"config": {
+		"discard-changes": true
 	}
 }


### PR DESCRIPTION
Add config section to composer.json which leads to a "hard override" of
existing changes in the vendor directory during deployment.

This change is necessary to un-break deployment for new versions of
FundraisingStore which has some permission changes that confuse
composer.