### PR TITLE
Dont use a mailer in tests by default

### DIFF
--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -27,6 +27,8 @@ class TestEnvironment {
 
 		$installer->install();
 
+		$instance->factory->setNullMessenger();
+
 		return $instance;
 	}
 


### PR DESCRIPTION
This avoids having to call setNullMesseger in a pile of end-to-end tests.

Another way to achieve this is to have the messeger in the factory be null
by default and have index.php set a messeger, like it does for the loggers.
For the tests this makes no difference, but it might be a nicer and more
consistent approach. Thoughts? (Please dont block merge on that, we can
change it later.)