### PR TITLE
use silex' twig instance

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -24,6 +24,7 @@ $app = new Application();
 $app->register( new SessionServiceProvider() );
 $app->register( new RoutingServiceProvider() );
 $app->register( new TwigServiceProvider() );
+$ffFactory->setTwigEnvironment( $app['twig'] );
 
 $app->before(
 	function ( Request $request, Application $app ) {

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -16,6 +16,7 @@
 	"web-basepath": "",
 	"twig": {
 		"enable-cache": true,
+		"strict-variables": false,
 		"loaders": {
 			"wiki": {
 				"enabled": true,

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -110,6 +110,11 @@
           "description": "If template caching should be enabled",
           "default": true
         },
+        "strict-variables": {
+            "type": "boolean",
+            "description": "Make twig throw errors when templates refer to non-existing variables",
+            "default": false
+        },
         "loaders": {
           "type": "object",
           "title": "Configuration for the different Twig template loaders.",
@@ -161,6 +166,7 @@
       "additionalProperties": false,
       "required": [
         "enable-cache",
+        "strict-variables",
         "loaders"
       ]
     },

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -341,8 +341,7 @@ class FunFunFactory {
 		};
 
 		$pimple['twig_factory'] = function () {
-			// TODO: like this we end up with two Twig instance, one created here and on in the framework
-			return new TwigFactory( $this->config['twig'], $this->getCachePath() . '/twig' );
+			return new TwigFactory( $this->pimple['twig_environment'], $this->config['twig'], $this->getCachePath() . '/twig' );
 		};
 
 		$pimple['twig'] = function() {
@@ -503,6 +502,10 @@ class FunFunFactory {
 
 	public function newGetInTouchHTMLPresenter(): GetInTouchHtmlPresenter {
 		return new GetInTouchHtmlPresenter( $this->getIncludeTemplate( 'Kontaktformular.twig' ), $this->getTranslator() );
+	}
+
+	public function setTwigEnvironment( Twig_Environment $twig ) {
+		$this->pimple['twig_environment'] = $twig;
 	}
 
 	public function getTwig(): Twig_Environment {


### PR DESCRIPTION
The way we created a `Twig_Environment` instance blocks us from using the twig bridge services provided by `TwigServiceProvider`. This change injects Silex' twig instance (and thus the twig bridge) into pimple.