### PR TITLE
Defined behavior when normalizing invalid domains

### DIFF
--- a/contexts/MembershipContext/src/Domain/Model/EmailAddress.php
+++ b/contexts/MembershipContext/src/Domain/Model/EmailAddress.php
@@ -38,7 +38,7 @@ class EmailAddress {
 	}
 
 	public function getNormalizedDomain(): string {
-		return idn_to_ascii( $this->domain );
+		return (string) idn_to_ascii( $this->domain );
 	}
 
 	public function getFullAddress(): string {

--- a/contexts/MembershipContext/tests/Unit/Domain/Model/EmailAddressTest.php
+++ b/contexts/MembershipContext/tests/Unit/Domain/Model/EmailAddressTest.php
@@ -59,6 +59,13 @@ class EmailAddressTest extends \PHPUnit_Framework_TestCase {
 		$this->assertSame( 'info@xn--triebwerk-grn-7ob.de', $email->getNormalizedAddress() );
 	}
 
+	public function testInvalidDomainNamesAreNormalizedToEmpty() {
+		$email = new EmailAddress( 'oh_boy@...' );
+
+		$this->assertSame( '', $email->getNormalizedDomain() );
+		$this->assertSame( 'oh_boy@', $email->getNormalizedAddress() );
+	}
+
 	public function testToStringOriginalInput() {
 		$email = new EmailAddress( 'jeroendedauw@gmail.com' );
 

--- a/tests/Unit/EmailValidatorTest.php
+++ b/tests/Unit/EmailValidatorTest.php
@@ -66,6 +66,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase {
 			[ 'hllo909a()_9a=f9@dsafadsff' ],
 			[ 'christoph.fischer@wikimedia.de ' ],
 			[ 'christoph.füscher@wikimedia.de ' ],
+			[ 'ich@ort...' ]
 		];
 	}
 


### PR DESCRIPTION
EmailAddress now Returns empty string when normalizing invalid domain
names.

This is for https://phabricator.wikimedia.org/T150442