### PR TITLE
Fix cache-busting prefix

### DIFF
--- a/deployment/tasks/deploy_to_server.yml
+++ b/deployment/tasks/deploy_to_server.yml
@@ -36,7 +36,7 @@
   file: path={{ app_dir }}/{{ release_name }}/var/cache owner={{app_owner}} group={{app_group}} state=directory mode=775
 
 - name: Create cache-busting prefix
-  copy: dest={{ app_dir }}/{{ release_prefix }}{{ release_name }}/var/file_prefix.txt content="{{ release_name|hash('md5') }}" owner={{app_owner}} group={{app_group}}
+  copy: dest={{ app_dir }}/{{ release_name }}/var/file_prefix.txt content="{{ release_name|hash('md5') }}" owner={{app_owner}} group={{app_group}}
 
 - name: Create symlink to log dir
   file: src={{ app_dir }}/{{ logs_dir }} dest={{ app_dir }}/{{ release_name }}/var/log state=link


### PR DESCRIPTION
There was one prefix too many, introduced by the changes in
4d8e91ef1059db7ff3dd95182ca9a758294e294d