### PR TITLE
Move tests to where they belong

### DIFF
--- a/contexts/DonatingContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/contexts/DonatingContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -2,14 +2,13 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\DataAccess;
 
 use Doctrine\ORM\EntityManager;
 use WMDE\Fundraising\Entities\Donation;
-use WMDE\Fundraising\Entities\MembershipApplication;
 use WMDE\Fundraising\Frontend\DonatingContext\DataAccess\DoctrineDonationRepository;
 use WMDE\Fundraising\Frontend\DonatingContext\Domain\Repositories\DonationRepository;
-use WMDE\Fundraising\Frontend\MembershipApplicationContext\DataAccess\DoctrineApplicationRepository;
+use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 
 /**
  * @licence GNU GPL v2+
@@ -319,73 +318,6 @@ class SerializedDataHandlingTest extends \PHPUnit_Framework_TestCase {
 		$dd->setPaymentType( $paymentType );
 		$dd->encodeAndSetData( $data );
 		$this->entityManager->persist( $dd );
-		$this->entityManager->flush();
-	}
-
-	/** @dataProvider encodedMembershipDataProvider */
-	public function testDataFieldOfMembershipApplicationIsInteractedWithCorrectly( $data ) {
-		$this->repository = new DoctrineApplicationRepository( $this->entityManager );
-		$this->storeMembershipApplication( $data );
-
-		$donation = $this->repository->getApplicationById( 1 );
-		$this->repository->storeApplication( $donation );
-
-		/** @var MembershipApplication $dma */
-		$dma = $this->entityManager->find( MembershipApplication::class, 1 );
-		$this->assertEquals( $data, $dma->getDecodedData() );
-	}
-
-	public function encodedMembershipDataProvider() {
-		return [
-			[
-				[
-					'member_agree' => '1',
-					'membership_fee_custom' => '',
-					'confirmationPage' => '10h16 Bestätigung-BEZ',
-					'confirmationPageCampaign' => 'MT15_WMDE_02',
-					'token' => '7998466$225c4e182d5b0f3d0e802624826200d21c900267',
-					'utoken' => 'c73d8d1b3e61a73f50bd37d0bf39f3930d77f02b',
-				]
-			],
-
-			[
-				[
-					'member_agree' => '1',
-					'membership_fee_custom' => '',
-					'confirmationPage' => '10h16 Bestätigung-BEZ',
-					'confirmationPageCampaign' => 'MT15_WMDE_02',
-					'token' => '1676175$26905b01f48c8c471f0617217540a8c82fdde52c',
-					'utoken' => '87bd8cedc7843525b87f287b1e3299f667eb7a22',
-				]
-			],
-
-			[
-				[
-					'member_agree' => '1',
-					'membership_fee_custom' => '',
-					'confirmationPage' => '10h16 Bestätigung',
-					'confirmationPageCampaign' => 'MT15_WMDE_02',
-					'token' => '3246619$c4e64cc3c49d8f8b8a0bdcf5788a029563ed9598',
-					'utoken' => '134bf8fce220de781d7b093711f36b5323ccfee5',
-				]
-			]
-		];
-	}
-
-	private function storeMembershipApplication( array $data ) {
-		$membershipAppl = new MembershipApplication();
-
-		$membershipAppl->setApplicantSalutation( 'Frau' );
-		$membershipAppl->setApplicantTitle( 'Dr.' );
-		$membershipAppl->setApplicantFirstName( 'Martha' );
-		$membershipAppl->setApplicantLastName( 'Muster' );
-		$membershipAppl->setCity( 'Smalltown' );
-		$membershipAppl->setPostcode( '12345' );
-		$membershipAppl->setAddress( 'Erlenkamp 12' );
-		$membershipAppl->setApplicantEmailAddress( 'martha.muster@mydomain.com' );
-
-		$membershipAppl->encodeAndSetData( $data );
-		$this->entityManager->persist( $membershipAppl );
 		$this->entityManager->flush();
 	}
 

--- a/contexts/DonatingContext/tests/Integration/UseCases/AddDonation/AddDonationPolicyValidatorTest.php
+++ b/contexts/DonatingContext/tests/Integration/UseCases/AddDonation/AddDonationPolicyValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\AddDonation;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\UseCases\AddDonation;
 
 use WMDE\Fundraising\Frontend\DonatingContext\UseCases\AddDonation\AddDonationPolicyValidator;
 use WMDE\Fundraising\Frontend\Tests\Data\ValidAddDonationRequest;

--- a/contexts/DonatingContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
+++ b/contexts/DonatingContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\AddDonation;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\UseCases\AddDonation;
 
 use PHPUnit_Framework_MockObject_MockObject;
 use WMDE\Euro\Euro;

--- a/contexts/DonatingContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
+++ b/contexts/DonatingContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\AddDonation;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\UseCases\AddDonation;
 
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\DonatingContext\Domain\Model\DonorName;

--- a/contexts/DonatingContext/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
+++ b/contexts/DonatingContext/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\CancelDonation;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\UseCases\CancelDonation;
 
 use WMDE\Fundraising\Frontend\DonatingContext\Authorization\DonationAuthorizer;
 use WMDE\Fundraising\Frontend\DonatingContext\Domain\Model\Donation;

--- a/contexts/DonatingContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
+++ b/contexts/DonatingContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\CreditCardPaymentNotification;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\UseCases\CreditCardPaymentNotification;
 
 use Psr\Log\NullLogger;
 use WMDE\Euro\Euro;

--- a/contexts/DonatingContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
+++ b/contexts/DonatingContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\HandlePayPalPaymentNotification;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\UseCases\HandlePayPalPaymentNotification;
 
 use Psr\Log\NullLogger;
 use WMDE\Fundraising\Frontend\DonatingContext\DataAccess\DoctrineDonationRepository;

--- a/contexts/DonatingContext/tests/Integration/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCaseTest.php
+++ b/contexts/DonatingContext/tests/Integration/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\ShowDonationConfirmation;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Integration\UseCases\ShowDonationConfirmation;
 
 use WMDE\Fundraising\Frontend\DonatingContext\UseCases\ShowDonationConfirmation\ShowDonationConfirmationRequest;
 use WMDE\Fundraising\Frontend\DonatingContext\UseCases\ShowDonationConfirmation\ShowDonationConfirmationUseCase;

--- a/contexts/DonatingContext/tests/Unit/UseCases/AddComment/AddCommentValidatorTest.php
+++ b/contexts/DonatingContext/tests/Unit/UseCases/AddComment/AddCommentValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Unit\UseCases\AddComment;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Unit\UseCases\AddComment;
 
 use WMDE\Fundraising\Frontend\DonatingContext\UseCases\AddComment\AddCommentRequest;
 use WMDE\Fundraising\Frontend\DonatingContext\UseCases\AddComment\AddCommentValidator;

--- a/contexts/DonatingContext/tests/Unit/UseCases/AddDonation/AddDonationRequestTest.php
+++ b/contexts/DonatingContext/tests/Unit/UseCases/AddDonation/AddDonationRequestTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Unit\UseCases\AddDonation;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Unit\UseCases\AddDonation;
 
 use WMDE\Fundraising\Frontend\DonatingContext\UseCases\AddDonation\AddDonationRequest;
 

--- a/contexts/DonatingContext/tests/Unit/UseCases/ListComments/CommentListTest.php
+++ b/contexts/DonatingContext/tests/Unit/UseCases/ListComments/CommentListTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Unit\UseCases\ListComments;
+namespace WMDE\Fundraising\Frontend\DonatingContext\Tests\Unit\UseCases\ListComments;
 
 use WMDE\Fundraising\Frontend\DonatingContext\Domain\Repositories\CommentWithAmount;
 use WMDE\Fundraising\Frontend\DonatingContext\UseCases\ListComments\CommentList;

--- a/contexts/MembershipApplicationContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/contexts/MembershipApplicationContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\MembershipApplicationContext\Tests\Integration\DataAccess;
+
+use Doctrine\ORM\EntityManager;
+use WMDE\Fundraising\Entities\MembershipApplication;
+use WMDE\Fundraising\Frontend\MembershipApplicationContext\DataAccess\DoctrineApplicationRepository;
+use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class SerializedDataHandlingTest extends \PHPUnit_Framework_TestCase {
+
+	/** @dataProvider encodedMembershipDataProvider */
+	public function testDataFieldOfMembershipApplicationIsInteractedWithCorrectly( $data ) {
+		$entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
+
+		$repository = new DoctrineApplicationRepository( $entityManager );
+		$this->storeMembershipApplication( $entityManager, $data );
+
+		$donation = $repository->getApplicationById( 1 );
+		$repository->storeApplication( $donation );
+
+		/** @var MembershipApplication $dma */
+		$dma = $entityManager->find( MembershipApplication::class, 1 );
+		$this->assertEquals( $data, $dma->getDecodedData() );
+	}
+
+	public function encodedMembershipDataProvider() {
+		return [
+			[
+				[
+					'member_agree' => '1',
+					'membership_fee_custom' => '',
+					'confirmationPage' => '10h16 Bestätigung-BEZ',
+					'confirmationPageCampaign' => 'MT15_WMDE_02',
+					'token' => '7998466$225c4e182d5b0f3d0e802624826200d21c900267',
+					'utoken' => 'c73d8d1b3e61a73f50bd37d0bf39f3930d77f02b',
+				]
+			],
+
+			[
+				[
+					'member_agree' => '1',
+					'membership_fee_custom' => '',
+					'confirmationPage' => '10h16 Bestätigung-BEZ',
+					'confirmationPageCampaign' => 'MT15_WMDE_02',
+					'token' => '1676175$26905b01f48c8c471f0617217540a8c82fdde52c',
+					'utoken' => '87bd8cedc7843525b87f287b1e3299f667eb7a22',
+				]
+			],
+
+			[
+				[
+					'member_agree' => '1',
+					'membership_fee_custom' => '',
+					'confirmationPage' => '10h16 Bestätigung',
+					'confirmationPageCampaign' => 'MT15_WMDE_02',
+					'token' => '3246619$c4e64cc3c49d8f8b8a0bdcf5788a029563ed9598',
+					'utoken' => '134bf8fce220de781d7b093711f36b5323ccfee5',
+				]
+			]
+		];
+	}
+
+	private function storeMembershipApplication( EntityManager $entityManager, array $data ) {
+		$membershipAppl = new MembershipApplication();
+
+		$membershipAppl->setApplicantSalutation( 'Frau' );
+		$membershipAppl->setApplicantTitle( 'Dr.' );
+		$membershipAppl->setApplicantFirstName( 'Martha' );
+		$membershipAppl->setApplicantLastName( 'Muster' );
+		$membershipAppl->setCity( 'Smalltown' );
+		$membershipAppl->setPostcode( '12345' );
+		$membershipAppl->setAddress( 'Erlenkamp 12' );
+		$membershipAppl->setApplicantEmailAddress( 'martha.muster@mydomain.com' );
+
+		$membershipAppl->encodeAndSetData( $data );
+		$entityManager->persist( $membershipAppl );
+		$entityManager->flush();
+	}
+
+}

--- a/contexts/MembershipApplicationContext/tests/Integration/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCaseTest.php
+++ b/contexts/MembershipApplicationContext/tests/Integration/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\CancelMembershipApplication;
+namespace WMDE\Fundraising\Frontend\MembershipApplicationContext\Tests\Integration\UseCases\CancelMembershipApplication;
 
 use WMDE\Fundraising\Frontend\MembershipApplicationContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipApplicationContext\Domain\Model\Application;

--- a/contexts/MembershipApplicationContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
+++ b/contexts/MembershipApplicationContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Unit\UseCases\ApplyForMembership;
+namespace WMDE\Fundraising\Frontend\MembershipApplicationContext\Tests\Unit\UseCases\ApplyForMembership;
 
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\MembershipApplicationContext\Domain\Model\ApplicantAddress;

--- a/contexts/MembershipApplicationContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/contexts/MembershipApplicationContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Unit\UseCases\ApplyForMembership;
+namespace WMDE\Fundraising\Frontend\MembershipApplicationContext\Tests\Unit\UseCases\ApplyForMembership;
 
 use WMDE\Fundraising\Frontend\MembershipApplicationContext\UseCases\ApplyForMembership\ApplicationValidationResult as Result;
 use WMDE\Fundraising\Frontend\MembershipApplicationContext\UseCases\ApplyForMembership\ApplyForMembershipRequest;

--- a/contexts/PaymentContext/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
+++ b/contexts/PaymentContext/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\GenerateIban;
+namespace WMDE\Fundraising\Frontend\PaymentContext\Tests\Integration\UseCases\GenerateIban;
 
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\BankDataConverter;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankData;

--- a/contexts/SubscriptionContext/tests/Integration/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCaseTest.php
+++ b/contexts/SubscriptionContext/tests/Integration/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCaseTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Integration\UseCases\ConfirmSubscription;
+namespace WMDE\Fundraising\Frontend\SubscriptionContext\Tests\Integration\UseCases\ConfirmSubscription;
 
 use PHPUnit_Framework_MockObject_MockObject;
 use WMDE\Fundraising\Entities\Address;

--- a/contexts/SubscriptionContext/tests/Unit/UseCases/AddSubscription/SubscriptionRequestTest.php
+++ b/contexts/SubscriptionContext/tests/Unit/UseCases/AddSubscription/SubscriptionRequestTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Unit\UseCases\AddSubscription;
+namespace WMDE\Fundraising\Frontend\SubscriptionContext\Tests\Unit\UseCases\AddSubscription;
 
 use WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\AddSubscription\SubscriptionRequest;
 

--- a/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManager;
 use WMDE\Fundraising\Entities\Donation;
 use WMDE\Fundraising\Entities\MembershipApplication;
 use WMDE\Fundraising\Frontend\DonatingContext\DataAccess\DoctrineDonationRepository;
+use WMDE\Fundraising\Frontend\DonatingContext\Domain\Repositories\DonationRepository;
 use WMDE\Fundraising\Frontend\MembershipApplicationContext\DataAccess\DoctrineApplicationRepository;
 
 /**
@@ -19,7 +20,7 @@ class SerializedDataHandlingTest extends \PHPUnit_Framework_TestCase {
 	/** @var EntityManager */
 	private $entityManager;
 
-	/** @var \WMDE\Fundraising\Frontend\DonatingContext\Domain\Repositories\DonationRepository */
+	/** @var DonationRepository */
 	private $repository;
 
 	public function setUp() {


### PR DESCRIPTION
This is a follow up to the earlier split into context directories,
and then moving of those to contexts/