### PR TITLE
omit validation dispatch on unset required fields

### DIFF
--- a/app/js/lib/validation_dispatchers/amount.js
+++ b/app/js/lib/validation_dispatchers/amount.js
@@ -17,13 +17,15 @@ var objectAssign = require( 'object-assign' ),
 	 * @return {ValidationDispatcher}
 	 */
 	createAmountValidationDispatcher = function ( validator,  initialValues ) {
-		var fieldNames = [ 'amount', 'paymentType' ];
+		var fieldNames = [ 'amount', 'paymentType' ],
+			fieldValuesIfNotSet = { amount: '0,00' };
 
 		return objectAssign( Object.create( ValidationDispatcher ), {
 			validationFunction: validator.validate.bind( validator ),
 			finishActionCreationFunction: Actions.newFinishPaymentDataValidationAction,
 			beginActionCreationFunction: Actions.newBeginPaymentDataValidationAction,
 			fields: fieldNames,
+			fieldValuesIfNotSet: fieldValuesIfNotSet,
 			previousFieldValues: _.pick( initialValues || {}, fieldNames )
 		} );
 	};

--- a/app/js/lib/validation_dispatchers/base.js
+++ b/app/js/lib/validation_dispatchers/base.js
@@ -20,6 +20,7 @@ var _ = require( 'underscore' ),
 		finishActionCreationFunction: null,
 		beginActionCreationFunction: null,
 		fields: null,
+		fieldValuesIfNotSet: null,
 		previousFieldValues: {},
 
 		/**
@@ -36,6 +37,10 @@ var _ = require( 'underscore' ),
 				return;
 			}
 
+			if ( !this.fieldsRequiredForDispatchAreSet( selectedValues ) ) {
+				return;
+			}
+
 			this.previousFieldValues = selectedValues;
 
 			if ( this.beginActionCreationFunction ) {
@@ -43,6 +48,20 @@ var _ = require( 'underscore' ),
 			}
 			validationResult = this.validationFunction( selectedValues );
 			return store.dispatch( this.finishActionCreationFunction( validationResult ) );
+		},
+
+		fieldsRequiredForDispatchAreSet: function ( formValues ) {
+			var allFieldsSet = true;
+
+			if ( _.isObject( formValues ) && this.fieldValuesIfNotSet !== null ) {
+				_.each( this.fieldValuesIfNotSet, function ( initalValue, fieldName ) {
+					if ( initalValue === formValues[ fieldName ] ) {
+						allFieldsSet = false;
+					}
+				} );
+			}
+
+			return allFieldsSet;
 		}
 	};
 

--- a/app/js/lib/validation_dispatchers/fee.js
+++ b/app/js/lib/validation_dispatchers/fee.js
@@ -17,13 +17,15 @@ var objectAssign = require( 'object-assign' ),
 	 * @return {ValidationDispatcher}
 	 */
 	createFeeValidationDispatcher = function ( validator,  initialValues ) {
-		var fieldNames = [ 'amount', 'paymentIntervalInMonths', 'addressType' ];
+		var fieldNames = [ 'amount', 'paymentIntervalInMonths', 'addressType' ],
+			fieldValuesIfNotSet = { amount: 0 };
 
 		return objectAssign( Object.create( ValidationDispatcher ), {
 			validationFunction: validator.validate.bind( validator ),
 			finishActionCreationFunction: Actions.newFinishPaymentDataValidationAction,
 			beginActionCreationFunction: Actions.newBeginPaymentDataValidationAction,
 			fields: fieldNames,
+			fieldValuesIfNotSet: fieldValuesIfNotSet,
 			previousFieldValues: _.pick( initialValues || {}, fieldNames )
 		} );
 	};

--- a/app/js/tests/validation_dispatchers/test_amount_validation_dispatcher.js
+++ b/app/js/tests/validation_dispatchers/test_amount_validation_dispatcher.js
@@ -107,3 +107,20 @@ test( 'ValidationDispatcher does nothing if ignored data changes', function ( t 
 
 	t.end();
 } );
+
+test( 'ValidationDispatcher does nothing if required fields don\'t have a value', function ( t ) {
+	var initialData = { amount: '0,00', paymentType: '' },
+		validator = { validate: sinon.spy() },
+		testStore = { dispatch: sinon.spy() },
+		dispatcher = createAmountValidationDispatcher(
+			validator,
+			initialData
+		);
+
+	dispatcher.dispatchIfChanged( { amount: '0,00', paymentType: 'BEZ' }, testStore );
+
+	t.notOk( validator.validate.called, 'validation function is never called' );
+	t.notOk( testStore.dispatch.called, 'no action is dispatched' );
+
+	t.end();
+} );

--- a/app/js/tests/validation_dispatchers/test_fee_validation_dispatcher.js
+++ b/app/js/tests/validation_dispatchers/test_fee_validation_dispatcher.js
@@ -110,3 +110,20 @@ test( 'ValidationDispatcher does nothing if ignored data changes', function ( t 
 
 	t.end();
 } );
+
+test( 'ValidationDispatcher does nothing if required fields don\'t have a value', function ( t ) {
+	var initialData = { amount: 0, addressType: 'privat', paymentIntervalInMonths: 12 },
+		validator = { validate: sinon.spy() },
+		testStore = { dispatch: sinon.spy() },
+		dispatcher = createFeeValidationDispatcher(
+			validator,
+			initialData
+		);
+
+	dispatcher.dispatchIfChanged( { amount: 0, addressType: 'wtf', paymentIntervalInMonths: 12 }, testStore );
+
+	t.notOk( validator.validate.called, 'validation function is never called' );
+	t.notOk( testStore.dispatch.called, 'no action is dispatched' );
+
+	t.end();
+} );


### PR DESCRIPTION
A validation should not be dispatched when one of the validated fields have not been touched by the user, since it will always return an error.

see wmde/fundraising#1277, but this also happens when switching the payment method before actually choosing a donation amount on page 1 of the donation form.