### PR TITLE
pass tracking data across forms

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -8,6 +8,7 @@ use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WMDE\Euro\Euro;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationRequest;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationResponse;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
@@ -40,7 +41,12 @@ class AddDonationHandler {
 		$responseModel = $this->ffFactory->newAddDonationUseCase()->addDonation( $addDonationRequest );
 
 		if ( !$responseModel->isSuccessful() ) {
-			return new Response( $this->ffFactory->newDonationFormViolationPresenter()->present( $responseModel->getValidationErrors(), $addDonationRequest ) );
+			return new Response(
+				$this->ffFactory->newDonationFormViolationPresenter()->present(
+					$responseModel->getValidationErrors(), $addDonationRequest,
+					$this->newTrackingInfoFromRequest( $request )
+				)
+			);
 		}
 
 		return $this->newHttpResponse( $responseModel );
@@ -166,6 +172,14 @@ class AddDonationHandler {
 		}
 
 		return true;
+	}
+
+	private function newTrackingInfoFromRequest( Request $request ): DonationTrackingInfo {
+		$tracking = new DonationTrackingInfo();
+		$tracking->setSingleBannerImpressionCount( intval( $request->get( 'bImpCount', 0 ) ) );
+		$tracking->setTotalImpressionCount( intval( $request->get( 'impCount', 0 ) ) );
+
+		return $tracking;
 	}
 
 }

--- a/app/routes.php
+++ b/app/routes.php
@@ -20,6 +20,7 @@ use WMDE\Fundraising\Frontend\App\RouteHandlers\PayPalNotificationHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\RouteRedirectionHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\ShowDonationConfirmationHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\ShowMembershipConfirmationHandler;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchRequest;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donor;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\DonorAddress;
@@ -390,6 +391,10 @@ $app->get( 'donation/new', function ( Request $request ) use ( $ffFactory ) {
 	}
 	$validationResult = $ffFactory->newPaymentDataValidator()->validate( $amount, (string) $request->get( 'zahlweise', '' ) );
 
+	$trackingInfo = new DonationTrackingInfo();
+	$trackingInfo->setTotalImpressionCount( intval( $request->get( 'impCount' ) ) );
+	$trackingInfo->setSingleBannerImpressionCount( intval( $request->get( 'bImpCount' ) ) );
+
 	// TODO: don't we want to use newDonationFormViolationPresenter when !$validationResult->isSuccessful()?
 
 	return new Response(
@@ -397,7 +402,8 @@ $app->get( 'donation/new', function ( Request $request ) use ( $ffFactory ) {
 			$amount,
 			$request->get( 'zahlweise', '' ),
 			intval( $request->get( 'periode', 0 ) ),
-			$validationResult->isSuccessful()
+			$validationResult->isSuccessful(),
+			$trackingInfo
 		)
 	);
 } )->method( 'POST|GET' );

--- a/src/Presentation/Presenters/DonationFormPresenter.php
+++ b/src/Presentation/Presenters/DonationFormPresenter.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
 use WMDE\Euro\Euro;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 
@@ -22,7 +23,8 @@ class DonationFormPresenter {
 		$this->amountFormatter = $amountFormatter;
 	}
 
-	public function present( Euro $amount, string $paymentType, int $paymentInterval, bool $paymentDataIsValid ): string {
+	public function present( Euro $amount, string $paymentType, int $paymentInterval, bool $paymentDataIsValid,
+							 DonationTrackingInfo $trackingInfo ): string {
 		return $this->template->render( [
 			'initialFormValues' => [
 				'amount' => $this->amountFormatter->format( $amount ),
@@ -31,6 +33,10 @@ class DonationFormPresenter {
 			],
 			'validationResult' => [
 				'paymentData' => $paymentDataIsValid
+			],
+			'tracking' => [
+				'bannerImpressionCount' => $trackingInfo->getSingleBannerImpressionCount(),
+				'impressionCount' => $trackingInfo->getTotalImpressionCount()
 			]
 		] );
 	}

--- a/src/Presentation/Presenters/DonationFormViolationPresenter.php
+++ b/src/Presentation/Presenters/DonationFormViolationPresenter.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationRequest;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
 use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
@@ -28,13 +29,18 @@ class DonationFormViolationPresenter {
 	/**
 	 * @param ConstraintViolation[] $violations
 	 * @param AddDonationRequest $request
+	 * @param DonationTrackingInfo $trackingData
 	 * @return string
 	 */
-	public function present( array $violations, AddDonationRequest $request ): string {
+	public function present( array $violations, AddDonationRequest $request, DonationTrackingInfo $trackingData ): string {
 		return $this->template->render(
 			[
 				'initialFormValues' => $this->getDonationFormArguments( $request ),
-				'violatedFields' => $this->getViolatedFields( $violations )
+				'violatedFields' => $this->getViolatedFields( $violations ),
+				'tracking' => [
+					'impressionCount' => $trackingData->getTotalImpressionCount(),
+					'bannerImpressionCount' => $trackingData->getSingleBannerImpressionCount()
+				]
 			]
 		);
 	}

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -409,6 +409,26 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
+	public function testGivenInvalidRequest_formStillContainsBannerTrackingData() {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$factory->setNullMessenger();
+
+			$client->request(
+				'POST',
+				'/donation/add',
+				[
+					'impCount' => 12,
+					'bImpCount' => 3
+				]
+			);
+
+			$response = $client->getResponse()->getContent();
+
+			$this->assertContains( 'Impression Count: 12', $response );
+			$this->assertContains( 'Banner Impression Count: 3', $response );
+		} );
+	}
+
 	public function testGivenNegativeDonationAmount_formIsReloadedAndPrefilledWithZero() {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setNullMessenger();

--- a/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
@@ -64,4 +64,20 @@ class NewDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
+	public function testWhenPassingTrackingData_theyCanBePassedThrough() {
+		$client = $this->createClient();
+		$client->request(
+			'POST',
+			'/donation/new',
+			[
+				'impCount' => 12,
+				'bImpCount' => 3
+			]
+		);
+
+		$response = $client->getResponse()->getContent();
+		$this->assertContains( 'Impression Count: 12', $response );
+		$this->assertContains( 'Banner Impression Count: 3', $response );
+	}
+
 }

--- a/tests/templates/DonationForm.twig
+++ b/tests/templates/DonationForm.twig
@@ -23,3 +23,7 @@ Violations:
 
 Initial validity:
 Payment data: {% if validationResult.paymentData == true %}valid{% else %}invalid{% endif %}
+
+Tracking data:
+Impression Count: {$ tracking.impressionCount $}
+Banner Impression Count: {$ tracking.bannerImpressionCount $}


### PR DESCRIPTION
Certain tracking data that is set in banners has to be passed through the donation form. This PR sets ground for it. For each of the tracking parameters an `<input type="hidden" />` must be added to the [form template](https://fundraising-cms.wikimedia.de/index.php?title=Web:Spendenseite-DefaultSkin/test/DonationForm_PersonalData&diff=601&oldid=596).