### PR TITLE
set expiry of cookie created after donation

### DIFF
--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -49,7 +49,7 @@ class DonationConfirmationHtmlPresenter {
 				// TODO: use locale to determine the date format
 				'creationDate' => ( new \DateTime() )->format( 'd.m.Y' ),
 				// TODO: set cookie duration for "hide banner cookie"
-				'cookieDuration' => '',
+				'cookieDuration' => '15552000', // 180 days
 				'updateToken' => $updateToken
 			],
 			'person' => $this->getPersonArguments( $donation ),

--- a/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
@@ -48,7 +48,7 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit_Framework_TestCase 
 				'optsIntoNewsletter' => false,
 				'bankTransferCode' => '',
 				'creationDate' => ( new \DateTime() )->format( 'd.m.Y' ),
-				'cookieDuration' => '',
+				'cookieDuration' => '15552000',
 				'updateToken' => 'update_token'
 			],
 			'person' => [ ],


### PR DESCRIPTION
as defined in wmde/fundraising#1122, the cookie duration has to be set to 180 days