### PR TITLE
Strip commas from street names

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -118,7 +118,7 @@ class AddDonationHandler {
 		$donationRequest->setDonorCompany( $request->get( 'companyName', '' ) );
 		$donationRequest->setDonorFirstName( $request->get( 'firstName', '' ) );
 		$donationRequest->setDonorLastName( $request->get( 'lastName', '' ) );
-		$donationRequest->setDonorStreetAddress( $request->get( 'street', '' ) );
+		$donationRequest->setDonorStreetAddress( $this->filterFormvalue( $request->get( 'street', '' ) ) );
 		$donationRequest->setDonorPostalCode( $request->get( 'postcode', '' ) );
 		$donationRequest->setDonorCity( $request->get( 'city', '' ) );
 		$donationRequest->setDonorCountryCode( $request->get( 'country', '' ) );
@@ -198,4 +198,7 @@ class AddDonationHandler {
 		return $tracking;
 	}
 
+	private function filterFormvalue( string $value ): string {
+		return trim( preg_replace( ['/,/', '/\s{2,}/'], [' ', ' '], $value ) );
+	}
 }

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -701,4 +701,23 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
+	public function testGivenCommasInStreetInput_donationGetsPersisted() {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+
+			$client->setServerParameter( 'HTTP_REFERER', 'https://en.wikipedia.org/wiki/Karla_Kennichnich' );
+			$client->followRedirects( false );
+
+			$formInput = $this->newValidFormInput();
+			$formInput['street'] = ',Lehmgasse, 12,';
+
+			$client->request(
+				'POST',
+				'/donation/add',
+				$formInput
+			);
+
+			$this->assertIsExpectedDonation( $this->getDonationFromDatabase( $factory ) );
+		} );
+	}
+
 }


### PR DESCRIPTION
For some unknown reason there are many commas in street names. The
easiest fix for this is just stripping them, it will probably not harm
the readability.

This is for fixing https://github.com/wmde/fundraising/issues/1202