### PR TITLE
automatically set salutation for companies

### DIFF
--- a/contexts/DonationContext/src/Domain/Model/DonorName.php
+++ b/contexts/DonationContext/src/Domain/Model/DonorName.php
@@ -18,6 +18,8 @@ class DonorName {
 	public const PERSON_COMPANY = 'firma';
 	public const PERSON_ANONYMOUS = 'anonym';
 
+	public const COMPANY_SALUTATION = 'Firma';
+
 	private $personType = '';
 
 	private $companyName = '';
@@ -53,7 +55,7 @@ class DonorName {
 	}
 
 	public function getSalutation(): string {
-		return $this->salutation;
+		return $this->personType === self::PERSON_COMPANY ? self::COMPANY_SALUTATION : $this->salutation;
 	}
 
 	public function setSalutation( string $salutation ) {

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
@@ -267,6 +267,24 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $request;
 	}
 
+	private function newValidCompanyDonationRequest(): AddDonationRequest {
+		$request = $this->newMinimumDonationRequest();
+
+		$request->setDonorType( DonorName::PERSON_COMPANY );
+		$request->setDonorFirstName( '' );
+		$request->setDonorLastName( '' );
+		$request->setDonorCompany( ValidDonation::DONOR_LAST_NAME );
+		$request->setDonorSalutation( '' );
+		$request->setDonorTitle( '' );
+		$request->setDonorStreetAddress( ValidDonation::DONOR_STREET_ADDRESS );
+		$request->setDonorCity( ValidDonation::DONOR_CITY );
+		$request->setDonorPostalCode( ValidDonation::DONOR_POSTAL_CODE );
+		$request->setDonorCountryCode( ValidDonation::DONOR_COUNTRY_CODE );
+		$request->setDonorEmailAddress( ValidDonation::DONOR_EMAIL_ADDRESS );
+
+		return $request;
+	}
+
 	public function testWhenAdditionWorks_successResponseContainsTokens() {
 		$useCase = $this->newValidationSucceedingUseCase();
 
@@ -274,6 +292,14 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertSame( self::UPDATE_TOKEN, $response->getUpdateToken() );
 		$this->assertSame( self::ACCESS_TOKEN, $response->getAccessToken() );
+	}
+
+	public function testWhenAddingCompanyDonation_salutationFieldIsSet() {
+		$useCase = $this->newValidationSucceedingUseCase();
+
+		$response = $useCase->addDonation( $this->newValidCompanyDonationRequest() );
+
+		$this->assertSame( DonorName::COMPANY_SALUTATION, $response->getDonation()->getDonor()->getName()->getSalutation() );
 	}
 
 }

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
@@ -246,12 +246,17 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 	}
 
 	private function newPersonName( DoctrineApplication $application ): ApplicantName {
-		$personName = ApplicantName::newPrivatePersonName();
-
-		$personName->setFirstName( $application->getApplicantFirstName() );
-		$personName->setLastName( $application->getApplicantLastName() );
-		$personName->setSalutation( $application->getApplicantSalutation() );
-		$personName->setTitle( $application->getApplicantTitle() );
+		if ( empty( $application->getCompany() ) ) {
+			$personName = ApplicantName::newPrivatePersonName();
+			$personName->setFirstName( $application->getApplicantFirstName() );
+			$personName->setLastName( $application->getApplicantLastName() );
+			$personName->setSalutation( $application->getApplicantSalutation() );
+			$personName->setTitle( $application->getApplicantTitle() );
+		} else {
+			$personName = ApplicantName::newCompanyName();
+			$personName->setCompanyName( $application->getCompany() );
+			$personName->setSalutation( $application->getApplicantSalutation() );
+		}
 
 		return $personName->freeze()->assertNoNullFields();
 	}

--- a/contexts/MembershipContext/src/Domain/Model/ApplicantName.php
+++ b/contexts/MembershipContext/src/Domain/Model/ApplicantName.php
@@ -13,6 +13,8 @@ use WMDE\Fundraising\Frontend\FreezableValueObject;
 class ApplicantName {
 	use FreezableValueObject;
 
+	public const COMPANY_SALUTATION = 'Firma';
+
 	private $companyName = '';
 
 	private $salutation = '';
@@ -28,7 +30,9 @@ class ApplicantName {
 	}
 
 	public static function newCompanyName(): self {
-		return new self();
+		$companyName = new self();
+		$companyName->setSalutation( self::COMPANY_SALUTATION );
+		return $companyName;
 	}
 
 	public function setCompanyName( string $companyName ) {

--- a/contexts/MembershipContext/src/Domain/Model/Application.php
+++ b/contexts/MembershipContext/src/Domain/Model/Application.php
@@ -15,17 +15,17 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalPayment;
  */
 class Application {
 
-	const ACTIVE_MEMBERSHIP = 'active';
-	const SUSTAINING_MEMBERSHIP = 'sustaining';
+	public const ACTIVE_MEMBERSHIP = 'active';
+	public const SUSTAINING_MEMBERSHIP = 'sustaining';
 
-	const NO_MODERATION_NEEDED = false;
-	const NEEDS_MODERATION = true;
+	private const NO_MODERATION_NEEDED = false;
+	private const NEEDS_MODERATION = true;
 
-	const IS_CURRENT = false;
-	const IS_CANCELLED = true;
+	private const IS_CURRENT = false;
+	private const IS_CANCELLED = true;
 
-	const IS_CONFIRMED = true;
-	const IS_PENDING = false;
+	private const IS_CONFIRMED = true;
+	private const IS_PENDING = false;
 
 	/**
 	 * @var int|null

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/MembershipApplicationBuilder.php
@@ -45,24 +45,26 @@ class MembershipApplicationBuilder {
 	}
 
 	private function newPersonName( ApplyForMembershipRequest $request ): ApplicantName {
-		$personName = $this->newBasePersonName( $request );
+		if ( $request->isCompanyApplication() ) {
+			return $this->newCompanyPersonName( $request );
+		} else {
+			return $this->newPrivatePersonName( $request );
+		}
+	}
 
+	private function newPrivatePersonName( ApplyForMembershipRequest $request ): ApplicantName {
+		$personName = ApplicantName::newPrivatePersonName();
 		$personName->setFirstName( $request->getApplicantFirstName() );
 		$personName->setLastName( $request->getApplicantLastName() );
 		$personName->setSalutation( $request->getApplicantSalutation() );
 		$personName->setTitle( $request->getApplicantTitle() );
-
 		return $personName->freeze()->assertNoNullFields();
 	}
 
-	private function newBasePersonName( ApplyForMembershipRequest $request ): ApplicantName {
-		if ( $request->isCompanyApplication() ) {
-			$personName = ApplicantName::newCompanyName();
-			$personName->setCompanyName( $request->getApplicantCompanyName() );
-			return $personName;
-		}
-
-		return ApplicantName::newPrivatePersonName();
+	private function newCompanyPersonName( ApplyForMembershipRequest $request ): ApplicantName {
+		$personName = ApplicantName::newCompanyName();
+		$personName->setCompanyName( $request->getApplicantCompanyName() );
+		return $personName->freeze()->assertNoNullFields();
 	}
 
 	private function newAddress( ApplyForMembershipRequest $request ): ApplicantAddress {

--- a/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipApplicationConfirmationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipApplicationConfirmationUseCase.php
@@ -4,10 +4,10 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\ShowMembershipApplicationConfirmation;
 
-use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\GetDonationException;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationTokenFetcher;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
+use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\GetMembershipApplicationException;
 
 /**
  * @license GNU GPL v2+
@@ -31,11 +31,11 @@ class ShowMembershipApplicationConfirmationUseCase {
 
 	public function showConfirmation( ShowMembershipAppConfirmationRequest $request ): ShowMembershipAppConfirmationResponse {
 		if ( $this->authorizer->canAccessApplication( $request->getApplicationId() ) ) {
-			$donation = $this->getMembershipApplicationById( $request->getApplicationId() );
+			$application = $this->getMembershipApplicationById( $request->getApplicationId() );
 
-			if ( $donation !== null ) {
+			if ( $application !== null ) {
 				return ShowMembershipAppConfirmationResponse::newValidResponse(
-					$donation,
+					$application,
 					$this->tokenFetcher->getTokens( $request->getApplicationId() )->getUpdateToken()
 				);
 			}
@@ -44,11 +44,11 @@ class ShowMembershipApplicationConfirmationUseCase {
 		return ShowMembershipAppConfirmationResponse::newNotAllowedResponse();
 	}
 
-	private function getMembershipApplicationById( int $donationId ) {
+	private function getMembershipApplicationById( int $applicationId ) {
 		try {
-			return $this->repository->getApplicationById( $donationId );
+			return $this->repository->getApplicationById( $applicationId );
 		}
-		catch ( GetDonationException $ex ) {
+		catch ( GetMembershipApplicationException $ex ) {
 			return null;
 		}
 	}

--- a/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
+++ b/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
@@ -49,6 +49,7 @@ class ValidMembershipApplication {
 	const PAYMENT_TYPE_DIRECT_DEBIT = 'BEZ';
 	const PAYMENT_PERIOD_IN_MONTHS = 3;
 	const PAYMENT_AMOUNT_IN_EURO = 10;
+	const COMPANY_PAYMENT_AMOUNT_IN_EURO = 25;
 	const TOO_HIGH_QUARTERLY_PAYMENT_AMOUNT_IN_EURO = 250.1;
 	const TOO_HIGH_YEARLY_PAYMENT_AMOUNT_IN_EURO = 1000.1;
 
@@ -81,7 +82,7 @@ class ValidMembershipApplication {
 		return Application::newApplication(
 			self::MEMBERSHIP_TYPE,
 			$self->newApplicant( $self->newCompanyApplicantName() ),
-			$self->newPayment()
+			$self->newPaymentWithHighAmount( self::PAYMENT_PERIOD_IN_MONTHS, self::COMPANY_PAYMENT_AMOUNT_IN_EURO )
 		);
 	}
 
@@ -256,6 +257,7 @@ class ValidMembershipApplication {
 		$application->setCompany( self::APPLICANT_COMPANY_NAME );
 		$application->setApplicantTitle( '' );
 		$application->setApplicantSalutation( self::APPLICANT_SALUTATION_COMPANY );
+		$application->setPaymentAmount( self::COMPANY_PAYMENT_AMOUNT_IN_EURO );
 
 		return $application;
 	}

--- a/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
+++ b/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
@@ -30,6 +30,7 @@ class ValidMembershipApplication {
 	const APPLICANT_FIRST_NAME = 'Potato';
 	const APPLICANT_LAST_NAME = 'The Great';
 	const APPLICANT_SALUTATION = 'Herr';
+	const APPLICANT_SALUTATION_COMPANY = ApplicantName::COMPANY_SALUTATION;
 	const APPLICANT_TITLE = '';
 	const APPLICANT_COMPANY_NAME = 'Evilcrop';
 
@@ -254,7 +255,7 @@ class ValidMembershipApplication {
 
 		$application->setCompany( self::APPLICANT_COMPANY_NAME );
 		$application->setApplicantTitle( '' );
-		$application->setApplicantSalutation( '' );
+		$application->setApplicantSalutation( self::APPLICANT_SALUTATION_COMPANY );
 
 		return $application;
 	}

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
@@ -46,10 +46,10 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 		$request->markApplicantAsCompany();
 		$request->setApplicantCompanyName( self::COMPANY_NAME );
 		$request->setMembershipType( ValidMembershipApplication::MEMBERSHIP_TYPE );
-		$request->setApplicantSalutation( ValidMembershipApplication::APPLICANT_SALUTATION );
-		$request->setApplicantTitle( ValidMembershipApplication::APPLICANT_TITLE );
-		$request->setApplicantFirstName( ValidMembershipApplication::APPLICANT_FIRST_NAME );
-		$request->setApplicantLastName( ValidMembershipApplication::APPLICANT_LAST_NAME );
+		$request->setApplicantSalutation( '' );
+		$request->setApplicantTitle( '' );
+		$request->setApplicantFirstName( '' );
+		$request->setApplicantLastName( '' );
 		$request->setApplicantStreetAddress( ValidMembershipApplication::APPLICANT_STREET_ADDRESS );
 		$request->setApplicantPostalCode( ValidMembershipApplication::APPLICANT_POSTAL_CODE );
 		$request->setApplicantCity( ValidMembershipApplication::APPLICANT_CITY );
@@ -101,10 +101,10 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 		$name = ApplicantName::newCompanyName();
 
 		$name->setCompanyName( self::COMPANY_NAME );
-		$name->setSalutation( ValidMembershipApplication::APPLICANT_SALUTATION );
-		$name->setTitle( ValidMembershipApplication::APPLICANT_TITLE );
-		$name->setFirstName( ValidMembershipApplication::APPLICANT_FIRST_NAME );
-		$name->setLastName( ValidMembershipApplication::APPLICANT_LAST_NAME );
+		$name->setSalutation( ApplicantName::COMPANY_SALUTATION );
+		$name->setTitle( '' );
+		$name->setFirstName( '' );
+		$name->setLastName( '' );
 
 		return $name->assertNoNullFields()->freeze();
 	}
@@ -139,6 +139,14 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 			Euro::newFromInt( ValidMembershipApplication::PAYMENT_AMOUNT_IN_EURO ),
 			$application->getPayment()->getAmount()
 		);
+	}
+
+	public function testWhenBuildingCompanyApplication_salutationFieldIsSet() {
+		$request = $this->newCompanyMembershipRequest( self::OMIT_OPTIONAL_FIELDS );
+
+		$application = ( new MembershipApplicationBuilder() )->newApplicationFromRequest( $request );
+
+		$this->assertSame( ApplicantName::COMPANY_SALUTATION, $application->getApplicant()->getName()->getSalutation() );
 	}
 
 }

--- a/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
@@ -336,4 +336,54 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		} );
 	}
 
+	public function testWhenCompaniesApply_salutationIsSetToFixedValue() {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+
+			$params = $this->newValidHttpParametersForCompanies();
+			$client->request(
+				'POST',
+				'apply-for-membership',
+				$params
+			);
+
+			$application = $factory->getMembershipApplicationRepository()->getApplicationById( 1 );
+
+			$this->assertNotNull( $application );
+
+			$expectedApplication = ValidMembershipApplication::newCompanyApplication();
+			$expectedApplication->assignId( 1 );
+			$expectedApplication->confirm();
+
+			$this->assertEquals( $expectedApplication, $application );
+		} );
+	}
+
+	private function newValidHttpParametersForCompanies(): array {
+		return [
+			'membership_type' => ValidMembershipApplication::MEMBERSHIP_TYPE,
+
+			'adresstyp' => 'firma',
+			'firma' => ValidMembershipApplication::APPLICANT_COMPANY_NAME,
+
+			'strasse' => ValidMembershipApplication::APPLICANT_STREET_ADDRESS,
+			'postcode' => ValidMembershipApplication::APPLICANT_POSTAL_CODE,
+			'ort' => ValidMembershipApplication::APPLICANT_CITY,
+			'country' => ValidMembershipApplication::APPLICANT_COUNTRY_CODE,
+
+			'email' => ValidMembershipApplication::APPLICANT_EMAIL_ADDRESS,
+			'phone' => ValidMembershipApplication::APPLICANT_PHONE_NUMBER,
+			'dob' => ValidMembershipApplication::APPLICANT_DATE_OF_BIRTH,
+
+			'payment_type' => (string)ValidMembershipApplication::PAYMENT_TYPE_DIRECT_DEBIT,
+			'membership_fee_interval' => (string)ValidMembershipApplication::PAYMENT_PERIOD_IN_MONTHS,
+			'membership_fee' => (string)ValidMembershipApplication::COMPANY_PAYMENT_AMOUNT_IN_EURO, // TODO: change to localized
+
+			'bank_name' => ValidMembershipApplication::PAYMENT_BANK_NAME,
+			'iban' => ValidMembershipApplication::PAYMENT_IBAN,
+			'bic' => ValidMembershipApplication::PAYMENT_BIC,
+			'account_number' => ValidMembershipApplication::PAYMENT_BANK_ACCOUNT,
+			'bank_code' => ValidMembershipApplication::PAYMENT_BANK_CODE,
+		];
+	}
+
 }


### PR DESCRIPTION
Fix for wmde/fundraising#1115

This adds a fixed salutation for company donors and membership applicants. I also added some constant scopes to the `Application` domain and refactored the way `MembershipApplicationBuilder` creates the `ApplicantName`.