### PR TITLE
Fix text policy validation errors

### DIFF
--- a/src/Validation/TextPolicyValidator.php
+++ b/src/Validation/TextPolicyValidator.php
@@ -115,7 +115,7 @@ class TextPolicyValidator {
 	private function hasBadWordNotMatchingWhiteWords( array $badMatches, array $whiteMatches ):bool {
 		return count(
 			array_udiff( $badMatches, $whiteMatches, function( $badMatch, $whiteMatch ) {
-				return !preg_match( $this->composeRegex( [ $badMatch ] ), $whiteMatch );
+				return !preg_match( $this->composeRegex( [ preg_quote( $badMatch, '#' ) ] ), $whiteMatch );
 			} )
 		) > 0;
 	}

--- a/tests/System/TextPolicyValidatorTest.php
+++ b/tests/System/TextPolicyValidatorTest.php
@@ -166,6 +166,31 @@ class TextPolicyValidatorTest extends \PHPUnit_Framework_TestCase {
 		];
 	}
 
+	/**
+	 * @dataProvider insultingTestProviderWithRegexChars
+	 */
+	public function testGivenBadWordMatchContainingRegexChars_validatorReturnsFalse( $commentToTest ) {
+		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
+
+		$this->assertFalse(
+			$textPolicyValidator->hasHarmlessContent(
+				$commentToTest,
+				TextPolicyValidator::CHECK_URLS
+				| TextPolicyValidator::CHECK_URLS_DNS
+				| TextPolicyValidator::CHECK_BADWORDS
+				| TextPolicyValidator::IGNORE_WHITEWORDS
+			)
+		);
+	}
+
+	public function insultingTestProviderWithRegexChars() {
+		return [
+			[ 'Ich heisse Deppendorf (ihr Deppen und das ist auch gut so!' ],
+			[ 'Ihr [Arschgeigen], ich wohne in //Marsch// und das ist auch gut so!' ],
+			[ 'Bei #Wikipedia gibts echt tolle Arschkrampen!' ],
+		];
+	}
+
 	private function getPreFilledTextPolicyValidator() {
 		$textPolicyValidator = new TextPolicyValidator();
 		$textPolicyValidator->addBadWordsFromArray(


### PR DESCRIPTION
When the matched "bad" words contained regular expression characters
that made the generated regular expression invalid, the validation
failed.

This is for https://phabricator.wikimedia.org/T148621