### PR TITLE
Server-side tracking for mobile paypal donations

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -63,8 +63,7 @@ class AddDonationHandler {
 		$campaign = $trackingCode[0];
 		$keyword = $trackingCode[1] ?? '';
 
-		$this->ffFactory->getServerSideTracker()->setIp( $request->getClientIp() );
-		$this->ffFactory->newPageViewTracker()->trackPaypalRedirection( $campaign, $keyword );
+		$this->ffFactory->getPageViewTracker()->trackPaypalRedirection( $campaign, $keyword, $request->getClientIp() );
 	}
 
 	private function newHttpResponse( AddDonationResponse $responseModel ): Response {

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -139,6 +139,7 @@
 	},
 	"piwik": {
 		"baseUrl": "//tracking.wikimedia.de/",
-		"siteId": 1
+		"siteId": 1,
+		"siteUrlBase": ""
 	}
 }

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -74,7 +74,8 @@
 	},
 	"piwik": {
 		"baseUrl": "//tracking.wikimedia.de/",
-		"siteId": 1234		
+		"siteId": 1234,
+		"siteUrlBase": "http://test-spenden.wikimedia.local"
 	},
 	"purging-secret": "Not so secret, testing"
 }

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -629,12 +629,20 @@
             "title": "Site ID",
             "description": "Unique site id (configured in Piwik)",
             "default": 1
-          }
+          },
+        "siteUrlBase": {
+          "type": "string",
+          "title": "Site url",
+          "description": "Base URL for server-side piwik tracking. It must *not* have a slash at the end",
+          "format": "url",
+          "minLength": 1
+        }
       },
       "additionalProperties": false,
       "required": [
         "baseUrl",
-        "siteId"
+        "siteId",
+        "siteUrlBase"
       ]
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 		"twig/extensions": "^1.3",
 		"micropayment-de/service-client": "~1.19.0",
 		"league/json-guard": "^0.3.2",
-		"symfony/console": "^2.3.0"
+		"symfony/console": "^2.3.0",
+		"piwik/piwik-php-tracker": "^1.0"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9d823d0d9917f04b29d3867c3bd283d7",
-    "content-hash": "1cc5bc5759596f5f38176f36cb5473ae",
+    "hash": "6ad0c16b1ca88ff87f16b10e338e3fe9",
+    "content-hash": "4d4feb4941246ee8219f960b96bd5d49",
     "packages": [
         {
             "name": "addwiki/mediawiki-api-base",
@@ -1163,17 +1163,17 @@
             "dist": {
                 "type": "zip",
                 "url": "https://techdoc.micropayment.de/payment/serviceclient/download/mcp-serviceclient_1_19.zip",
-                "reference": "1.19.0",
+                "reference": null,
                 "shasum": null
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "lib/init.php"
+                ],
                 "classmap": [
                     "lib",
                     "services"
-                ],
-                "files": [
-                    "lib/init.php"
                 ]
             }
         },
@@ -1400,6 +1400,46 @@
                 "dependency injection"
             ],
             "time": "2015-09-11 15:10:35"
+        },
+        {
+            "name": "piwik/piwik-php-tracker",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/piwik/piwik-php-tracker.git",
+                "reference": "eb4df1e223d4b377d06785c9b5fb3723d16d4465"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/piwik/piwik-php-tracker/zipball/eb4df1e223d4b377d06785c9b5fb3723d16d4465",
+                "reference": "eb4df1e223d4b377d06785c9b5fb3723d16d4465",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "."
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "The Piwik Team",
+                    "email": "hello@piwik.org",
+                    "homepage": "http://piwik.org/the-piwik-team/"
+                }
+            ],
+            "description": "PHP Client for Piwik Analytics Tracking API",
+            "homepage": "http://piwik.org",
+            "keywords": [
+                "analytics",
+                "piwik",
+                "tracker"
+            ],
+            "time": "2016-07-13 05:26:45"
         },
         {
             "name": "psr/http-message",

--- a/contexts/MembershipContext/src/Tracking/ApplicationPiwikTracker.php
+++ b/contexts/MembershipContext/src/Tracking/ApplicationPiwikTracker.php
@@ -5,6 +5,8 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\MembershipContext\Tracking;
 
 /**
+ * Services implementing this interface store the Piwik tracking data associated with a membership application.
+ *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -416,10 +416,8 @@ class FunFunFactory {
 			return new VoidCache();
 		};
 
-		$this->pimple['server_side_tracker'] = function () {
-			return new PiwikServerSideTracker(
-				new \PiwikTracker( $this->config['piwik']['site_id'], 'https://' . $this->config['piwik']['baseUrl'] )
-			);
+		$this->pimple['page_view_tracker'] = function () {
+			return new PageViewTracker( $this->newServerSideTracker(), $this->config['piwik']['siteUrlBase'] );
 		};
 
 		return $pimple;
@@ -1292,18 +1290,20 @@ class FunFunFactory {
 		return new PageNotFoundPresenter( $this->getLayoutTemplate( '404message.html.twig' ) );
 	}
 
-	public function setServerSideTracker( ServerSideTracker $tracker ) {
-		$this->pimple['server_side_tracker'] = function () use ( $tracker )  {
+	public function setPageViewTracker( PageViewTracker $tracker ) {
+		$this->pimple['page_view_tracker'] = function () use ( $tracker )  {
 			return $tracker;
 		};
 	}
 
-	public function newPageViewTracker() {
-		return new PageViewTracker( $this->getServerSideTracker(), $this->config['piwik']['siteUrlBase'] );
+	public function getPageViewTracker(): PageViewTracker {
+		return $this->pimple['page_view_tracker'];
 	}
 
-	public function getServerSideTracker(): ServerSideTracker {
-		return $this->pimple['server_side_tracker'];
+	public function newServerSideTracker(): ServerSideTracker {
+		return new PiwikServerSideTracker(
+			new \PiwikTracker( $this->config['piwik']['site_id'], 'https://' . $this->config['piwik']['baseUrl'] )
+		);
 	}
 
 }

--- a/src/Infrastructure/PageViewTracker.php
+++ b/src/Infrastructure/PageViewTracker.php
@@ -20,11 +20,12 @@ class PageViewTracker {
 		$this->trackingUrlBase = $trackingUrlBase;
 	}
 
-	public function trackPaypalRedirection( string $campaign, string $keyword ) {
-		$this->trackPageView(
+	public function trackPaypalRedirection( string $campaign, string $keyword, string $visitorIP ) {
+		$this->tracker->trackPageView(
 			$this->getPaypalRedirectionTrackingUrl( $campaign, $keyword ),
 			self::TRACKING_TITLE_PAYPAL_REDIRECT
 		);
+		$this->tracker->setIp( $visitorIP );
 	}
 
 	private function getPaypalRedirectionTrackingUrl( string $campaign, string $keyword ): string {
@@ -32,9 +33,4 @@ class PageViewTracker {
 			'?piwik_campaign=' . urlencode( $campaign ) .
 			'&piwik_kwd=' . urlencode( $keyword );
 	}
-
-	private function trackPageView( string $trackingUrl, string $title ) {
-		$this->tracker->trackPageView( $trackingUrl, $title );
-	}
-
 }

--- a/src/Infrastructure/PageViewTracker.php
+++ b/src/Infrastructure/PageViewTracker.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Leszek Manicki <leszek.manicki@wikimedia.de>
+ */
+class PageViewTracker {
+
+	const TRACKING_TITLE_PAYPAL_REDIRECT = 'Redirection from mobile banner to PayPal';
+
+	private $tracker;
+
+	private $trackingUrlBase;
+
+	public function __construct( ServerSideTracker $tracker, string $trackingUrlBase ) {
+		$this->tracker = $tracker;
+		$this->trackingUrlBase = $trackingUrlBase;
+	}
+
+	public function trackPaypalRedirection( string $campaign, string $keyword ) {
+		$trackingUrl = $this->getPaypalRedirectionTrackingUrl( $campaign, $keyword );
+		$this->trackPageView( $trackingUrl, self::TRACKING_TITLE_PAYPAL_REDIRECT );
+	}
+
+	private function getPaypalRedirectionTrackingUrl( string $campaign, string $keyword ): string {
+		return $this->trackingUrlBase . '/paypal-redir/' .
+		'?piwik_campaign=' . urlencode( $campaign ) .
+		'&piwik_kwd=' . urlencode( $keyword );
+	}
+
+	private function trackPageView( string $trackingUrl, string $title ) {
+		$this->tracker->trackPageView( $trackingUrl, $title );
+	}
+
+}

--- a/src/Infrastructure/PiwikServerSideTracker.php
+++ b/src/Infrastructure/PiwikServerSideTracker.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class PiwikServerSideTracker implements ServerSideTracker {
+
+	private $tracker;
+
+	public function __construct( \PiwikTracker $tracker ) {
+		$this->tracker = $tracker;
+	}
+
+	public function trackPageView( string $url, string $title ) {
+		$this->tracker->setUrl( $url );
+		$this->tracker->doTrackPageView( $title );
+	}
+
+	public function setIp( string $ip ) {
+		$this->tracker->setIp( $ip );
+	}
+
+}

--- a/src/Infrastructure/ServerSideTracker.php
+++ b/src/Infrastructure/ServerSideTracker.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+/**
+ * Server-Side triggering of page view tracking
+ *
+ * @licence GNU GPL v2+
+ * @author Leszek Manicki <leszek.manicki@wikimedia.de>
+ */
+interface ServerSideTracker {
+
+	public function trackPageView( string $url, string $title );
+	public function setIp( string $ip );
+
+}

--- a/tests/Fixtures/ServerSideTrackerSpy.php
+++ b/tests/Fixtures/ServerSideTrackerSpy.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Fixtures;
+
+use WMDE\Fundraising\Frontend\Infrastructure\ServerSideTracker;
+
+/**
+ * @licence GNU GPL v2+
+ * @author Leszek Manicki <leszek.manicki@wikimedia.de>
+ */
+class ServerSideTrackerSpy implements ServerSideTracker {
+
+	/**
+	 * @var string[]
+	 */
+	private $pageViews = [];
+
+	private $ips = [];
+
+	public function trackPageView( string $url, string $title ) {
+		$this->pageViews[] = [
+			'url' => $url,
+			'title' => $title,
+		];
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getPageViews() {
+		return $this->pageViews;
+	}
+
+	public function setIp( string $ip ) {
+		$this->ips[] = $ip;
+	}
+
+	public function getIps(): array {
+		return $this->ips;
+	}
+
+}

--- a/tests/Fixtures/ServerSideTrackerSpy.php
+++ b/tests/Fixtures/ServerSideTrackerSpy.php
@@ -37,7 +37,7 @@ class ServerSideTrackerSpy implements ServerSideTracker {
 		$this->ips[] = $ip;
 	}
 
-	public function getIps(): array {
+	public function getCallsToSetIp(): array {
 		return $this->ips;
 	}
 

--- a/tests/Unit/Infrastructure/PageViewTrackerTest.php
+++ b/tests/Unit/Infrastructure/PageViewTrackerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WMDE\Fundraising\Tests\Integration;
+
+use WMDE\Fundraising\Frontend\Tests\Fixtures\ServerSideTrackerSpy;
+use WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker
+ *
+ * @licence GNU GPL v2+
+ * @author Leszek Manicki <leszek.manicki@wikimedia.de>
+ */
+class PageViewTrackerTest extends \PHPUnit_Framework_TestCase {
+
+	public function testTrackPaypalRedirection() {
+		$tracker = new ServerSideTrackerSpy();
+		$pageViewTracker = new PageViewTracker( $tracker, 'http://awesome.url' );
+
+		$pageViewTracker->trackPaypalRedirection( 'foo-campaign', 'foo-keyword' );
+
+		$trackedPageViews = $tracker->getPageViews();
+		$this->assertCount( 1, $trackedPageViews );
+		$this->assertEquals(
+			'http://awesome.url/paypal-redir/?piwik_campaign=foo-campaign&piwik_kwd=foo-keyword',
+			$trackedPageViews[0]['url']
+		);
+		$this->assertEquals( 'Redirection from mobile banner to PayPal', $trackedPageViews[0]['title'] );
+	}
+
+}

--- a/tests/Unit/Infrastructure/PageViewTrackerTest.php
+++ b/tests/Unit/Infrastructure/PageViewTrackerTest.php
@@ -19,7 +19,7 @@ class PageViewTrackerTest extends \PHPUnit_Framework_TestCase {
 		$tracker = new ServerSideTrackerSpy();
 		$pageViewTracker = new PageViewTracker( $tracker, 'http://awesome.url' );
 
-		$pageViewTracker->trackPaypalRedirection( 'foo-campaign', 'foo-keyword' );
+		$pageViewTracker->trackPaypalRedirection( 'foo-campaign', 'foo-keyword', '10.1.2.3' );
 
 		$trackedPageViews = $tracker->getPageViews();
 		$this->assertCount( 1, $trackedPageViews );
@@ -33,6 +33,8 @@ class PageViewTrackerTest extends \PHPUnit_Framework_TestCase {
 			'Redirection from mobile banner to PayPal',
 			$trackedPageViews[0]['title']
 		);
+
+		$this->assertSame( '10.1.2.3', $tracker->getCallsToSetIp()[0], 'IP address must be set' );
 	}
 
 }


### PR DESCRIPTION
Mobile paypal donations are anonymous and go straight to donation/add
route which redirects to paypal. That means we don't have Piwik tracking
data which is needed by the backend. That means we have to simulate the
piwik tracking on the server.

ServerSideTracker, its implementations and PageViewTracker were taken
from the old fundraising app.

This is for https://phabricator.wikimedia.org/T150525