### PR TITLE
Fixed return type violation in TextPolicyValidator

### DIFF
--- a/src/Validation/TextPolicyValidator.php
+++ b/src/Validation/TextPolicyValidator.php
@@ -158,16 +158,14 @@ class TextPolicyValidator {
 		$parsedUrl = parse_url( 'http://' . $url );
 
 		if ( !$parsedUrl ) {
-			return false;
+			return '';
 		}
 
 		if ( isset( $parsedUrl['host'] ) ) {
-			$host = $parsedUrl['host'];
-		} else {
-			$host = $parsedUrl['path'];
+			return $parsedUrl['host'];
 		}
 
-		return $host;
+		return $parsedUrl['path'];
 	}
 
 	private function composeRegex( array $wordArray ): string {


### PR DESCRIPTION
Just noticed it was wrong by looking at this. Not sure how to triger the code path
in a test, probably would need to factor out parse_url