### PR TITLE
Bank data validation

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -145,7 +145,7 @@ class AddDonationHandler {
 			->setBankCode( $request->get( 'blz', '' ) )
 			->setBankName( $request->get( 'bankname', '' ) );
 
-		if ( $bankData->hasIban() && !$bankData->hasCompleteLegacyBankData() ) {
+		if ( $bankData->hasIban() && !$bankData->hasBic() && !$bankData->hasCompleteLegacyBankData() ) {
 			$bankData = $this->newBankDataFromIban( $bankData->getIban() );
 		}
 		if ( $bankData->hasCompleteLegacyBankData() && !$bankData->hasIban() ) {

--- a/app/js/lib/form_components.js
+++ b/app/js/lib/form_components.js
@@ -202,6 +202,7 @@ module.exports = {
 		var component = objectAssign( Object.create( BankDataComponent ), bankDataElements );
 		bankDataElements.ibanElement.on( 'change', createDefaultChangeHandler( store, 'iban' ) );
 		bankDataElements.bicElement.on( 'change', createDefaultChangeHandler( store, 'bic' ) );
+		bankDataElements.bicElement.on( 'change', createRegexValidator( store, 'bic' ) );
 		bankDataElements.accountNumberElement.on( 'change', createDefaultChangeHandler( store, 'accountNumber' ) );
 		bankDataElements.bankCodeElement.on( 'change', createDefaultChangeHandler( store, 'bankCode' ) );
 		bankDataElements.debitTypeElement.on( 'change', createDefaultChangeHandler( store, 'debitType' ) );

--- a/app/js/lib/reducers/form_content.js
+++ b/app/js/lib/reducers/form_content.js
@@ -103,7 +103,7 @@ module.exports = {
 				}
 				return objectAssign( {}, state, {
 					iban: action.payload.iban || '',
-					bic: action.payload.bic || '',
+					bic: action.payload.bic || state.bic || '',
 					accountNumber: action.payload.account || '',
 					bankCode: action.payload.bankCode || '',
 					bankName: action.payload.bankName || ''

--- a/app/js/lib/reducers/validity.js
+++ b/app/js/lib/reducers/validity.js
@@ -39,7 +39,7 @@ function validity( state, action ) {
 			return objectAssign( {}, state, { address: convertExternalResult( action ) } );
 		case 'FINISH_BANK_DATA_VALIDATION':
 			return objectAssign( {}, state, {
-				bankData: convertExternalResult( action ) && action.payload.bic
+				bankData: convertExternalResult( action )
 			} );
 		case 'FINISH_SEPA_CONFIRMATION_VALIDATION':
 			return objectAssign( {}, state, { sepaConfirmation: action.payload } );

--- a/app/js/tests/reducers/test_form_content.js
+++ b/app/js/tests/reducers/test_form_content.js
@@ -201,3 +201,14 @@ test( 'FINISH_BANK_DATA_VALIDATION does not modify state data when status is not
 	t.end();
 } );
 
+test( 'FINISH_BANK_DATA_VALIDATION does not clear BIC when it is not passed in validation response', function ( t ) {
+	var stateBefore = { iban: 'AT022050302101023600', bic: 'SPIHAT22XXX', accountNumber: '', bankCode: '', bankName: '' },
+		action = { type: 'FINISH_BANK_DATA_VALIDATION', payload: {
+			status: 'OK',
+			iban: 'AT022050302101023600'
+		} };
+
+	deepFreeze( stateBefore );
+	t.deepEqual( formContent( stateBefore, action ), stateBefore );
+	t.end();
+} );

--- a/app/js/tests/reducers/test_validity.js
+++ b/app/js/tests/reducers/test_validity.js
@@ -50,11 +50,11 @@ test( 'FINISH_BANK_DATA_VALIDATION with BIC sets bank data validation state to v
 	t.end();
 } );
 
-test( 'FINISH_BANK_DATA_VALIDATION without BIC sets bank data validation state to invalid', function ( t ) {
+test( 'FINISH_BANK_DATA_VALIDATION without BIC does not set bank data validation state to invalid', function ( t ) {
 	var beforeState = { bankData: null };
 
 	deepFreeze( beforeState );
-	t.notOk( validity( beforeState, { type: 'FINISH_BANK_DATA_VALIDATION', payload: {
+	t.ok( validity( beforeState, { type: 'FINISH_BANK_DATA_VALIDATION', payload: {
 		status: 'OK',
 		iban: 'AT022050302101023600'
 	} } ).bankData );

--- a/app/js/tests/test_form_components.js
+++ b/app/js/tests/test_form_components.js
@@ -13,8 +13,8 @@ var test = require( 'tape' ),
 			change: sinon.spy()
 		};
 	},
-	assertChangeHandlerWasSet = function ( t, spyingElement ) {
-		t.ok( spyingElement.on.calledOnce, 'event handler was set once' );
+	assertChangeHandlerWasSet = function ( t, spyingElement, expectedCallCount ) {
+		t.equal( spyingElement.on.callCount, expectedCallCount || 1, 'event handler was set' );
 		t.equal( spyingElement.on.firstCall.args[ 0 ], 'change', 'event handler was set for change events' );
 		t.equal( typeof spyingElement.on.firstCall.args[ 1 ], 'function', 'event handler is a function' );
 	},
@@ -244,7 +244,7 @@ test( 'Bank data component adds change handling function to its elements', funct
 	formComponents.createBankDataComponent( store, bankDataComponentConfig );
 
 	assertChangeHandlerWasSet( t, bankDataComponentConfig.ibanElement );
-	assertChangeHandlerWasSet( t, bankDataComponentConfig.bicElement );
+	assertChangeHandlerWasSet( t, bankDataComponentConfig.bicElement, 2 );
 	assertChangeHandlerWasSet( t, bankDataComponentConfig.accountNumberElement );
 	assertChangeHandlerWasSet( t, bankDataComponentConfig.bankCodeElement );
 	assertChangeHandlerWasSet( t, bankDataComponentConfig.debitTypeElement );

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
@@ -27,6 +27,9 @@ use WMDE\Fundraising\Frontend\Validation\ValidationResult;
  */
 class AddDonationValidatorTest extends ValidatorTestCase {
 
+	const FOREIGN_IBAN = 'NL18ABNA0484869868';
+	const FOREIGN_BIC = 'ABNANL2A';
+
 	/** @var AddDonationValidator */
 	private $donationValidator;
 
@@ -107,7 +110,22 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 
 		$this->assertConstraintWasViolated( $result, AddDonationValidationResult::SOURCE_IBAN );
 		$this->assertConstraintWasViolated( $result, AddDonationValidationResult::SOURCE_BIC );
-		$this->assertConstraintWasViolated( $result, AddDonationValidationResult::SOURCE_BANK_NAME );
+	}
+
+	public function testForeignDirectDebitMissingBankData_validationSucceeds() {
+		$bankData = new BankData();
+		$bankData->setIban( new Iban( self::FOREIGN_IBAN ) );
+		$bankData->setBic( self::FOREIGN_BIC );
+		$bankData->setBankName( '' );
+		$bankData->setAccount( '' );
+		$bankData->setBankCode( '' );
+
+		$request = ValidAddDonationRequest::getRequest();
+		$request->setBankData( $bankData );
+
+		$result = $this->donationValidator->validate( $request );
+		$this->assertTrue( $result->isSuccessful() );
+		$this->assertFalse( $result->hasViolations() );
 	}
 
 	public function testAmountTooLow_validatorReturnsFalse() {

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -159,16 +159,16 @@ class MembershipApplicationValidatorTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function testWhenBankNameIsMissing_validationFails() {
+	public function testWhenBankNameIsMissing_validationSucceeds() {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
 		$request->getBankData()->setBankName( '' );
+		$response = $this->newValidator()->validate( $request );
 
-		$this->assertRequestValidationResultInErrors(
-			$request,
-			[ Result::SOURCE_BANK_NAME => Result::VIOLATION_MISSING ]
-		);
+		$this->assertEquals( new Result(), $response );
+		$this->assertEmpty( $response->getViolationSources() );
+		$this->assertTrue( $response->isSuccessful() );
 	}
 
 	public function testWhenBankCodeIsMissing_validationFails() {

--- a/contexts/PaymentContext/src/Domain/Model/BankData.php
+++ b/contexts/PaymentContext/src/Domain/Model/BankData.php
@@ -74,6 +74,10 @@ class BankData {
 		return !empty( $this->getIban()->toString() );
 	}
 
+	public function hasBic(): bool {
+		return !empty( $this->getBic() );
+	}
+
 	public function hasCompleteLegacyBankData(): bool {
 		return !empty( $this->getAccount() ) || !empty( $this->getBankCode() );
 	}

--- a/src/Validation/BankDataValidator.php
+++ b/src/Validation/BankDataValidator.php
@@ -25,7 +25,6 @@ class BankDataValidator {
 
 		$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getIban()->toString() ), 'iban' );
 		$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getBic() ), 'bic' );
-		$violations[] = $this->getFieldViolation( $validator->validate( $bankData->getBankName() ), 'bankname' );
 
 		if ( $bankData->getIban()->getCountryCode() === 'DE' ) {
 			$stringLengthValidator = new StringLengthValidator();

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -720,4 +720,29 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
+	public function testGivenSufficientForeignBankData_donationGetsPersisted() {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$formInput = $this->newValidFormInput();
+			$formInput['iban'] = 'AT022050302101023600';
+			$formInput['bic'] = 'SPIHAT22XXX';
+			$formInput['konto'] = '';
+			$formInput['blz'] = '';
+			$formInput['bankname'] = '';
+			$client->request(
+				'POST',
+				'/donation/add',
+				$formInput
+			);
+
+			$donation = $this->getDonationFromDatabase( $factory );
+			$data = $donation->getDecodedData();
+
+			$this->assertSame( 'AT022050302101023600', $data['iban'] );
+			$this->assertSame( 'SPIHAT22XXX', $data['bic'] );
+			$this->assertSame( '', $data['konto'] );
+			$this->assertSame( '', $data['blz'] );
+			$this->assertSame( '', $data['bankname'] );
+		} );
+	}
+
 }

--- a/web/res/js/donationForm.js
+++ b/web/res/js/donationForm.js
@@ -71,7 +71,7 @@ $( function () {
 						initData.data( 'generate-iban-url' )
 					),
 					actions.newFinishBankDataValidationAction,
-					[ 'iban', 'accountNumber', 'bankCode', 'debitType', 'paymentType' ],
+					[ 'iban', 'bic', 'accountNumber', 'bankCode', 'debitType', 'paymentType' ],
 					initialValues
 				),
 				WMDE.ReduxValidation.createValidationDispatcher(

--- a/web/res/js/membershipForm.js
+++ b/web/res/js/membershipForm.js
@@ -83,7 +83,7 @@ $( function () {
 						initData.data( 'generate-iban-url' )
 					),
 					actions.newFinishBankDataValidationAction,
-					[ 'iban', 'accountNumber', 'bankCode', 'debitType', 'paymentType' ],
+					[ 'iban', 'bic', 'accountNumber', 'bankCode', 'debitType', 'paymentType' ],
 					initialValues
 				),
 				WMDE.ReduxValidation.createValidationDispatcher(


### PR DESCRIPTION
The bank data validation did not work well with IBANs that do not start with "DE".

- Bank data is not considered invalid when BIC is missing in the validation result.
- BIC is not overwritten with an empty value anymore.
- Bank name is not a mandatory field anymore.
- BIC is also validated by regex now.

This is a fix for wmde/fundraising#1247 and wmde/fundraising#1254