### PR TITLE
Use more specific locale in Paypal URL

### DIFF
--- a/src/Presentation/PayPalUrlGenerator.php
+++ b/src/Presentation/PayPalUrlGenerator.php
@@ -16,6 +16,7 @@ class PayPalUrlGenerator {
 	const PAYMENT_REATTEMPT = '1';
 	const PAYMENT_CYCLE_INFINITE = '0';
 	const PAYMENT_CYCLE_MONTHLY = 'M';
+	const DEFAULT_LOCALE = 'de_DE';
 
 	private $config;
 
@@ -39,7 +40,7 @@ class PayPalUrlGenerator {
 		return [
 			'business' => $this->config->getPayPalAccountAddress(),
 			'currency_code' => 'EUR',
-			'lc' => 'de',
+			'lc' => self::DEFAULT_LOCALE,
 			'item_name' => $this->config->getItemName(),
 			'item_number' => $itemId,
 			'notify_url' => $this->config->getNotifyUrl(),

--- a/tests/Unit/PayPalUrlGeneratorTest.php
+++ b/tests/Unit/PayPalUrlGeneratorTest.php
@@ -106,7 +106,7 @@ class PayPalUrlGeneratorTest extends \PHPUnit_Framework_TestCase {
 		$this->assertContains( 'https://www.sandbox.paypal.com/cgi-bin/webscr', $generatedUrl );
 		$this->assertContains( 'business=foerderpp%40wikimedia.de', $generatedUrl );
 		$this->assertContains( 'currency_code=EUR', $generatedUrl );
-		$this->assertContains( 'lc=de', $generatedUrl );
+		$this->assertContains( 'lc=de_DE', $generatedUrl );
 		$this->assertContains( 'item_name=Mentioning+that+awesome+organization+on+the+invoice', $generatedUrl );
 		$this->assertContains( 'item_number=1234', $generatedUrl );
 		$this->assertContains( 'notify_url=http%3A%2F%2Fmy.donation.app%2Fhandler%2Fpaypal%2F', $generatedUrl );


### PR DESCRIPTION
On the official list of supported locales, our shortened locale "de"
does not show up and there is no mention if a shortened locale will be
processed by PayPal:
https://developer.paypal.com/docs/classic/api/locale_codes/

So now the default locale is one of the offical Paypal language codes,
'de_DE'.