### PR TITLE
Changed wrong field name for company

### DIFF
--- a/src/Presentation/Presenters/DonationFormViolationPresenter.php
+++ b/src/Presentation/Presenters/DonationFormViolationPresenter.php
@@ -68,7 +68,7 @@ class DonationFormViolationPresenter {
 			'addressType' => $request->getDonorType(),
 			'salutation' => $request->getDonorSalutation(),
 			'title' => $request->getDonorTitle(),
-			'company' => $request->getDonorCompany(),
+			'companyName' => $request->getDonorCompany(),
 			'firstName' => $request->getDonorFirstName(),
 			'lastName' => $request->getDonorLastName(),
 		];


### PR DESCRIPTION
initialValues expects `companyName` instead of `company`.

Also fixed the wrong field name in the wiki template.