### PR TITLE
allow postal codes between 1 and 6 digits if not defined otherwise

### DIFF
--- a/app/js/lib/country_specifics_repository.js
+++ b/app/js/lib/country_specifics_repository.js
@@ -4,7 +4,7 @@ var _ = require( 'underscore' ),
 	countrySpecifics = {
 		generic: {
 			postCode: {
-				'data-pattern': '{1,}',
+				'data-pattern': '^\\s*[0-9]{1,6}\\s*$',
 				placeholder: 'z. B. 10117',
 				title: 'Postleitzahl'
 			},

--- a/app/js/tests/test_country_specifics_repository.js
+++ b/app/js/tests/test_country_specifics_repository.js
@@ -36,7 +36,7 @@ test( 'Generics', function ( t ) {
 		var countrySpecifics = getCountrySpecifics( countryCode ),
 			expectedAttributes = {
 				postCode: {
-					'data-pattern': '{1,}',
+					'data-pattern': '^\\s*[0-9]{1,6}\\s*$',
 					placeholder: 'z. B. 10117',
 					title: 'Postleitzahl'
 				},


### PR DESCRIPTION
The pattern we've been using is actually invalid.
(see wmde/fundraising#1170)