### PR TITLE
Refactor tracking

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -12,11 +12,10 @@ use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationRe
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationResponse;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\AmountParser;
-use WMDE\Fundraising\Frontend\Infrastructure\PiwikVariableCollector;
+use WMDE\Fundraising\Frontend\Infrastructure\TrackingDataSelector;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\Iban;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
-use WMDE\Fundraising\Frontend\Presentation\SelectedConfirmationPage;
 
 /**
  * @license GNU GPL v2+
@@ -111,10 +110,10 @@ class AddDonationHandler {
 		}
 
 		$donationRequest->setTracking(
-			AddDonationRequest::getPreferredValue( [
+			TrackingDataSelector::getFirstNonEmptyValue( [
 				$request->cookies->get( 'spenden_tracking' ),
 				$request->request->get( 'tracking' ),
-				AddDonationRequest::concatTrackingFromVarCouple(
+				TrackingDataSelector::concatTrackingFromVarTuple(
 					$request->get( 'piwik_campaign', '' ),
 					$request->get( 'piwik_kwd', '' )
 				)
@@ -123,7 +122,7 @@ class AddDonationHandler {
 
 		$donationRequest->setOptIn( $request->get( 'info', '' ) );
 		$donationRequest->setSource(
-			AddDonationRequest::getPreferredValue( [
+			TrackingDataSelector::getFirstNonEmptyValue( [
 				$request->cookies->get( 'spenden_source' ),
 				$request->request->get( 'source' ),
 				$request->server->get( 'HTTP_REFERER' )

--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -12,7 +12,6 @@ use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationRe
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationResponse;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\AmountParser;
-use WMDE\Fundraising\Frontend\Infrastructure\TrackingDataSelector;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\Iban;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
@@ -109,25 +108,9 @@ class AddDonationHandler {
 			$donationRequest->setBankData( $this->getBankDataFromRequest( $request ) );
 		}
 
-		$donationRequest->setTracking(
-			TrackingDataSelector::getFirstNonEmptyValue( [
-				$request->cookies->get( 'spenden_tracking' ),
-				$request->request->get( 'tracking' ),
-				TrackingDataSelector::concatTrackingFromVarTuple(
-					$request->get( 'piwik_campaign', '' ),
-					$request->get( 'piwik_kwd', '' )
-				)
-			] )
-		);
-
+		$donationRequest->setTracking( $request->attributes->get( 'trackingCode' ) );
 		$donationRequest->setOptIn( $request->get( 'info', '' ) );
-		$donationRequest->setSource(
-			TrackingDataSelector::getFirstNonEmptyValue( [
-				$request->cookies->get( 'spenden_source' ),
-				$request->request->get( 'source' ),
-				$request->server->get( 'HTTP_REFERER' )
-			] )
-		);
+		$donationRequest->setSource( $request->attributes->get( 'trackingSource' ) );
 		$donationRequest->setTotalImpressionCount( intval( $request->get( 'impCount', 0 ) ) );
 		$donationRequest->setSingleBannerImpressionCount( intval( $request->get( 'bImpCount', 0 ) ) );
 

--- a/app/RouteHandlers/ApplyForMembershipHandler.php
+++ b/app/RouteHandlers/ApplyForMembershipHandler.php
@@ -91,7 +91,7 @@ class ApplyForMembershipHandler {
 			$httpRequest->request->get( 'templateName', '' )
 		) );
 
-		$request->setPiwikTrackingString( $httpRequest->cookies->get( 'spenden_tracking', '' ) );
+		$request->setPiwikTrackingString( $httpRequest->attributes->get( 'trackingCode' ) );
 
 		$bankData = new BankData();
 

--- a/contexts/DonationContext/src/UseCases/AddDonation/AddDonationRequest.php
+++ b/contexts/DonationContext/src/UseCases/AddDonation/AddDonationRequest.php
@@ -231,24 +231,6 @@ class AddDonationRequest {
 		$this->donorEmailAddress = $donorEmailAddress;
 	}
 
-	public static function getPreferredValue( array $values ) {
-		foreach ( $values as $value ) {
-			if ( $value !== null && $value !== '' ) {
-				return $value;
-			}
-		}
-
-		return '';
-	}
-
-	public static function concatTrackingFromVarCouple( string $campaign, string $keyword ): string {
-		if ( $campaign !== '' ) {
-			return strtolower( implode( '/', array_filter( [ $campaign, $keyword ] ) ) );
-		}
-
-		return '';
-	}
-
 	public function donorIsAnonymous(): bool {
 		return $this->getDonorType() === DonorName::PERSON_ANONYMOUS;
 	}

--- a/src/Infrastructure/TrackingDataSelector.php
+++ b/src/Infrastructure/TrackingDataSelector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class TrackingDataSelector {
+
+	public static function getFirstNonEmptyValue( array $values ): string {
+		$nonEmptyValues = array_filter( $values );
+		return count( $nonEmptyValues ) > 0 ? array_shift( $nonEmptyValues ) : '';
+	}
+
+	public static function concatTrackingFromVarTuple( string $campaign, string $keyword ): string {
+		if ( $campaign !== '' ) {
+			return strtolower( implode( '/', array_filter( [ $campaign, $keyword ] ) ) );
+		}
+
+		return '';
+	}
+}

--- a/tests/Unit/Infrastructure/TrackingDataSelectorTest.php
+++ b/tests/Unit/Infrastructure/TrackingDataSelectorTest.php
@@ -4,15 +4,15 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Unit\UseCases\AddDonation;
 
-use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationRequest;
+use WMDE\Fundraising\Frontend\Infrastructure\TrackingDataSelector;
 
 /**
- * @covers WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationRequest
+ * @covers WMDE\Fundraising\Frontend\Infrastructure\TrackingDataSelector
  *
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class AddDonationRequestTest extends \PHPUnit_Framework_TestCase {
+class TrackingDataSelectorTest extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider preferredValueProvider
@@ -21,7 +21,7 @@ class AddDonationRequestTest extends \PHPUnit_Framework_TestCase {
 	 * @param string[] $values
 	 */
 	public function testGetPreferredValueReturnsFirstSetElementOrEmptyString( $expectedResult, $values ) {
-		$value = AddDonationRequest::getPreferredValue( $values );
+		$value = TrackingDataSelector::getFirstNonEmptyValue( $values );
 		$this->assertSame( $expectedResult, $value );
 	}
 
@@ -42,10 +42,10 @@ class AddDonationRequestTest extends \PHPUnit_Framework_TestCase {
 	 * @param $keyword
 	 */
 	public function testConcatTrackingFromVarCouple( $expectedResult, $campaign, $keyword ) {
-		$value = AddDonationRequest::getPreferredValue( [
+		$value = TrackingDataSelector::getFirstNonEmptyValue( [
 			'',
 			'',
-			AddDonationRequest::concatTrackingFromVarCouple( $campaign, $keyword )
+			TrackingDataSelector::concatTrackingFromVarTuple( $campaign, $keyword )
 		] );
 
 		$this->assertSame( $expectedResult, $value );


### PR DESCRIPTION
Now all request handlers can access the tracking code and the tracking source from `Request` attributes. This is more consistent, especially when `Subscription` will also store the tracking information.