### PR TITLE
switch amount parser locale to en_EN

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -381,7 +381,7 @@ $app->post(
 // Show a donation form with pre-filled payment values, e.g. when coming from a banner
 $app->get( 'donation/new', function ( Request $request ) use ( $ffFactory ) {
 	try {
-		$amount = Euro::newFromFloat( ( new AmountParser( 'de_DE' ) )->parseAsFloat(
+		$amount = Euro::newFromFloat( ( new AmountParser( 'en_EN' ) )->parseAsFloat(
 			$request->get( 'betrag_auswahl', $request->get( 'amountGiven', '' ) ) )
 		);
 	} catch ( \InvalidArgumentException $ex ) {

--- a/tests/EdgeToEdge/Routes/DefaultRouteTest.php
+++ b/tests/EdgeToEdge/Routes/DefaultRouteTest.php
@@ -18,7 +18,7 @@ class DefaultRouteTest extends WebRouteTestCase {
 			'GET',
 			'/',
 			[
-				'amountGiven' => '12,34',
+				'amountGiven' => '12.34',
 				'zahlweise' => 'UEB',
 				'periode' => 6
 			]
@@ -36,7 +36,7 @@ class DefaultRouteTest extends WebRouteTestCase {
 			'GET',
 			'/',
 			[
-				'amountGiven' => '-12,34',
+				'amountGiven' => '-12.34',
 				'zahlweise' => 'UEB',
 				'periode' => 6
 			]

--- a/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
@@ -39,7 +39,7 @@ class NewDonationRouteTest extends WebRouteTestCase {
 			],
 			[
 				[
-					'amountGiven' => '123,45',
+					'amountGiven' => '123.45',
 					'zahlweise' => 'PPL',
 					'periode' => 6
 				],


### PR DESCRIPTION
The banners are converting the amount input into a parsable float before sending POSTing. To make sure older banners are still working, I changed the locale the `AmountParser` is using to `en_EN`.

see [phab:T148039](https://phabricator.wikimedia.org/T148039)