### PR TITLE
Add some defensive code for when idn_to_ascii fails

### DIFF
--- a/contexts/MembershipContext/src/Domain/Model/EmailAddress.php
+++ b/contexts/MembershipContext/src/Domain/Model/EmailAddress.php
@@ -38,7 +38,8 @@ class EmailAddress {
 	}
 
 	public function getNormalizedDomain(): string {
-		return idn_to_ascii( $this->domain );
+		$normalizedDomain = idn_to_ascii( $this->domain );
+		return is_string( $normalizedDomain ) ? $normalizedDomain : '';
 	}
 
 	public function getFullAddress(): string {


### PR DESCRIPTION
This is for https://phabricator.wikimedia.org/T148823

Follow up to https://github.com/wmde/FundraisingFrontend/pull/721

I don't know of a way to trigger the failure after #721, hence no test here. Could factor out that function of course, but I'm somewhat dubious about that being worth it, esp since this is  value object. (Makes constructing it kinda difficult, and we're not using any type of factory for this so can't hide it without bigger changes)