### PR TITLE
Improve fee selection view

### DIFF
--- a/app/js/lib/view_handler/fee_option_switcher.js
+++ b/app/js/lib/view_handler/fee_option_switcher.js
@@ -3,6 +3,10 @@
 var objectAssign = require( 'object-assign' ),
 	_ = require( 'underscore' ),
 
+	feePerMonth = function ( intervalInMonths, fee ) {
+		return ( 12 / intervalInMonths ) * fee;
+	},
+
 	/**
 	 * View Handler for enabling and disabling elements if the update value exceeds a certain threshold
 	 * @class
@@ -13,9 +17,8 @@ var objectAssign = require( 'object-assign' ),
 		elements: [],
 
 		update: function ( state ) {
-			var self = this;
 			_.each( this.elements, function ( feeOption ) {
-				var shouldBeDisabled = self.minimumFee[ state.addressType ] > 12 / state.paymentIntervalInMonths * parseFloat( feeOption.val() );
+				var shouldBeDisabled = this.minimumFee[ state.addressType ] > feePerMonth( state.paymentIntervalInMonths, parseFloat( feeOption.val() ) ) ;
 
 				if ( shouldBeDisabled ) {
 					feeOption.prop( 'checked', false );
@@ -23,7 +26,7 @@ var objectAssign = require( 'object-assign' ),
 				} else {
 					feeOption.prop( 'disabled', false );
 				}
-			} );
+			}, this );
 		}
 	};
 


### PR DESCRIPTION
The comparison involved quite a lot of operators, I moved them to a
function so we're left with only a comparison operator.

Used the `context` parameter for _.each to avoid manual context setting
with self=this.