### PR TITLE
Add special case for PayPal currency check

### DIFF
--- a/app/RouteHandlers/PayPalNotificationHandler.php
+++ b/app/RouteHandlers/PayPalNotificationHandler.php
@@ -32,15 +32,11 @@ class PayPalNotificationHandler {
 		try {
 			$this->ffFactory->getPayPalPaymentNotificationVerifier()->verify( $post->all() );
 		} catch ( PayPalPaymentNotificationVerifierException $e ) {
-			// TODO: let PayPal resend IPN?
-
 			$this->ffFactory->getPaypalLogger()->log( LogLevel::ERROR, $e->getMessage(), [
 				'post_vars' => $request->request->all()
 			] );
 			return $this->createErrorResponse( $e );
 		}
-
-		// TODO: check txn_type
 
 		$useCase = $this->ffFactory->newHandlePayPalPaymentNotificationUseCase( $this->getUpdateToken( $post ) );
 

--- a/src/Infrastructure/PayPalPaymentNotificationVerifier.php
+++ b/src/Infrastructure/PayPalPaymentNotificationVerifier.php
@@ -15,6 +15,9 @@ class PayPalPaymentNotificationVerifier implements PaymentNotificationVerifier {
 
 	/* private */ const ALLOWED_STATUSES = [ 'Completed', 'Processed' ];
 	/* private */ const ALLOWED_CURRENCY_CODES = [ 'EUR' ];
+	/* private */ const NOTIFICATION_TYPES_WITH_DIFFERENT_CURRENCY_FIELDS = [
+		'recurring_payment_suspended_due_to_max_failed_payment'
+	];
 
 	private $httpClient;
 	private $config;
@@ -86,7 +89,17 @@ class PayPalPaymentNotificationVerifier implements PaymentNotificationVerifier {
 	}
 
 	private function hasValidCurrencyCode( array $request ): bool {
-		return array_key_exists( 'mc_currency', $request ) &&
+		if ( $this->hasDifferentCurrencyField( $request ) ) {
+			return array_key_exists( 'currency_code', $request ) &&
+				in_array( $request['currency_code'], self::ALLOWED_CURRENCY_CODES );
+		}
+		return
+			array_key_exists( 'mc_currency', $request ) &&
 			in_array( $request['mc_currency'], self::ALLOWED_CURRENCY_CODES );
+	}
+
+	private function hasDifferentCurrencyField( array $request ): bool {
+		return array_key_exists( 'txn_type', $request ) &&
+			in_array( $request['txn_type'], self::NOTIFICATION_TYPES_WITH_DIFFERENT_CURRENCY_FIELDS );
 	}
 }

--- a/tests/Unit/Infrastructure/PayPalPaymentNotificationVerifierTest.php
+++ b/tests/Unit/Infrastructure/PayPalPaymentNotificationVerifierTest.php
@@ -154,7 +154,7 @@ class PayPalPaymentNotificationVerifierTest extends \PHPUnit_Framework_TestCase 
 		return $this->newClient( $body );
 	}
 
-	private function newClient( Stream $body, array $expectedParams=null ): Client {
+	private function newClient( Stream $body, array $expectedParams = null ): Client {
 		$response = $this->getMockBuilder( Response::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getBody' ] )


### PR DESCRIPTION
The PayPal notification
`recurring_payment_suspended_due_to_max_failed_payment` has no
`mc_currency` field which causes an unhandled exception instead of
being passed to the use case (where it is dropped). This can lead to
Paypal re-trying the notification and/or disabling notifications.