### PR TITLE
track template name as page title

### DIFF
--- a/app/templates/Piwik.twig
+++ b/app/templates/Piwik.twig
@@ -1,7 +1,7 @@
 <!-- Piwik -->
 <script type="text/javascript">
 	var _paq = _paq || [];
-	_paq.push( [ 'trackPageView' ] );
+	_paq.push( [ 'trackPageView', '{$ main_template $}' ] );
 	_paq.push( [ 'enableLinkTracking' ] );
 
 	{% for piwikEvent in piwikEvents %}


### PR DESCRIPTION
This is a rather simple approach to track the page impressions of different confirmation pages during a/b tests. The page title tracking is currently not used at all, so I figured, we could as well use it for this.

related to wmde/fundraising#1275