### PR TITLE
Move Paypal logging to handler

### DIFF
--- a/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/PayPalNotificationRequest.php
+++ b/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/PayPalNotificationRequest.php
@@ -258,36 +258,4 @@ class PayPalNotificationRequest {
 	public function isForRecurringPayment(): bool {
 		return strpos( $this->transactionType, 'subscr_' ) === 0;
 	}
-
-	public function toArray(): array {
-		return [
-			'transactionType' => $this->transactionType,
-			'transactionId' => $this->transactionId,
-
-			'payerId' => $this->payerId,
-			'payerEmail' => $this->payerEmail,
-			'payerStatus' => $this->payerStatus,
-			'subscriberId' => $this->subscriberId,
-
-			'payerFirstName' => $this->payerFirstName,
-			'payerLastName' => $this->payerLastName,
-			'payerAddressName' => $this->payerAddressName,
-			'payerAddressStreet' => $this->payerAddressStreet,
-			'payerAddressPostalCode' => $this->payerAddressPostalCode,
-			'payerAddressCity' => $this->payerAddressCity,
-			'payerAddressCountryCode' => $this->payerAddressCountryCode,
-			'payerAddressStatus' => $this->payerAddressStatus,
-
-			'donationId' => $this->donationId,
-			'token' => $this->token,
-
-			'currencyCode' => $this->currencyCode,
-			'transactionFee' => $this->transactionFee,
-			'amountGross' => $this->amountGross,
-			'settleAmount' => $this->settleAmount,
-			'paymentTimestamp' => $this->paymentTimestamp,
-			'paymentStatus' => $this->paymentStatus,
-			'paymentType' => $this->paymentType
-		];
-	}
 }

--- a/contexts/DonationContext/tests/Data/ValidPayPalNotificationRequest.php
+++ b/contexts/DonationContext/tests/Data/ValidPayPalNotificationRequest.php
@@ -17,7 +17,7 @@ class ValidPayPalNotificationRequest {
 	const TRANSACTION_ID = '61E67681CH3238416';
 	const PAYER_ID = 'LPLWNMTBWMFAY';
 	const SUBSCRIBER_ID = '8RHHUM3W3PRH7QY6B59';
-	const PAYER_EMAIL = 'payer.email@address.com';
+	const PAYER_EMAIL = 'foerderpp@wikimedia.de';
 	const PAYER_STATUS = 'verified';
 	const PAYER_FIRST_NAME = 'Generous';
 	const PAYER_LAST_NAME = 'Donor';
@@ -30,10 +30,15 @@ class ValidPayPalNotificationRequest {
 	const TOKEN = 'my_secret_token';
 	const CURRENCY_CODE = 'EUR';
 	const TRANSACTION_FEE_CENTS = 27;
+	const TRANSACTION_FEE_EURO_STRING = '2.70';
 	const AMOUNT_GROSS_CENTS = 500;
+	const AMOUNT_GROSS_EURO_STRING = '5.00';
 	const SETTLE_AMOUNT_CENTS = 123;
+	const SETTLE_AMOUNT_EURO_STRING = '1.23';
 	const PAYMENT_TIMESTAMP = '20:12:59 Jan 13, 2009 PST';
 	const PAYMENT_TYPE = 'instant';
+	const ITEM_NAME = 'Spende an Wikimdia Deutschland';
+	const ITEM_NUMBER = 1;
 
 	const PAYMENT_STATUS_COMPLETED = 'Completed';
 	const PAYMENT_STATUS_PENDING = 'Pending';
@@ -73,6 +78,34 @@ class ValidPayPalNotificationRequest {
 			->setDonationId( $donationId )
 			->setTransactionType( 'subscr_payment' )
 			->setPaymentStatus( self::PAYMENT_STATUS_COMPLETED );
+	}
+
+	public static function newHttpParamsForSubscriptionModification(): array {
+		return [
+			'receiver_email' => self::PAYER_EMAIL,
+			'payment_status' => self::PAYMENT_STATUS_COMPLETED,
+			'payer_id' => self::PAYER_ID,
+			'subscr_id' => self::SUBSCRIBER_ID,
+			'payer_status' => self::PAYER_STATUS,
+			'address_status' => self::PAYER_ADDRESS_STATUS,
+			'mc_gross' => self::AMOUNT_GROSS_EURO_STRING,
+			'mc_currency' => self::CURRENCY_CODE,
+			'mc_fee' => self::TRANSACTION_FEE_EURO_STRING,
+			'settle_amount' => self::SETTLE_AMOUNT_EURO_STRING,
+			'first_name' => self::PAYER_FIRST_NAME,
+			'last_name' => self::PAYER_LAST_NAME,
+			'address_name' => self::PAYER_ADDRESS_NAME,
+			'item_name' => self::ITEM_NAME,
+			'item_number' => self::ITEM_NUMBER,
+			'custom' => json_encode( [
+				'id' => self::DONATION_ID,
+				'utoken' => self::TOKEN
+			] ),
+			'txn_id' => self::TRANSACTION_ID,
+			'payment_type' => self::PAYMENT_TYPE,
+			'txn_type' => 'subscr_modify',
+			'payment_date' => self::PAYMENT_TIMESTAMP,
+		];
 	}
 
 	private static function newBaseRequest(): PayPalNotificationRequest {

--- a/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
@@ -100,21 +100,6 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit_Framework_Test
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenPaymentStatusIsPending_responseContainsMoreInformation() {
-		$request = $request = ValidPayPalNotificationRequest::newPendingPayment();
-
-		$useCase = new HandlePayPalPaymentNotificationUseCase(
-			new FakeDonationRepository(),
-			new SucceedingDonationAuthorizer(),
-			$this->getMailer(),
-			$this->getEventLogger()
-		);
-
-		$response = $useCase->handleNotification( $request );
-		$this->assertSame( 'Unhandled PayPal instant payment notification', $response->getContext()['message'] );
-		$this->assertSame( 'Pending', $response->getContext()['request']['paymentStatus'] );
-	}
-
 	public function testWhenTransactionTypeIsForSubscriptionChanges_unhandledResponseIsReturned() {
 		$request = ValidPayPalNotificationRequest::newSubscriptionModification();
 
@@ -125,21 +110,6 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit_Framework_Test
 			$this->getEventLogger()
 		);
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
-	}
-
-	public function testWhenTransactionTypeIsForSubscriptionChanges_responseContainsMoreInformation() {
-		$useCase = new HandlePayPalPaymentNotificationUseCase(
-			new FakeDonationRepository(),
-			new SucceedingDonationAuthorizer(),
-			$this->getMailer(),
-			$this->getEventLogger()
-		);
-
-		$request = ValidPayPalNotificationRequest::newSubscriptionModification();
-
-		$response = $useCase->handleNotification( $request );
-		$this->assertSame( 'Unhandled PayPal subscription notification', $response->getContext()['message'] );
-		$this->assertSame( 'subscr_modify', $response->getContext()['request']['transactionType'] );
 	}
 
 	public function testWhenAuthorizationSucceeds_confirmationMailIsSent() {

--- a/src/Infrastructure/PayPalPaymentNotificationVerifier.php
+++ b/src/Infrastructure/PayPalPaymentNotificationVerifier.php
@@ -40,13 +40,6 @@ class PayPalPaymentNotificationVerifier implements PaymentNotificationVerifier {
 			);
 		}
 
-		if ( !$this->hasAllowedPaymentStatus( $request ) ) {
-			throw new PayPalPaymentNotificationVerifierException(
-				'Payment status is not supported',
-				PayPalPaymentNotificationVerifierException::ERROR_UNSUPPORTED_STATUS
-			);
-		}
-
 		if ( !$this->hasValidCurrencyCode( $request ) ) {
 			throw new PayPalPaymentNotificationVerifierException(
 				'Unsupported currency',


### PR DESCRIPTION
The Paypal notification Response object no longer contains the
PayPalNotificationRequest object. Instead, the POST params from Paypal
are logged in the handler. This enables better debugging because we can
see what data was sent by Paypal.
The test of the logging contents have been moved from the use case to
the route test.

Removed status check from PayPalPaymentNotificationVerifier because
status is automatically and implicitly handled by the use case.

Added logging in case the PayPalPaymentNotificationVerifier throws an
Exception.

Removed wrapped PayPalPaymentNotificationVerifier from test.