### PR TITLE
Set different logger names for entry points

### DIFF
--- a/web/index.dev.php
+++ b/web/index.dev.php
@@ -40,7 +40,7 @@ $ffFactory = call_user_func( function() {
 } );
 
 $ffFactory->setLogger( call_user_func( function() use ( $ffFactory ) {
-	$logger = new Logger( 'WMDE Fundraising Frontend logger' );
+	$logger = new Logger( 'index_dev_php' );
 
 	$streamHandler = new StreamHandler(
 		$ffFactory->getLoggingPath() . '/' . ( new \DateTime() )->format( 'Y-m-d\TH:i:s\Z' ) . '.log'

--- a/web/index.php
+++ b/web/index.php
@@ -30,7 +30,7 @@ $ffFactory = call_user_func( function() {
 $ffFactory->enablePageCache();
 
 $ffFactory->setLogger( call_user_func( function() use ( $ffFactory ) {
-	$logger = new Logger( 'index.php logger' );
+	$logger = new Logger( 'index_php' );
 
 	$streamHandler = new StreamHandler(
 		$ffFactory->getLoggingPath() . '/error-debug.log'


### PR DESCRIPTION
The logger "names" (channels) now designate what entry point was used.
Until we have different channels for different parts of the application
(db_layer, use_case, service_name, etc) the entry point adds useful
information.

Using underscore instead of dots for the file name avoids confusion when
looking for the source of an error and when grepping through the files.