### PR TITLE
Fix paypal donation update

### DIFF
--- a/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
+++ b/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
@@ -324,9 +324,10 @@ class DoctrineDonationRepository implements DonationRepository {
 				$dd->getId(),
 				var_export( $dd->getDecodedData(), true ) )
 			);
-			error_log( implode( "\n", array_map( function( $bt ) {
-				return sprintf( '%s, line %d, %s', $bt['file'], $bt['line'], $bt['function'] );
-			}, debug_backtrace() ) ) );
+			// using an exception to get nicely formatted a backtrace instead of gathering data from debug_backtrace
+			// we don't throw it, because we only want the information
+			$ex = new \Exception();
+			error_log( $ex->getTraceAsString() );
 			return null;
 		}
 

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -184,6 +184,32 @@ class DoctrineDonationRepositoryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame( 'untouched', $data['another'] );
 	}
 
+	/**
+	 * The backend application data purge script sets the personal information to empty strings
+	 */
+	public function testGivenPurgedDonationNoDonorIsCreated() {
+		$doctrineDonation = $this->getNewlyCreatedDoctrineDonation();
+		$doctrineDonation->setDtBackup( new \DateTime() );
+		$this->entityManager->persist( $doctrineDonation );
+		$this->entityManager->flush();
+
+		$donation = $this->newRepository()->getDonationById( $doctrineDonation->getId() );
+
+		$this->assertNull( $donation->getDonor() );
+	}
+
+	public function testGivenDonationUpdateWithoutDonorInformation_DonorNameStaysTheSame() {
+		$donation = ValidDonation::newBookedPayPalDonation();
+		$this->newRepository()->storeDonation( $donation );
+
+		$anonymousDonation = ValidDonation::newBookedAnonymousPayPalDonationUpdate( $donation->getId() );
+		$this->newRepository()->storeDonation( $anonymousDonation );
+
+		$doctrineDonation = $this->getDoctrineDonationById( $donation->getId() );
+
+		$this->assertSame( $donation->getDonor()->getName()->getFullName(), $doctrineDonation->getDonorFullName() );
+	}
+
 	private function getNewlyCreatedDoctrineDonation(): DoctrineDonation {
 		$donation = ValidDonation::newDirectDebitDonation();
 		$this->newRepository()->storeDonation( $donation );

--- a/tests/Data/ValidDonation.php
+++ b/tests/Data/ValidDonation.php
@@ -118,6 +118,17 @@ class ValidDonation {
 		);
 	}
 
+	public static function newBookedAnonymousPayPalDonationUpdate( int $donationId ): Donation {
+		$payPalData = new PayPalData();
+		$payPalData->setPaymentId( self::PAYPAL_TRANSACTION_ID );
+
+		return ( new self() )->createAnonymousDonationWithId(
+			$donationId,
+			new PayPalPayment( $payPalData ),
+			Donation::STATUS_EXTERNAL_BOOKED
+		);
+	}
+
 	public static function newBookedCreditCardDonation() {
 		$creditCardData = new CreditCardTransactionData();
 		$creditCardData->setTransactionId( self::CREDIT_CARD_TRANSACTION_ID );
@@ -163,6 +174,17 @@ class ValidDonation {
 	private function createAnonymousDonation( PaymentMethod $paymentMethod, string $status ): Donation {
 		return new Donation(
 			null,
+			$status,
+			null,
+			$this->newDonationPayment( $paymentMethod ),
+			false,
+			$this->newTrackingInfo()
+		);
+	}
+
+	private function createAnonymousDonationWithId( int $donationId, PaymentMethod $paymentMethod, string $status ) {
+		return new Donation(
+			$donationId,
 			$status,
 			null,
 			$this->newDonationPayment( $paymentMethod ),


### PR DESCRIPTION
This solves two problems:

1) Loading of exported donations failed because their donor information
is purged. The email address was checked for a null value, which was not
a good indicator (since it's set to empty string by the backup script)
Now we handle the two cases where there is no donor information -
address type is "anonym" and doctrine entity is marked as "exported"
(the export purges the data).

2) Writing back information of donations with no donor information
caused the full name to be overwritten with `Anonym` which is not
correct. Now we only write the name when the doctrine donation is new.