### PR TITLE
Fix piwik base URL

### DIFF
--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -620,9 +620,10 @@
           "baseUrl": {
             "type": "string",
             "title": "Tracker URL",
-            "description": "Base URL for the Piwik installation",
+            "description": "Base URL for the Piwik installation. Make sure it starts with //, not with http:// or https://, that way the browser will automatically select the right transport when the URL is printed in a template",
             "format": "url",
-            "default": "//tracking.wikimedia.de/"
+            "default": "//tracking.wikimedia.de/",
+            "pattern": "^//"
           },
           "siteId": {
             "type": "integer",

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1301,8 +1301,10 @@ class FunFunFactory {
 	}
 
 	public function newServerSideTracker(): ServerSideTracker {
+		// the "https:" prefix does NOT get any slashes because baseURL is stored in a protocol-agnostic way
+		// (e.g. "//tracking.wikimedia.de" )
 		return new PiwikServerSideTracker(
-			new \PiwikTracker( $this->config['piwik']['siteId'], 'https://' . $this->config['piwik']['baseUrl'] )
+			new \PiwikTracker( $this->config['piwik']['siteId'], 'https:' . $this->config['piwik']['baseUrl'] )
 		);
 	}
 


### PR DESCRIPTION
Mobile paypal tracking was not working because there were too many
slashes in the URL. Now the format is documented in code and configuration.