### PR TITLE
Membership application confirmation

### DIFF
--- a/app/translations/donationStatus.de_DE.json
+++ b/app/translations/donationStatus.de_DE.json
@@ -1,8 +1,0 @@
-{
-	"P": "wurde registriert und wird geprüft",
-	"N": "wurde registriert und wird in Kürze gebucht",
-	"X": "wurde registriert und wartet auf Bestätigung",
-	"Z": "wurde zugesagt und wartet auf Buchung",
-	"B": "wurde gebucht",
-	"E": "ist in Buchung"
-}

--- a/app/translations/paymentStatus.de_DE.json
+++ b/app/translations/paymentStatus.de_DE.json
@@ -1,0 +1,8 @@
+{
+	"status-pending": "wurde registriert und wird geprüft",
+	"status-new": "wurde registriert und wird in Kürze gebucht",
+	"status-unconfirmed": "wurde registriert und wartet auf Bestätigung",
+	"status-pledge": "wurde zugesagt und wartet auf Buchung",
+	"status-booked": "wurde gebucht",
+	"status-booking": "ist in Buchung"
+}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -318,9 +318,9 @@ class FunFunFactory {
 
 			$translator->addResource(
 				'json',
-				__DIR__ . '/../../app/translations/donationStatus.' . $locale . '.json',
+				__DIR__ . '/../../app/translations/paymentStatus.' . $locale . '.json',
 				$locale,
-				'donationStatus'
+				'paymentStatus'
 			);
 
 			$translator->addResource(

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -40,7 +40,7 @@ class DonationConfirmationHtmlPresenter {
 			'templateCampaign' => $selectedPage->getCampaignCode(),
 			'donation' => [
 				'id' => $donation->getId(),
-				'status' => $donation->getStatus(),
+				'status' => $this->mapStatus( $donation->getStatus() ),
 				'amount' => $donation->getAmount()->getEuroFloat(),
 				'interval' => $donation->getPaymentIntervalInMonths(),
 				'paymentType' => $donation->getPaymentType(),
@@ -137,4 +137,26 @@ class DonationConfirmationHtmlPresenter {
 		];
 	}
 
+	/**
+	 * Maps the membership application's status to a translatable message key
+	 *
+	 * @param string $status
+	 * @return string
+	 */
+	private function mapStatus( string $status ): string {
+		switch ( $status ) {
+			case Donation::STATUS_MODERATION:
+				return 'status-pending';
+			case Donation::STATUS_NEW:
+				return 'status-new';
+			case Donation::STATUS_EXTERNAL_INCOMPLETE:
+				return 'status-unconfirmed';
+			case Donation::STATUS_PROMISE:
+				return 'status-pledge';
+			case Donation::STATUS_EXTERNAL_BOOKED:
+				return 'status-booked';
+			default:
+				return 'status-unknown';
+		}
+	}
 }

--- a/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
@@ -5,7 +5,6 @@ namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Applicant;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\UseCases\ShowMembershipApplicationConfirmation\ShowMembershipAppConfirmationResponse;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\DirectDebitPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
@@ -44,6 +43,8 @@ class MembershipApplicationConfirmationHtmlPresenter {
 	private function getApplicationArguments( Application $membershipApplication, string $updateToken ): array {
 		return [
 			'id' => $membershipApplication->getId(),
+			'paymentType' => $membershipApplication->getPayment()->getPaymentMethod()->getType(),
+			'status' => $this->mapStatus( $membershipApplication->isConfirmed() ),
 			'membershipFee' => $membershipApplication->getPayment()->getAmount()->getEuroString(),
 			'paymentIntervalInMonths' => $membershipApplication->getPayment()->getIntervalInMonths(),
 			'updateToken' => $updateToken
@@ -72,6 +73,16 @@ class MembershipApplicationConfirmationHtmlPresenter {
 		}
 
 		return [];
+	}
+
+	/**
+	 * Maps the membership application's status to a translatable message key
+	 *
+	 * @param bool $isConfirmed
+	 * @return string
+	 */
+	private function mapStatus( bool $isConfirmed ): string {
+		return $isConfirmed ? 'status-booked' : 'status-unconfirmed';
 	}
 
 }

--- a/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
@@ -22,6 +22,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\FixedTokenGenerator;
 class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 
 	const CORRECT_ACCESS_TOKEN = 'KindlyAllowMeAccess';
+	const MAPPED_STATUS = 'status-new';
 
 	const ACCESS_DENIED_TEXT = 'keine Berechtigung';
 
@@ -170,7 +171,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		$paymentMethod = $donation->getPaymentMethod();
 
 		$this->assertContains( 'donation.id: ' . $donation->getId(), $responseContent );
-		$this->assertContains( 'donation.status: ' . $donation->getStatus(), $responseContent );
+		$this->assertContains( 'donation.status: ' . self::MAPPED_STATUS, $responseContent );
 		$this->assertContains( 'donation.amount: ' . $donation->getAmount()->getEuroString(), $responseContent );
 		$this->assertContains( 'donation.interval: ' . $donation->getPaymentIntervalInMonths(), $responseContent );
 		$this->assertContains( 'donation.paymentType: ' . $donation->getPaymentType(), $responseContent );

--- a/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Tests\Integration\Presentation\Presenters;
+
+use WMDE\Fundraising\Frontend\MembershipContext\Tests\Data\ValidMembershipApplication;
+use WMDE\Fundraising\Frontend\MembershipContext\UseCases\ShowMembershipApplicationConfirmation\ShowMembershipAppConfirmationResponse;
+use WMDE\Fundraising\Frontend\Presentation\Presenters\MembershipApplicationConfirmationHtmlPresenter;
+use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
+
+/**
+ * @covers WMDE\Fundraising\Frontend\Presentation\Presenters\MembershipApplicationConfirmationHtmlPresenter
+ *
+ * @licence GNU GPL v2+
+ * @author Kai Nissen < kai.nissen@wikimedia.de >
+ */
+class MembershipApplicationConfirmationHtmlPresenterTest extends \PHPUnit_Framework_TestCase {
+
+	private const STATUS_BOOKED = 'status-booked';
+	private const STATUS_UNCONFIRMED = 'status-unconfirmed';
+
+	/** @dataProvider applicationStatusProvider */
+	public function testWhenPresenterPresents_itPassesParametersToTemplate( $isConfirmed, $expectedMappedStatus ) {
+		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
+		$twig->expects( $this->once() )
+			->method( 'render' )
+			->with( $this->getExpectedRenderParams( $expectedMappedStatus ) );
+
+		$membershipApplication = ValidMembershipApplication::newDomainEntityUsingPayPal();
+		if ( $isConfirmed === true ) {
+			$membershipApplication->confirm();
+		}
+
+		$presenter = new MembershipApplicationConfirmationHtmlPresenter( $twig );
+		$presenter->present(
+			ShowMembershipAppConfirmationResponse::newValidResponse(
+				$membershipApplication,
+				'update_token'
+			)
+		);
+	}
+
+	public function applicationStatusProvider() {
+		return [
+			[ true, self::STATUS_BOOKED ],
+			[ false, self::STATUS_UNCONFIRMED ]
+		];
+	}
+
+	private function getExpectedRenderParams( string $mappedStatus ): array {
+		return [
+			'membershipApplication' => [
+				'id' => null,
+				'paymentType' => 'PPL',
+				'status' => $mappedStatus,
+				'membershipFee' => '10.00',
+				'paymentIntervalInMonths' => 3,
+				'updateToken' => 'update_token'
+			],
+			'person' => [
+				'salutation' => 'Herr',
+				'title' => '',
+				'fullName' => 'Potato The Great',
+				'streetAddress' => 'Nyan street',
+				'postalCode' => '1234',
+				'city' => 'Berlin',
+				'email' => 'jeroendedauw@gmail.com',
+			],
+			'bankData' => []
+		];
+	}
+
+}

--- a/tests/templates/DonationConfirmation.twig
+++ b/tests/templates/DonationConfirmation.twig
@@ -119,7 +119,7 @@
 							<div class="payment f-left">
 								{% if donation.paymentType == 'PPL' or donation.paymentType == 'MCP' %}
 									<p>
-										Ihre Spende per {$ donation.paymentType|trans({}, 'paymentTypes') $} {$ donation.status|trans({}, 'donationStatus') $}.
+										Ihre Spende per {$ donation.paymentType|trans({}, 'paymentTypes') $} {$ donation.status|trans({}, 'paymentStatus') $}.
 									</p>
 								{% elseif donation.paymentType == 'BEZ' %}
 									<p>


### PR DESCRIPTION
In order to reflect the additional payment type on the confirmation page, further payment related parameters need to be passed to the template.

Once this is merged, the templates can be changed.