### PR TITLE
Avoid exception with negative donation amount

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -168,8 +168,12 @@ class AddDonationHandler {
 
 	private function getEuroAmountFromString( string $amount ) {
 		$locale = 'de_DE'; // TODO: make this configurable for multilanguage support
+		try {
+			return Euro::newFromFloat( ( new AmountParser( $locale ) )->parseAsFloat( $amount ) );
+		} catch ( \InvalidArgumentException $ex ) {
+			return Euro::newFromCents( 0 );
+		}
 
-		return Euro::newFromFloat( ( new AmountParser( $locale ) )->parseAsFloat( $amount ) );
 	}
 
 	private function isSubmissionAllowed( Request $request ) {

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -408,6 +408,25 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
+	public function testGivenNegativeDonationAmount_formIsReloadedAndPrefilledWithZero() {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$factory->setNullMessenger();
+
+			$formValues = $this->newInvalidFormInput();
+			$formValues['betrag'] = '-5,00';
+
+			$client->request(
+				'POST',
+				'/donation/add',
+				$formValues
+			);
+
+			$response = $client->getResponse()->getContent();
+
+			$this->assertContains( 'Amount: 0,00', $response );
+		} );
+	}
+
 	private function newInvalidFormInput() {
 		return [
 			'betrag' => '0',

--- a/tests/EdgeToEdge/Routes/DefaultRouteTest.php
+++ b/tests/EdgeToEdge/Routes/DefaultRouteTest.php
@@ -24,13 +24,27 @@ class DefaultRouteTest extends WebRouteTestCase {
 			]
 		);
 
-		$this->assertParametersArePassedToTemplate( $client->getResponse()->getContent() );
-	}
-
-	private function assertParametersArePassedToTemplate( string $responseContent ) {
+		$responseContent = $client->getResponse()->getContent();
 		$this->assertContains( 'Amount: 12,34', $responseContent );
 		$this->assertContains( 'Payment type: UEB', $responseContent );
 		$this->assertContains( 'Interval: 6', $responseContent );
 	}
 
+	public function testWhenFormParametersContainNegativeAmount_zeroAmountIsPassedToTheTemplate() {
+		$client = $this->createClient();
+		$client->request(
+			'GET',
+			'/',
+			[
+				'betrag' => '-12,34',
+				'zahlweise' => 'UEB',
+				'periode' => 6
+			]
+		);
+
+		$responseContent = $client->getResponse()->getContent();
+		$this->assertContains( 'Amount: 0,00', $responseContent );
+		$this->assertContains( 'Payment type: UEB', $responseContent );
+		$this->assertContains( 'Interval: 6', $responseContent );
+	}
 }


### PR DESCRIPTION
Since the Euro class is used for building the requests and it does not
allow for negative values, we initialize it with 0 if the amount is
lower than 0.