### PR TITLE
Shorten PHPUnit testsuite names

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,15 +12,15 @@
          stopOnSkipped="false"
          verbose="false">
     <testsuites>
-        <testsuite name="FundraisingFrontend-unit">
+        <testsuite name="unit">
             <directory>tests/Unit</directory>
             <directory>contexts/*/tests/Unit</directory>
         </testsuite>
-        <testsuite name="FundraisingFrontend-integration">
+        <testsuite name="integration">
             <directory>tests/Integration</directory>
             <directory>contexts/*/tests/Integration</directory>
         </testsuite>
-        <testsuite name="FundraisingFrontend-edgetoedge">
+        <testsuite name="edgetoedge">
             <directory>tests/EdgeToEdge</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Not sure why we'd need to have these namespaced. Only makes using
them as filter more annoying as far as I can tell.