### PR TITLE
Check SOA record in DNS checks

### DIFF
--- a/src/Infrastructure/InternetDomainNameValidator.php
+++ b/src/Infrastructure/InternetDomainNameValidator.php
@@ -11,7 +11,7 @@ namespace WMDE\Fundraising\Frontend\Infrastructure;
 class InternetDomainNameValidator implements DomainNameValidator {
 
 	public function isValid( string $domain ): bool {
-		return checkdnsrr( $domain, 'MX' ) || checkdnsrr( $domain, 'A' );
+		return checkdnsrr( $domain, 'MX' ) || checkdnsrr( $domain, 'A' ) || checkdnsrr( $domain, 'SOA' );
 	}
 
 }


### PR DESCRIPTION
Not all mail domains have a MX or A record, some are zones with only a
'SOA' record where the MX and A records are delegated to another
subdomain.

Example: web.de-mail.de

This fixes https://github.com/wmde/fundraising/issues/1207