### PR TITLE
Text policy moderation for membership applications

### DIFF
--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidator.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership;
+
+use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
+use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
+
+/**
+ * @license GNU GPL v2+
+ * @author Gabriel Birke < gabriel.birke@wikimedia.de >
+ */
+class ApplyForMembershipPolicyValidator {
+
+	/* private */ const YEARLY_PAYMENT_MODERATION_THRESHOLD_IN_EURO = 1000;
+
+	private $textPolicyValidator;
+
+	public function __construct( TextPolicyValidator $textPolicyValidator ) {
+		$this->textPolicyValidator = $textPolicyValidator;
+	}
+
+	public function needsModeration( Application $application ): bool {
+		return $this->yearlyAmountExceedsLimit( $application ) ||
+			$this->addressContainsBadWords( $application );
+	}
+
+	private function yearlyAmountExceedsLimit( Application $application ): bool {
+		return
+			$application->getPayment()->getYearlyAmount()->getEuroFloat()
+			> self::YEARLY_PAYMENT_MODERATION_THRESHOLD_IN_EURO;
+	}
+
+	private function addressContainsBadWords( Application $application ) {
+		$applicant = $application->getApplicant();
+		$harmless = $this->textPolicyValidator->textIsHarmless( $applicant->getName()->getFirstName() ) &&
+			$this->textPolicyValidator->textIsHarmless( $applicant->getName()->getLastName() ) &&
+			$this->textPolicyValidator->textIsHarmless( $applicant->getName()->getCompanyName() ) &&
+			$this->textPolicyValidator->textIsHarmless( $applicant->getPhysicalAddress()->getCity() ) &&
+			$this->textPolicyValidator->textIsHarmless( $applicant->getPhysicalAddress()->getStreetAddress() );
+		return !$harmless;
+	}
+}

--- a/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
+++ b/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
@@ -47,6 +47,8 @@ class ValidMembershipApplication {
 	const PAYMENT_TYPE_DIRECT_DEBIT = 'BEZ';
 	const PAYMENT_PERIOD_IN_MONTHS = 3;
 	const PAYMENT_AMOUNT_IN_EURO = 10;
+	const TOO_HIGH_QUARTERLY_PAYMENT_AMOUNT_IN_EURO = 250.1;
+	const TOO_HIGH_YEARLY_PAYMENT_AMOUNT_IN_EURO = 1000.1;
 
 	const PAYMENT_BANK_ACCOUNT = '0648489890';
 	const PAYMENT_BANK_CODE = '50010517';
@@ -72,6 +74,24 @@ class ValidMembershipApplication {
 			self::MEMBERSHIP_TYPE,
 			$self->newApplicant( $self->newCompanyApplicantName() ),
 			$self->newPayment()
+		);
+	}
+
+	public static function newApplicationWithTooHighQuarterlyAmount(): Application {
+		$self = ( new self() );
+		return Application::newApplication(
+			self::MEMBERSHIP_TYPE,
+			$self->newApplicant( $self->newPersonApplicantName() ),
+			$self->newPaymentWithHighAmount( self::PAYMENT_PERIOD_IN_MONTHS, self::TOO_HIGH_QUARTERLY_PAYMENT_AMOUNT_IN_EURO )
+		);
+	}
+
+	public static function newApplicationWithTooHighYearlyAmount(): Application {
+		$self = ( new self() );
+		return Application::newApplication(
+			self::MEMBERSHIP_TYPE,
+			$self->newApplicant( $self->newPersonApplicantName() ),
+			$self->newPaymentWithHighAmount( 12, self::TOO_HIGH_YEARLY_PAYMENT_AMOUNT_IN_EURO )
 		);
 	}
 
@@ -131,6 +151,14 @@ class ValidMembershipApplication {
 		return new Payment(
 			self::PAYMENT_PERIOD_IN_MONTHS,
 			Euro::newFromFloat( self::PAYMENT_AMOUNT_IN_EURO ),
+			$this->newDirectDebitPayment( $this->newBankData() )
+		);
+	}
+
+	private function newPaymentWithHighAmount( int $periodInMonths, float $amount ): Payment {
+		return new Payment(
+			$periodInMonths,
+			Euro::newFromFloat( $amount ),
 			$this->newDirectDebitPayment( $this->newBankData() )
 		);
 	}

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace WMDE\Fundraising\Frontend\MembershipContext\Tests\Unit\UseCases\ApplyForMembership;
+
+use WMDE\Fundraising\Frontend\MembershipContext\Tests\Data\ValidMembershipApplication;
+use WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipPolicyValidator;
+use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
+
+class ApplyForMembershipPolicyValidatorTest extends \PHPUnit_Framework_TestCase {
+
+	public function testGivenQuarterlyAmountTooHigh_MembershipApplicationNeedsModeration() {
+		$textPolicyValidator = $this->createMock( TextPolicyValidator::class );
+		$textPolicyValidator->method( 'textIsHarmless' )->willReturn( true );
+		$policyValidator = new ApplyForMembershipPolicyValidator( $textPolicyValidator );
+		$this->assertTrue( $policyValidator->needsModeration(
+			ValidMembershipApplication::newApplicationWithTooHighQuarterlyAmount()
+		) );
+	}
+
+	public function testGivenYearlyAmountTooHigh_MembershipApplicationNeedsModeration() {
+		$textPolicyValidator = $this->createMock( TextPolicyValidator::class );
+		$textPolicyValidator->method( 'textIsHarmless' )->willReturn( true );
+		$policyValidator = new ApplyForMembershipPolicyValidator( $textPolicyValidator );
+		$this->assertTrue( $policyValidator->needsModeration(
+			ValidMembershipApplication::newApplicationWithTooHighYearlyAmount()
+		) );
+	}
+
+	public function testFailingTextPolicyValidation_MembershipApplicationNeedsModeration() {
+		$textPolicyValidator = $this->createMock( TextPolicyValidator::class );
+		$textPolicyValidator->method( 'textIsHarmless' )->willReturn( false );
+		$policyValidator = new ApplyForMembershipPolicyValidator( $textPolicyValidator );
+		$this->assertTrue( $policyValidator->needsModeration(
+			ValidMembershipApplication::newDomainEntity()
+		) );
+	}
+
+}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -33,6 +33,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\Cache\AllOfTheCachePurger;
 use WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker;
 use WMDE\Fundraising\Frontend\Infrastructure\PiwikServerSideTracker;
 use WMDE\Fundraising\Frontend\Infrastructure\ServerSideTracker;
+use WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipPolicyValidator;
 use WMDE\Fundraising\Frontend\Presentation\Honorifics;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\PageNotFoundPresenter;
 use WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchUseCase;
@@ -983,6 +984,7 @@ class FunFunFactory {
 			$this->newMembershipApplicationTokenFetcher(),
 			$this->newApplyForMembershipMailer(),
 			$this->newMembershipApplicationValidator(),
+			$this->newApplyForMembershipPolicyValidator(),
 			$this->newMembershipApplicationTracker(),
 			$this->newMembershipApplicationPiwikTracker()
 		);
@@ -1013,6 +1015,10 @@ class FunFunFactory {
 
 	private function newMembershipApplicationPiwikTracker(): ApplicationPiwikTracker {
 		return new DoctrineApplicationPiwikTracker( $this->getEntityManager() );
+	}
+
+	private function newApplyForMembershipPolicyValidator(): ApplyForMembershipPolicyValidator {
+		return new ApplyForMembershipPolicyValidator( $this->newTextPolicyValidator( 'fields' ) );
 	}
 
 	public function newCancelMembershipApplicationUseCase( string $updateToken ): CancelMembershipApplicationUseCase {


### PR DESCRIPTION
Move moderation policy to its own class, similar to donation.
Use TextPolicy for address fields in moderation application.

This is for https://github.com/wmde/fundraising/issues/1154