### PR TITLE
Don't check domain names in route test

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1239,6 +1239,10 @@ class FunFunFactory {
 		$this->profiler = $profiler;
 	}
 
+	public function setEmailValidator( EmailValidator $validator ) {
+		$this->pimple['mail_validator'] = $validator;
+	}
+
 	public function setLogger( LoggerInterface $logger ) {
 		$this->pimple['logger'] = $logger;
 	}

--- a/tests/EdgeToEdge/Routes/GetInTouchRouteTest.php
+++ b/tests/EdgeToEdge/Routes/GetInTouchRouteTest.php
@@ -7,6 +7,7 @@ namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge\Routes;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
 use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\SucceedingEmailValidator;
 
 /**
  * @licence GNU GPL v2+
@@ -21,7 +22,13 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 	}
 
 	public function testGivenValidRequest_contactRequestIsProperlyProcessed() {
-		$client = $this->createClient();
+		$client = $this->createClient(
+			[],
+			function ( FunFunFactory $factory ) {
+				$factory->setEmailValidator( new SucceedingEmailValidator() );
+			},
+			self::DISABLE_DEBUG
+		);
 		$client->followRedirects( false );
 
 		$client->request(
@@ -80,6 +87,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 					->willThrowException( new \RuntimeException( 'Something unexpected happened' ) );
 
 				$factory->setMessenger( $messenger );
+				$factory->setEmailValidator( new SucceedingEmailValidator() );
 			},
 			self::DISABLE_DEBUG
 		);


### PR DESCRIPTION
When testing the "get in touch" route we don't check the email address
validity, since we only want to check the route flow.

This avoids failing tests when there are DNS outages or one of the tested email
domains is gone.