### PR TITLE
preserve membership application status

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2495,16 +2495,16 @@
         },
         {
             "name": "wmde/fundraising-store",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/FundraisingStore.git",
-                "reference": "644d37299381ffc4e11e200dec8d4ef8ba474712"
+                "reference": "89a19bb8418938e2937ba541c5049b8c7fab18fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/FundraisingStore/zipball/644d37299381ffc4e11e200dec8d4ef8ba474712",
-                "reference": "644d37299381ffc4e11e200dec8d4ef8ba474712",
+                "url": "https://api.github.com/repos/wmde/FundraisingStore/zipball/89a19bb8418938e2937ba541c5049b8c7fab18fb",
+                "reference": "89a19bb8418938e2937ba541c5049b8c7fab18fb",
                 "shasum": ""
             },
             "require": {
@@ -2538,7 +2538,7 @@
                 "GPL-2.0+"
             ],
             "description": "Persistence services around the fundraising database",
-            "time": "2016-08-03 08:41:34"
+            "time": "2016-09-28 15:30:18"
         }
     ],
     "packages-dev": [

--- a/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
+++ b/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
@@ -223,4 +223,14 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit_Framework_Tes
 		$this->assertTrue( $application->isCancelled() );
 	}
 
+	public function testGivenDoctrineApplicationWithCancelledFlag_initialStatusIsPreserved() {
+		$application = ValidMembershipApplication::newDomainEntity();
+		$application->cancel();
+
+		$this->newRepository()->storeApplication( $application );
+		$doctrineApplication = $this->getApplicationFromDatabase( $application->getId() );
+
+		$this->assertSame( DoctrineApplication::STATUS_CONFIRMED, $doctrineApplication->getDataObject()->getPreservedStatus() );
+	}
+
 }

--- a/tests/Data/ValidMembershipApplication.php
+++ b/tests/Data/ValidMembershipApplication.php
@@ -115,6 +115,7 @@ class ValidMembershipApplication {
 	private function createDoctrineApplication(): DoctrineMembershipApplication {
 		$application = new DoctrineMembershipApplication();
 
+		$application->setStatus( DoctrineMembershipApplication::STATUS_CONFIRMED );
 		$application->setApplicantFirstName( self::APPLICANT_FIRST_NAME );
 		$application->setApplicantLastName( self::APPLICANT_LAST_NAME );
 		$application->setApplicantSalutation( self::APPLICANT_SALUTATION );


### PR DESCRIPTION
The status constants of membership applications can be positive and negative which in mixed constellations lead to an ambiguous status. Thus, the only positive status is preserved when any negative status is applied. This resembles the behaviour the old application.

This depends on wmde/FundraisingStore#100. The build will fail until that is merged.