### PR TITLE
Add legacy routing

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -496,9 +496,25 @@ $app->get( '/', function ( Application $app, Request $request ) {
 	);
 } );
 
+// TODO Figure out how to rewrite with Nginx
+// See https://serverfault.com/questions/805881/nginx-populate-request-uri-with-rewritten-url
+$app->post(
+	'/spenden/paypal_handler.php',
+	function ( Request $request ) use ( $ffFactory ) {
+		return ( new PayPalNotificationHandler( $ffFactory ) )->handle( $request );
+	}
+);
+
 // redirect display page requests from old URLs
 $app->get( '/spenden/{page}', function( Application $app, Request $request, string $page ) {
-	return ( new RouteRedirectionHandler( $app, $request->getQueryString() ) )->handle( '/page/' . $page );
+	// Poor man's rewrite until someone has figured out how to do this with Nginx without breaking REQUEST_URI
+	// See https://serverfault.com/questions/805881/nginx-populate-request-uri-with-rewritten-url
+	switch ( $page ) {
+		case 'Mitgliedschaft':
+			return ( new RouteRedirectionHandler( $app, $request->getQueryString() ) )->handle( '/page/MembershipApplication' );
+		default:
+			return ( new RouteRedirectionHandler( $app, $request->getQueryString() ) )->handle( '/page/' . $page );
+	}
 } )->assert( 'page', '[a-zA-Z_\-\s\x7f-\xff]+' );
 
 // redirect different formats of comment lists

--- a/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
+++ b/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
@@ -14,11 +14,11 @@ class RouteRedirectionTest extends WebRouteTestCase {
 
 	public function simplePageDisplayProvider() {
 		return [
-			[ '/spenden/Mitgliedschaft', '/page/Mitgliedschaft' ],
+			[ '/spenden/Mitgliedschaft', '/page/MembershipApplication' ],
 			[ '/spenden/Fördermitgliedschaft', '/page/Fördermitgliedschaft' ],
 			[ '/spenden/Kontaktformular', '/page/Kontaktformular' ],
 			[ '/spenden/Ihre_Spende_wirkt', '/page/Ihre_Spende_wirkt' ],
-			[ '/spenden/Mitgliedschaft?bar=baz&foo=bar', '/page/Mitgliedschaft?bar=baz&foo=bar' ],
+			[ '/spenden/Mitgliedschaft?bar=baz&foo=bar', '/page/MembershipApplication?bar=baz&foo=bar' ],
 		];
 	}
 


### PR DESCRIPTION
After several hours of trying to get Nginx rewriting to work (together
with having the correct value for REQUEST_URI which is needed for our PHP
routing) I gave up and implemented the legacy routing in PHP.

When
https://serverfault.com/questions/805881/nginx-populate-request-uri-with-rewritten-url
is answered, this commit can be reverted.