### PR TITLE
Fix page view tracker init

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -416,7 +416,7 @@ class FunFunFactory {
 			return new VoidCache();
 		};
 
-		$this->pimple['page_view_tracker'] = function () {
+		$pimple['page_view_tracker'] = function () {
 			return new PageViewTracker( $this->newServerSideTracker(), $this->config['piwik']['siteUrlBase'] );
 		};
 


### PR DESCRIPTION
Wrong initialization was not caught by tests because it was mocked.

Fix for #747