### PR TITLE
Add explicit 404 presenter

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -15,6 +15,7 @@ use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use WMDE\Fundraising\Frontend\App\AccessDeniedException;
 use WMDE\Fundraising\Frontend\Infrastructure\TrackingDataSelector;
 
@@ -69,6 +70,19 @@ $app->error( function ( AccessDeniedException $e ) use ( $ffFactory ) {
 		[ 'X-Status-Code' => 403 ]
 	);
 } );
+
+$app->error( function ( NotFoundHttpException $e ) use ( $ffFactory, $app ) {
+	if ( $app['request_stack.is_json'] ) {
+		return $app->json( [ 'ERR' => $e->getMessage() ], 404, [ 'X-Status-Code' => 404 ] );
+	}
+
+	return new Response(
+		$ffFactory->newPageNotFoundHTMLPresenter()->present(),
+		404,
+		[ 'X-Status-Code' => 404 ]
+	);
+} );
+
 
 $app->error( function ( \Exception $e, Request $request, $code ) use ( $ffFactory, $app ) {
 	if ( $app['debug'] ) {

--- a/app/routes.php
+++ b/app/routes.php
@@ -12,6 +12,7 @@ declare( strict_types = 1 );
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\AddDonationHandler;
@@ -222,10 +223,12 @@ $app->get(
 $app->get(
 	'page/{pageName}',
 	function( $pageName ) use ( $ffFactory ) {
-		$templateExists = $ffFactory->getTemplateNameValidator()->validate( $pageName )->isSuccessful();
+		if ( !$ffFactory->getTemplateNameValidator()->validate( $pageName )->isSuccessful() ) {
+			throw new NotFoundHttpException( "Page '$pageName' not found." );
+		}
 
 		return $ffFactory->getLayoutTemplate( 'DisplayPageLayout.twig' )->render( [
-			'main_template' => $templateExists ? $pageName : '404message.html.twig',
+			'main_template' => $pageName
 		] );
 	}
 )

--- a/app/templates/404message.html.twig
+++ b/app/templates/404message.html.twig
@@ -1,2 +1,5 @@
-Could not load main content!
-{# TODO translate this and add a link to main page #}
+{% extends 'BaseLayout.twig' %}
+
+{% block main %}
+    {$ message|default( 'page_not_found' )|trans()|raw $}
+{% endblock %}

--- a/app/translations/messages.de_DE.json
+++ b/app/translations/messages.de_DE.json
@@ -29,5 +29,6 @@
   "comment_success_needs_moderation": "Ihr Kommentar wurde von unserem System zur Überprüfung vorgemerkt und steht daher nicht automatisch in der öffentlichen Spenderliste.",
   "pagination_page_n_of_x": "Seite %page% von %max_pages%+",
   "donation_rejected_limit": "Sie haben vor sehr kurzer Zeit bereits gespendet. Bitte warten Sie einen Moment.<br />Wenn Sie Fragen dazu haben, wenden Sie sich bitte an <a href=\"mailto:spenden%40wikimedia.de\">spenden@wikimedia.de</a>.",
-  "membership_application_rejected_limit": "Sie haben vor sehr kurzer Zeit bereits einen Mitgliedschaftsantrag gesendet. Bitte warten Sie einen Moment.<br />Wenn Sie Fragen dazu haben, wenden Sie sich bitte an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder@wikimedia.de</a>."
+  "membership_application_rejected_limit": "Sie haben vor sehr kurzer Zeit bereits einen Mitgliedschaftsantrag gesendet. Bitte warten Sie einen Moment.<br />Wenn Sie Fragen dazu haben, wenden Sie sich bitte an <a href=\"mailto:mitglieder%40wikimedia.de\">mitglieder@wikimedia.de</a>.",
+  "page_not_found": "Diese Seite existiert leider nicht.<br /><a href=\"/\">Klicken Sie hier, um unsere Spenden-Seite aufzurufen.</a>"
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -31,6 +31,7 @@ use Twig_Extensions_Extension_Intl;
 use WMDE\Fundraising\Frontend\DonationContext\DonationAcceptedEventHandler;
 use WMDE\Fundraising\Frontend\Infrastructure\Cache\AllOfTheCachePurger;
 use WMDE\Fundraising\Frontend\Presentation\Honorifics;
+use WMDE\Fundraising\Frontend\Presentation\Presenters\PageNotFoundPresenter;
 use WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchUseCase;
 use WMDE\Fundraising\Frontend\Infrastructure\Cache\AuthorizedCachePurger;
 use WMDE\Fundraising\Frontend\DonationContext\Authorization\DonationAuthorizer;
@@ -1272,6 +1273,10 @@ class FunFunFactory {
 			$this->getDonationRepository(),
 			$this->newDonationConfirmationMailer()
 		);
+	}
+
+	public function newPageNotFoundHTMLPresenter(): PageNotFoundPresenter {
+		return new PageNotFoundPresenter( $this->getLayoutTemplate( '404message.html.twig' ) );
 	}
 
 }

--- a/src/Presentation/Presenters/PageNotFoundPresenter.php
+++ b/src/Presentation/Presenters/PageNotFoundPresenter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
+
+use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class PageNotFoundPresenter {
+
+	private $template;
+
+	public function __construct( TwigTemplate $template ) {
+		$this->template = $template;
+	}
+
+	public function present(): string {
+		return $this->template->render( [] );
+	}
+
+}

--- a/tests/EdgeToEdge/Routes/DisplayPageRouteTest.php
+++ b/tests/EdgeToEdge/Routes/DisplayPageRouteTest.php
@@ -18,6 +18,8 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\ApiPostRequestHandler;
  */
 class DisplayPageRouteTest extends WebRouteTestCase {
 
+	private $notFoundMessage;
+
 	// @codingStandardsIgnoreStart
 	protected function onTestEnvironmentCreated( FunFunFactory $factory, array $config ) {
 		// @codingStandardsIgnoreEnd
@@ -30,6 +32,7 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 			} );
 
 		$factory->setMediaWikiApi( $api );
+		$this->notFoundMessage = $factory->getTranslator()->trans( 'page_not_found' );
 	}
 
 	public function testWhenPageDoesNotExist_missingResponseIsReturned() {
@@ -37,7 +40,7 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 		$client->request( 'GET', '/page/kittens' );
 
 		$this->assertContains(
-			'Could not load main content!',
+			$this->notFoundMessage,
 			$client->getResponse()->getContent()
 		);
 	}


### PR DESCRIPTION
The error message was not localizable and contained the HTTP request
method and the word "route" which can be considered jargon.

Also, every 404 error was logged with a stack trace.

This patch adds a localizable general message and does not log 404
errors to the app error log (the errors will still show up in the web
server logs).

This is the first improvement for https://phabricator.wikimedia.org/T147931