### PR TITLE
Prefix asset files

### DIFF
--- a/app/templates/BaseLayout.twig
+++ b/app/templates/BaseLayout.twig
@@ -35,7 +35,7 @@
     <script type="text/javascript" src="{$ basepath $}/skin/10h16/_js/lightbox_init.js"></script>
 
     <script type="text/javascript" src="{$ basepath $}/res/js/lib/jquery.als-1.7.min.js"></script>
-    <script type="text/javascript" src="{$ basepath $}/res/js/wmde.js"></script>
+    <script type="text/javascript" src="{$ basepath $}/{$ 'res/js/wmde.js'|prefix_file $}"></script>
     <script type="text/javascript" src="{$ basepath $}/res/js/donationTicker.js"></script>
     <script type="text/javascript" src="{$ basepath $}/res/js/donationCommentsLightbox.js"></script>
     {% endblock %}

--- a/deployment/tasks/deploy_to_server.yml
+++ b/deployment/tasks/deploy_to_server.yml
@@ -29,6 +29,9 @@
 - name: Create var/cache dir
   file: path={{ app_dir }}/{{ release_prefix }}{{ release_name }}/var/cache owner={{app_owner}} group={{app_group}} state=directory mode=775
 
+- name: Create cache-busting prefix
+  copy: dest={{ app_dir }}/{{ release_prefix }}{{ release_name }}/var/file_prefix.txt content="{{ release_name|hash('md5') }}" owner={{app_owner}} group={{app_group}}
+
 - name: Create symlink to log dir
   file: src={{ app_dir }}/{{ logs_dir }} dest={{ app_dir }}/{{ release_prefix }}{{ release_name }}/var/log state=link
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -104,6 +104,7 @@ use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
 use WMDE\Fundraising\Frontend\Presentation\CreditCardUrlConfig;
 use WMDE\Fundraising\Frontend\Presentation\CreditCardUrlGenerator;
 use WMDE\Fundraising\Frontend\Presentation\DonationConfirmationPageSelector;
+use WMDE\Fundraising\Frontend\Presentation\FilePrefixer;
 use WMDE\Fundraising\Frontend\Presentation\GreetingGenerator;
 use WMDE\Fundraising\Frontend\Presentation\PayPalUrlConfig;
 use WMDE\Fundraising\Frontend\Presentation\PayPalUrlGenerator;
@@ -343,8 +344,13 @@ class FunFunFactory {
 				$twigFactory->newTranslationExtension( $this->getTranslator() ),
 				new Twig_Extensions_Extension_Intl()
 			];
+			$filters = [
+				$twigFactory->newFilePrefixFilter(
+					$this->newFilePrefixer()
+				)
+			];
 
-			return $twigFactory->create( $loaders, $extensions );
+			return $twigFactory->create( $loaders, $extensions, $filters );
 		} );
 
 		$pimple['messenger'] = $pimple->share( function() {
@@ -1184,6 +1190,18 @@ class FunFunFactory {
 
 	private function newIbanValidator(): IbanValidator {
 		return new IbanValidator( $this->newBankDataConverter(), $this->config['banned-ibans'] );
+	}
+
+	private function newFilePrefixer(): FilePrefixer {
+		return new FilePrefixer( $this->getFilePrefix() );
+	}
+
+	private function getFilePrefix(): string {
+		$prefixContentFile = $this->getVarPath() . '/file_prefix.txt';
+		if ( !file_exists( $prefixContentFile ) ) {
+			return '';
+		}
+		return $prefix = preg_replace( '/[^0-9a-f]/', '', file_get_contents( $prefixContentFile ) );
 	}
 
 }

--- a/src/Factories/TwigFactory.php
+++ b/src/Factories/TwigFactory.php
@@ -13,6 +13,7 @@ use Twig_Loader_Array;
 use Twig_Loader_Filesystem;
 use WMDE\Fundraising\Frontend\ApplicationContext\Infrastructure\PageRetriever;
 use WMDE\Fundraising\Frontend\Presentation\Content\TwigPageLoader;
+use WMDE\Fundraising\Frontend\Presentation\FilePrefixer;
 
 /**
  * @license GNU GPL v2+
@@ -30,7 +31,7 @@ class TwigFactory {
 		$this->cachePath = $cachePath;
 	}
 
-	public function create( array $loaders, array $extensions ): Twig_Environment {
+	public function create( array $loaders, array $extensions, array $filters ): Twig_Environment {
 		$options = [];
 
 		if ( $this->config['enable-cache'] ) {
@@ -41,6 +42,10 @@ class TwigFactory {
 			new \Twig_Loader_Chain( $loaders ),
 			$options
 		);
+
+		foreach ( $filters as $filter ) {
+			$twig->addFilter( $filter );
+		}
 
 		foreach ( $extensions as $ext ) {
 			$twig->addExtension( $ext );
@@ -116,5 +121,9 @@ class TwigFactory {
 
 	public function newTranslationExtension( TranslatorInterface $translator ) {
 		return new TranslationExtension( $translator );
+	}
+
+	public function newFilePrefixFilter( FilePrefixer $filePrefixer ) {
+		return new \Twig_SimpleFilter( 'prefix_file', [ $filePrefixer, 'prefixFile' ] );
 	}
 }

--- a/src/Presentation/FilePrefixer.php
+++ b/src/Presentation/FilePrefixer.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Presentation;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class FilePrefixer {
+
+	private $filePrefix;
+
+	public function __construct( string $filePrefix ) {
+		$this->filePrefix = $filePrefix;
+	}
+
+	public function prefixFile( $filename ) {
+		if ( !$this->filePrefix ) {
+			return $filename;
+		}
+		$pathParts = pathinfo( $filename );
+		$dirPrefix = $pathParts['dirname'] === '.' ? '' : $pathParts['dirname'] . DIRECTORY_SEPARATOR;
+		return $dirPrefix . $this->filePrefix . '.' . $pathParts['basename'];
+	}
+
+}

--- a/tests/Unit/Presentation/FilePrefixerTest.php
+++ b/tests/Unit/Presentation/FilePrefixerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace Unit\Presentation;
+
+use WMDE\Fundraising\Frontend\Presentation\FilePrefixer;
+
+class FilePrefixerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenNoFilePrefixes_fileNameIsNotChanged() {
+		$prefixer = new FilePrefixer( '' );
+		$this->assertSame( 'wmde.js', $prefixer->prefixFile( 'wmde.js' ) );
+	}
+
+	public function testGivenPrefixes_prefixIsPrependedToFilename() {
+		$prefixer = new FilePrefixer( 'badcaffee' );
+		$this->assertSame( 'badcaffee.wmde.js', $prefixer->prefixFile( 'wmde.js' ) );
+	}
+
+	public function testGivenPrefixesWithPath_prefixIsPrependedToFilename() {
+		$prefixer = new FilePrefixer( 'badcaffee' );
+		$this->assertSame( 'res/js/badcaffee.wmde.js', $prefixer->prefixFile( 'res/js/wmde.js' ) );
+	}
+
+}


### PR DESCRIPTION
Goal: Add a cache-busting prefix to asset files.
This solves https://phabricator.wikimedia.org/T147399

The prerequisite Nginx configuration from the [infrastructure repo](
https://github.com/wmde/fundraising-infrastructure/pull/62/commits/eff4e55f5696cd2628e75c62fc4016e760f1825b) is already deployed on the servers.

In this PR:
- Add Twig extension that adds a file prefix, if one is configured.
- Generate a prefix value when deploying