### PR TITLE
Make subscription confirmation a named route

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -250,7 +250,8 @@ $app->get( 'contact/confirm-subscription/{confirmationCode}', function ( $confir
 	$response = $useCase->confirmSubscription( $confirmationCode );
 	return $ffFactory->newConfirmSubscriptionHtmlPresenter()->present( $response );
 } )
-->assert( 'confirmationCode', '^[0-9a-f]+$' );
+->assert( 'confirmationCode', '^[0-9a-f]+$' )
+->bind( 'confirm-subscription' );
 
 $app->get(
 	'check-iban',


### PR DESCRIPTION
This makes it possible to easily generate the URL path for this route in the 
mail template.

This is for https://github.com/wmde/fundraising/issues/1110