### PR TITLE
Fix select fields

### DIFF
--- a/web/skin/10h16/_js/spenden.wikimedia.js
+++ b/web/skin/10h16/_js/spenden.wikimedia.js
@@ -81,7 +81,7 @@ $(function() {
 
 		}
 
-      $( 'select' ).selectmenu( {
+      $( '.ctcol select' ).selectmenu( {
             positionOptions: {
               collision: 'none'
             },


### PR DESCRIPTION
Only "prettify" select fields with the "selectmenu" jQuery UI plugin
inside the main column. This avoids unselectable items and missing
change events in lightboxes that don't account for `select` items being
replaced. Example: BTC currency selection.

This fixes https://github.com/wmde/fundraising/issues/1208