### PR TITLE
Improve naming of mailers

### DIFF
--- a/src/ApplicationContext/UseCases/GetInTouch/GetInTouchUseCase.php
+++ b/src/ApplicationContext/UseCases/GetInTouch/GetInTouchUseCase.php
@@ -18,14 +18,14 @@ use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
 class GetInTouchUseCase {
 
 	private $validator;
-	private $forwardingMailer;
-	private $confirmingMailer;
+	private $operatorMailer;
+	private $userMailer;
 
-	public function __construct( GetInTouchValidator $validator, TemplateBasedMailer $forwardingMailer,
-								 TemplateBasedMailer $confirmingMailer ) {
+	public function __construct( GetInTouchValidator $validator, TemplateBasedMailer $operatorMailer,
+								 TemplateBasedMailer $userMailer ) {
 		$this->validator = $validator;
-		$this->forwardingMailer = $forwardingMailer;
-		$this->confirmingMailer = $confirmingMailer;
+		$this->operatorMailer = $operatorMailer;
+		$this->userMailer = $userMailer;
 	}
 
 	/**
@@ -38,21 +38,23 @@ class GetInTouchUseCase {
 			return ValidationResponse::newFailureResponse( $validationResult->getViolations() );
 		}
 
-		$this->forwardContactRequest( $request );
-		$this->confirmToUser( $request );
+		$this->sendContactRequestToOperator( $request );
+		$this->sendNotificationToUser( $request );
 
 		return ValidationResponse::newSuccessResponse();
 	}
 
-	private function forwardContactRequest( GetInTouchRequest $request ) {
-		$this->forwardingMailer->sendMailToOperator(
+	private function sendContactRequestToOperator( GetInTouchRequest $request ) {
+		$this->operatorMailer->sendMailToOperator(
 			new EmailAddress( $request->getEmailAddress() ),
 			$this->getTemplateParams( $request )
 		);
 	}
 
-	private function confirmToUser( GetInTouchRequest $request ) {
-		$this->confirmingMailer->sendMail( new EmailAddress( $request->getEmailAddress() ) );
+	private function sendNotificationToUser( GetInTouchRequest $request ) {
+		// We don't send any template input here to avoid misusing the form for spam.
+		// The user just gets a "We received your inquiry and will contact you shortly" message
+		$this->userMailer->sendMail( new EmailAddress( $request->getEmailAddress() ) );
 	}
 
 	private function getTemplateParams( GetInTouchRequest $request ) {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -667,19 +667,19 @@ class FunFunFactory {
 	public function newGetInTouchUseCase() {
 		return new GetInTouchUseCase(
 			$this->getContactValidator(),
-			$this->newContactForwardingMailer(),
-			$this->newContactConfirmationMailer()
+			$this->newContactOperatorMailer(),
+			$this->newContactUserMailer()
 		);
 	}
 
-	private function newContactConfirmationMailer(): TemplateBasedMailer {
+	private function newContactUserMailer(): TemplateBasedMailer {
 		return $this->newTemplateMailer(
 			new TwigTemplate( $this->getTwig(), 'KontaktMailExtern.twig' ),
 			'mail_subject_getintouch'
 		);
 	}
 
-	private function newContactForwardingMailer(): TemplateBasedMailer {
+	private function newContactOperatorMailer(): TemplateBasedMailer {
 		return $this->newTemplateMailer(
 			new TwigTemplate( $this->getTwig(), 'KontaktMailIntern.twig' ),
 			'mail_subject_getintouch_forward'

--- a/tests/Fixtures/TemplateBasedMailerSpy.php
+++ b/tests/Fixtures/TemplateBasedMailerSpy.php
@@ -22,11 +22,11 @@ class TemplateBasedMailerSpy extends TemplateBasedMailer {
 	}
 
 	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ) {
-		$this->sendMailCalls[] = func_get_args();
+		$this->sendMailCalls[] = [ $recipient, $templateArguments ];
 	}
 
 	public function sendMailToOperator( EmailAddress $replyToAddress, array $templateArguments = [] ) {
-		$this->sendMailCalls[] = func_get_args();
+		$this->sendMailCalls[] = [ $replyToAddress, $templateArguments ];
 	}
 
 	public function getSendMailCalls(): array {


### PR DESCRIPTION
Change names of mailers according to the people who receive mails.
Add a test to check if the user mail is actually sent.
Improve TemplateBasedMailerSpy to accept calls without template params
(func_get_args doesn't get default params, only the real params of the
function call).