### PR TITLE
Improve checking for URLs in comments

### DIFF
--- a/tests/Unit/Validation/TextPolicyValidatorTest.php
+++ b/tests/Unit/Validation/TextPolicyValidatorTest.php
@@ -73,6 +73,7 @@ class TextPolicyValidatorTest extends \PHPUnit_Framework_TestCase {
 			[ 'Wikipedia ist so super, meine Eltern sagen es ist eine toll Seite. Berlin ist auch Super.' ],
 			[ 'Ich mag Wikipedia. Aber meine Seite ist auch toll. Googelt mal nach Bunsenbrenner!!!1' ],
 			[ 'Bei Wikipedia kann man eine Menge zum Thema Hamster finden. Hamster fressen voll viel Zeug alter!' ],
+			[ 'Manche Seiten haben keinen Inhalt, das finde ich sch...e' ], // this also tests the domain detection
 		];
 	}
 


### PR DESCRIPTION
Address the concerns in
https://github.com/wmde/FundraisingFrontend/pull/621#issue-169557470

While looking at the code, it was not quite clear if certain code paths
could be tested in unit test cases. Further research hinted at the fact
that the code paths might not be testable:

https://www.reddit.com/r/lolphp/comments/4sgcmj/on_seriously_malformed_urls_parse_url_may_return/
http://stackoverflow.com/questions/38956582/can-parse-url-ever-detect-a-malformed-url-when-combined-with-a-regular-expressio

The point of the TextPolicyValidator is to detect URLs but be lenient
for URL-lookalikes and non-existing URLs. So instead of `parse_url`,
which required 3 different code paths that could not be tested properly,
`filter_var` is now used for URL detection.