### PR TITLE
Re-add code that presumably got lost

### DIFF
--- a/src/ApplicationContext/DataAccess/ApiBasedPageRetriever.php
+++ b/src/ApplicationContext/DataAccess/ApiBasedPageRetriever.php
@@ -59,6 +59,14 @@ class ApiBasedPageRetriever implements PageRetriever {
 			return '';
 		}
 
+		// Full HTML document usually indicates an error (e.g. access denied)
+		if ( preg_match( '/^<!DOCTYPE html/', $content ) ) {
+			$this->logger->debug( __METHOD__ . ': fail, got error page', [ $content, $normalizedPageName ] );
+			return '';
+		}
+
+		$content = trim( $content );
+
 		return $content;
 	}
 


### PR DESCRIPTION
This behaviour was there before in PageContentModifier, which is no longer
used since https://github.com/wmde/FundraisingFrontend/pull/611

Not sure the trim is correct here

And not sure the drop of the code was not intentional. This PR is initially to
keep track of this. Tests are missing.