### PR TITLE
Make ScrutinizerCI wait for way slow coverage generation

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,8 @@
 inherit: true
 
 tools:
-    external_code_coverage: true
+    external_code_coverage:
+        timeout: 3600
     php_code_sniffer: true
     php_cpd: true
     php_cs_fixer: true


### PR DESCRIPTION
Taking TarvisCi over 40 min...

https://scrutinizer-ci.com/docs/tools/external-code-coverage/