### PR TITLE
Fix paypal handler

### DIFF
--- a/app/RouteHandlers/PayPalNotificationHandler.php
+++ b/app/RouteHandlers/PayPalNotificationHandler.php
@@ -32,7 +32,7 @@ class PayPalNotificationHandler {
 		} catch ( PayPalPaymentNotificationVerifierException $e ) {
 			// TODO: let PayPal resend IPN?
 
-			return new Response( '', Response::HTTP_INTERNAL_SERVER_ERROR );
+			return $this->createErrorResponse( $e );
 		}
 
 		// TODO: check txn_type
@@ -77,6 +77,22 @@ class PayPalNotificationHandler {
 			->setPaymentTimestamp( $postRequest->get( 'payment_date', '' ) )
 			->setPaymentStatus( $postRequest->get( 'payment_status', '' ) )
 			->setPaymentType( $postRequest->get( 'payment_type', '' ) );
+	}
+
+	private function createErrorResponse( PayPalPaymentNotificationVerifierException $e ): Response {
+		switch ( $e->getCode() ) {
+			case PayPalPaymentNotificationVerifierException::ERROR_UNSUPPORTED_STATUS;
+				// Just ignore IPN notices with a status we don't handle
+				return new Response( '', Response::HTTP_OK );
+			case PayPalPaymentNotificationVerifierException::ERROR_WRONG_RECEIVER:
+				return new Response( $e->getMessage(), Response::HTTP_FORBIDDEN );
+			case PayPalPaymentNotificationVerifierException::ERROR_VERIFICATION_FAILED:
+				return new Response( $e->getMessage(), Response::HTTP_FORBIDDEN );
+			case PayPalPaymentNotificationVerifierException::ERROR_UNSUPPORTED_CURRENCY:
+				return new Response( $e->getMessage(), Response::HTTP_NOT_ACCEPTABLE );
+			default:
+				return new Response( $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR );
+		}
 	}
 
 }

--- a/app/RouteHandlers/PayPalNotificationHandler.php
+++ b/app/RouteHandlers/PayPalNotificationHandler.php
@@ -31,7 +31,7 @@ class PayPalNotificationHandler {
 			$this->ffFactory->getPayPalPaymentNotificationVerifier()->verify( $post->all() );
 		} catch ( PayPalPaymentNotificationVerifierException $e ) {
 			// TODO: let PayPal resend IPN?
-			// TODO: is this the right Response?
+
 			return new Response( '', Response::HTTP_INTERNAL_SERVER_ERROR );
 		}
 

--- a/src/Infrastructure/LoggingPaymentNotificationVerifier.php
+++ b/src/Infrastructure/LoggingPaymentNotificationVerifier.php
@@ -30,8 +30,13 @@ class LoggingPaymentNotificationVerifier implements PaymentNotificationVerifier 
 		try {
 			$this->verifier->verify( $request );
 		} catch ( PayPalPaymentNotificationVerifierException $exception ) {
-			$this->logger->log( $this->logLevel, $exception->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $exception ] );
-			$this->logger->log( LogLevel::DEBUG, 'Paypal request data', $request );
+			if ( $exception->getCode() == PayPalPaymentNotificationVerifierException::ERROR_UNSUPPORTED_STATUS ) {
+				$this->logger->log( LogLevel::INFO, 'Unsupported payment_status', $request );
+			} else {
+				$this->logger->log( $this->logLevel, $exception->getMessage(), [ self::CONTEXT_EXCEPTION_KEY => $exception ] );
+				$this->logger->log( LogLevel::DEBUG, 'Paypal request data', $request );
+			}
+
 			throw $exception;
 		}
 	}

--- a/src/Infrastructure/PayPalPaymentNotificationVerifier.php
+++ b/src/Infrastructure/PayPalPaymentNotificationVerifier.php
@@ -40,10 +40,6 @@ class PayPalPaymentNotificationVerifier implements PaymentNotificationVerifier {
 			throw new PayPalPaymentNotificationVerifierException( 'Payment status is not configured as confirmable' );
 		}
 
-		if ( !$this->hasValidItemName( $request ) ) {
-			throw new PayPalPaymentNotificationVerifierException( 'Invalid item name' );
-		}
-
 		if ( !$this->hasValidCurrencyCode( $request ) ) {
 			throw new PayPalPaymentNotificationVerifierException( 'Invalid currency code' );
 		}
@@ -77,11 +73,6 @@ class PayPalPaymentNotificationVerifier implements PaymentNotificationVerifier {
 	private function hasAllowedPaymentStatus( array $request ): bool {
 		return array_key_exists( 'payment_status', $request ) &&
 			in_array( $request['payment_status'], self::ALLOWED_STATUSES );
-	}
-
-	private function hasValidItemName( array $request ): bool {
-		return array_key_exists( 'item_name', $request ) &&
-			$request['item_name'] === $this->config['item-name'];
 	}
 
 	private function hasValidCurrencyCode( array $request ): bool {

--- a/src/Infrastructure/PayPalPaymentNotificationVerifier.php
+++ b/src/Infrastructure/PayPalPaymentNotificationVerifier.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Client;
  */
 class PayPalPaymentNotificationVerifier implements PaymentNotificationVerifier {
 
-	/* private */ const ALLOWED_STATUSES = [ 'Completed' ];
+	/* private */ const ALLOWED_STATUSES = [ 'Completed', 'Processed' ];
 	/* private */ const ALLOWED_CURRENCY_CODES = [ 'EUR' ];
 
 	private $httpClient;

--- a/src/Infrastructure/PayPalPaymentNotificationVerifierException.php
+++ b/src/Infrastructure/PayPalPaymentNotificationVerifierException.php
@@ -10,8 +10,10 @@ namespace WMDE\Fundraising\Frontend\Infrastructure;
  */
 class PayPalPaymentNotificationVerifierException extends \RuntimeException {
 
-	public function __construct( string $message, \Exception $previous = null ) {
-		parent::__construct( $message, 0, $previous );
-	}
+	const ERROR_UNKNOWN = 0;
+	const ERROR_UNSUPPORTED_STATUS = 1;
+	const ERROR_WRONG_RECEIVER = 2;
+	const ERROR_VERIFICATION_FAILED = 3;
+	const ERROR_UNSUPPORTED_CURRENCY = 4;
 
 }


### PR DESCRIPTION
Various code changes to make the handling behave more like the old application.

Based on the exceptions that were thrown on the server, both either stemming from `item_name` or `payment_status`