### PR TITLE
Ignore missing PayPal address status

### DIFF
--- a/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
+++ b/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
@@ -445,7 +445,7 @@ class DoctrineDonationRepository implements DonationRepository {
 				->setPayerId( $data['paypal_payer_id'] )
 				->setSubscriberId( $data['paypal_subscr_id'] )
 				->setPayerStatus( $data['paypal_payer_status'] )
-				->setAddressStatus( $data['paypal_address_status'] )
+				->setAddressStatus( isset( $data['paypal_address_status'] ) ? $data['paypal_address_status'] : 'unknown' )
 				->setAmount( Euro::newFromString( $data['paypal_mc_gross'] ) )
 				->setCurrencyCode( $data['paypal_mc_currency'] )
 				->setFee( Euro::newFromString( $data['paypal_mc_fee'] ) )


### PR DESCRIPTION
Ignore missing 'paypal_address_status' when constructing the paypal data
from the data blob.

Should be either "confirmed" or "unconfirmed", but is sometimes not
written by the IPN callback, so we need to handle entities that don't
have it.

This is for https://phabricator.wikimedia.org/T147785