### PR TITLE
Added PHPUnit config to each context

### DIFF
--- a/contexts/DonationContext/phpunit.xml.dist
+++ b/contexts/DonationContext/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<phpunit bootstrap="../../tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/contexts/MembershipContext/phpunit.xml.dist
+++ b/contexts/MembershipContext/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<phpunit bootstrap="../../tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/contexts/PaymentContext/phpunit.xml.dist
+++ b/contexts/PaymentContext/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<phpunit bootstrap="../../tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/contexts/SubscriptionContext/phpunit.xml.dist
+++ b/contexts/SubscriptionContext/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<phpunit bootstrap="../../tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Typically it is better to use the main config file and run

    vendor/bin/phpunit contexts/DonationContext

in case you just want to run for one context. For some tools,
such as Humbug (Mutation Testing), having a dedicated config
file makes things a lot easier.