### PR TITLE
fix class constant names

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -518,9 +518,9 @@ $app->get( '/purge-cache', function( Request $request ) use ( $ffFactory ) {
 
 	return new Response(
 		[
-			AuthorizedCachePurger::RESPONSE_SUCCESS => 'SUCCESS',
-			AuthorizedCachePurger::RESPONSE_ERROR => 'ERROR',
-			AuthorizedCachePurger::RESPONSE_ACCESS_DENIED=> 'ACCESS DENIED'
+			AuthorizedCachePurger::RESULT_SUCCESS => 'SUCCESS',
+			AuthorizedCachePurger::RESULT_ERROR => 'ERROR',
+			AuthorizedCachePurger::RESULT_ACCESS_DENIED=> 'ACCESS DENIED'
 		][$response]
 	);
 } );

--- a/tests/EdgeToEdge/Routes/PurgeCacheRouteTest.php
+++ b/tests/EdgeToEdge/Routes/PurgeCacheRouteTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge\Routes;
+
+use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class PurgeCacheRouteTest extends WebRouteTestCase {
+
+	const INVALID_SECRET = 'pedo mellon a minno';
+
+	public function testGivenInvalidSecret_responseIsReturned() {
+		$client = $this->createClient();
+
+		$client->request(
+			'GET',
+			'/purge-cache',
+			[
+				'secret' => self::INVALID_SECRET
+			]
+		);
+
+		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+		$this->assertSame( 'ACCESS DENIED', $client->getResponse()->getContent() );
+	}
+
+}


### PR DESCRIPTION
#660 broke the route. I'm introducing a simple route test just for the failure case to make sure the route exists. Everything else is covered in the integration test.