### PR TITLE
add payment delay option to config schema documentation

### DIFF
--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -502,6 +502,12 @@
           "default": ""
         }
       },
+      "delay-in-days": {
+        "type": "int",
+        "title": "Delay in days",
+        "description": "Number of days until the first payment will be made",
+        "default": 90
+      },
       "additionalProperties": false,
       "required": [
         "base-url",


### PR DESCRIPTION
Commit 13fb8c6 in #656 introduced a payment delay in days. This PR catches up on this in `schema.json`.