### PR TITLE
Delay asyncnchronous validators

### DIFF
--- a/app/js/lib/form_validation.js
+++ b/app/js/lib/form_validation.js
@@ -72,7 +72,11 @@ var jQuery = require( 'jquery' ),
 		validationUrl: '',
 		sendFunction: null,
 		validate: function ( formValues ) {
-			var postData = {
+			var postData;
+			if ( !formValues.email ) {
+				return { status: ValidationStates.INCOMPLETE };
+			}
+			postData = {
 				email: formValues.email
 			};
 			return jQueryDeferredToPromise( this.sendFunction( this.validationUrl, postData, null, 'json' ) );
@@ -83,7 +87,12 @@ var jQuery = require( 'jquery' ),
 		validationUrl: '',
 		sendFunction: null,
 		validate: function ( formValues ) {
-			var postData = {
+			var amountAsFloat = parseFloat( formValues.amount ),
+				postData;
+			if ( amountAsFloat === 0 || isNaN( amountAsFloat ) || !formValues.paymentType ) {
+				return { status: ValidationStates.INCOMPLETE };
+			}
+			postData = {
 				amount: formValues.amount,
 				paymentType: formValues.paymentType
 			};
@@ -95,7 +104,12 @@ var jQuery = require( 'jquery' ),
 		validationUrl: '',
 		sendFunction: null,
 		validate: function ( formValues ) {
-			var postData = {
+			var amountAsFloat = parseFloat( formValues.amount ),
+				postData;
+			if ( amountAsFloat === 0 || isNaN( amountAsFloat ) || !formValues.addressType || !formValues.paymentIntervalInMonths ) {
+				return { status: ValidationStates.INCOMPLETE };
+			}
+			postData = {
 				amount: formValues.amount,
 				paymentIntervalInMonths: formValues.paymentIntervalInMonths,
 				addressType: formValues.addressType

--- a/app/js/lib/form_validation.js
+++ b/app/js/lib/form_validation.js
@@ -87,9 +87,8 @@ var jQuery = require( 'jquery' ),
 		validationUrl: '',
 		sendFunction: null,
 		validate: function ( formValues ) {
-			var amountAsFloat = parseFloat( formValues.amount ),
-				postData;
-			if ( amountAsFloat === 0 || isNaN( amountAsFloat ) || !formValues.paymentType ) {
+			var postData;
+			if ( this.formValuesHaveEmptyRequiredFields( formValues ) ) {
 				return { status: ValidationStates.INCOMPLETE };
 			}
 			postData = {
@@ -97,6 +96,12 @@ var jQuery = require( 'jquery' ),
 				paymentType: formValues.paymentType
 			};
 			return jQueryDeferredToPromise( this.sendFunction( this.validationUrl, postData, null, 'json' ) );
+		},
+		formValuesHaveEmptyRequiredFields: function ( formValues ) {
+			// WARNING: As we don't have localized money values at the moment,
+			// this method will behave incorrectly for amounts between 0 and 1
+			var amountAsFloat = parseFloat( formValues.amount );
+			return amountAsFloat === 0 || isNaN( amountAsFloat ) || !formValues.paymentType;
 		}
 	},
 
@@ -104,9 +109,8 @@ var jQuery = require( 'jquery' ),
 		validationUrl: '',
 		sendFunction: null,
 		validate: function ( formValues ) {
-			var amountAsFloat = parseFloat( formValues.amount ),
-				postData;
-			if ( amountAsFloat === 0 || isNaN( amountAsFloat ) || !formValues.addressType || !formValues.paymentIntervalInMonths ) {
+			var postData;
+			if ( this.formValuesHaveEmptyRequiredFields( formValues ) ) {
 				return { status: ValidationStates.INCOMPLETE };
 			}
 			postData = {
@@ -115,6 +119,12 @@ var jQuery = require( 'jquery' ),
 				addressType: formValues.addressType
 			};
 			return jQueryDeferredToPromise( this.sendFunction( this.validationUrl, postData, null, 'json' ) );
+		},
+		formValuesHaveEmptyRequiredFields: function ( formValues ) {
+			// WARNING: As we don't have localized money values at the moment,
+			// this method will behave incorrectly for amounts between 0 and 1
+			var amountAsFloat = parseFloat( formValues.amount );
+			return amountAsFloat === 0 || isNaN( amountAsFloat ) || !formValues.addressType || !formValues.paymentIntervalInMonths;
 		}
 	},
 

--- a/app/js/lib/reducers/input_validation.js
+++ b/app/js/lib/reducers/input_validation.js
@@ -42,12 +42,14 @@ function inputValidation( validationState, action ) {
 			} );
 			return newValidationState;
 		case 'FINISH_PAYMENT_DATA_VALIDATION':
-			if ( action.payload.status === ValidationStates.OK ) {
+			if ( action.payload.status === ValidationStates.INCOMPLETE ) {
+				return newValidationState;
+			} else if ( action.payload.status === ValidationStates.OK ) {
 				newValidationState.amount =  { dataEntered: true, isValid: true };
 				newValidationState.paymentType = { dataEntered: true, isValid: true };
 			} else {
-				newValidationState.amount = { dataEntered: true, isValid: action.payload.messages.amount ? false : true };
-				newValidationState.paymentType = { dataEntered: true, isValid: action.payload.messages.paymentType ? false : true };
+				newValidationState.amount = { dataEntered: true, isValid: !action.payload.messages.amount };
+				newValidationState.paymentType = { dataEntered: true, isValid: !action.payload.messages.paymentType };
 			}
 			return newValidationState;
 		case 'FINISH_BANK_DATA_VALIDATION':
@@ -67,6 +69,9 @@ function inputValidation( validationState, action ) {
 			}
 			return newValidationState;
 		case 'FINISH_EMAIL_ADDRESS_VALIDATION':
+			if ( action.payload.status === ValidationStates.INCOMPLETE ) {
+				return newValidationState;
+			}
 			newValidationState.email = { dataEntered: true, isValid: action.payload.status !== ValidationStates.ERR };
 			return newValidationState;
 		case 'FINISH_ADDRESS_VALIDATION':

--- a/app/js/tests/test_form_validation.js
+++ b/app/js/tests/test_form_validation.js
@@ -27,6 +27,24 @@ test( 'Amount validation sends values to server', function ( t ) {
 	t.end();
 } );
 
+test( 'Amount validation sends nothing to server if any of the necessary values are not set', function ( t ) {
+	var incompleteResult = { status: 'INCOMPLETE' },
+		postFunctionSpy = sinon.spy(),
+		amountValidator = validation.createAmountValidator(
+			'http://spenden.wikimedia.org/validate-amount',
+			postFunctionSpy
+		),
+		validationResults = [];
+
+	// Test multiple empty values
+	validationResults.push( amountValidator.validate( { amount: 0, paymentType: 'BEZ', otherStuff: 'foo' } ) );
+	validationResults.push( amountValidator.validate( { amount: '0,00', paymentType: 'BEZ', otherStuff: 'foo' } ) );
+	validationResults.push( amountValidator.validate( { amount: 23, paymentType: null, otherStuff: 'foo' } ) );
+
+	t.notOk( postFunctionSpy.called, 'no data is sent ' );
+	t.deepEquals( [ incompleteResult, incompleteResult, incompleteResult], validationResults, 'validation function returns incomplete result' );
+	t.end();
+} );
 test( 'Address validation is valid for anonymous address', function ( t ) {
 	var positiveResult = { status: 'OK' },
 		postFunctionSpy = sinon.spy(),

--- a/app/js/tests/test_form_validation.js
+++ b/app/js/tests/test_form_validation.js
@@ -42,9 +42,109 @@ test( 'Amount validation sends nothing to server if any of the necessary values 
 	validationResults.push( amountValidator.validate( { amount: 23, paymentType: null, otherStuff: 'foo' } ) );
 
 	t.notOk( postFunctionSpy.called, 'no data is sent ' );
-	t.deepEquals( [ incompleteResult, incompleteResult, incompleteResult], validationResults, 'validation function returns incomplete result' );
+	t.deepEquals( [ incompleteResult, incompleteResult, incompleteResult ], validationResults, 'validation function returns incomplete result' );
 	t.end();
 } );
+
+test( 'Fee validation sends values to server', function ( t ) {
+	var positiveResult = { status: 'OK' },
+		postFunctionSpy = sinon.stub().returns( Promise.resolve( positiveResult ) ),
+		feeValidator = validation.createFeeValidator(
+			'http://spenden.wikimedia.org/validate-fee',
+			postFunctionSpy
+		),
+		formData = {
+			amount: 23,
+			addressType: 'privat',
+			paymentIntervalInMonths: 1,
+			otherStuff: 'foo'
+		},
+		callParameters, validationResult;
+
+	validationResult = feeValidator.validate( formData );
+
+	t.ok( postFunctionSpy.calledOnce, 'data is sent once' );
+	callParameters = postFunctionSpy.getCall( 0 ).args;
+	t.equal( callParameters[ 0 ], 'http://spenden.wikimedia.org/validate-fee', 'validation calls configured URL' );
+	t.deepEqual( callParameters[ 1 ], { amount: 23, addressType: 'privat', paymentIntervalInMonths: 1 }, 'validation sends only necessary data' );
+	t.equal( callParameters[ 3 ], 'json', 'validation expects JSON data' );
+	validationResult.then( function ( resultData ) {
+		t.deepEqual( resultData, positiveResult, 'validation function returns promise result' );
+	} );
+	t.end();
+} );
+
+test( 'Fee validation sends nothing to server if necessary values are not set', function ( t ) {
+	var incompleteResult = { status: 'INCOMPLETE' },
+		postFunctionSpy = sinon.spy(),
+		feeValidator = validation.createFeeValidator(
+			'http://spenden.wikimedia.org/validate-fee',
+			postFunctionSpy
+		),
+		formDataEmptyAmount = {
+			amount: 0,
+			addressType: 'privat',
+			paymentIntervalInMonths: 1
+		},
+		formDataEmptyAddressType = {
+			amount: 23,
+			addressType: null,
+			paymentIntervalInMonths: 1
+		},
+		formDataEmptyPaymentInterval = {
+			amount: 23,
+			addressType: 'privat',
+			paymentIntervalInMonths: null
+		},
+		validationResults = [];
+
+	validationResults.push( feeValidator.validate( formDataEmptyAmount ) );
+	validationResults.push( feeValidator.validate( formDataEmptyAddressType ) );
+	validationResults.push( feeValidator.validate( formDataEmptyPaymentInterval ) );
+
+	t.notOk( postFunctionSpy.called, 'no data is sent ' );
+	t.deepEquals( [ incompleteResult, incompleteResult, incompleteResult ], validationResults, 'validation function returns incomplete result' );
+	t.end();
+} );
+
+test( 'Email validation sends values to server', function ( t ) {
+	var positiveResult = { status: 'OK' },
+		postFunctionSpy = sinon.stub().returns( Promise.resolve( positiveResult ) ),
+		emailValidator = validation.createEmailAddressValidator(
+			'http://spenden.wikimedia.org/validate-email',
+			postFunctionSpy
+		),
+		callParameters, validationResult;
+
+	validationResult = emailValidator.validate( { email: 'test@example.com', otherStuff: 'foo' } );
+
+	t.ok( postFunctionSpy.calledOnce, 'data is sent once' );
+	callParameters = postFunctionSpy.getCall( 0 ).args;
+	t.equal( callParameters[ 0 ], 'http://spenden.wikimedia.org/validate-email', 'validation calls configured URL' );
+	t.deepEqual( callParameters[ 1 ], { email: 'test@example.com' }, 'validation sends only necessary data' );
+	t.equal( callParameters[ 3 ], 'json', 'validation expects JSON data' );
+	validationResult.then( function ( resultData ) {
+		t.deepEqual( resultData, positiveResult, 'validation function returns promise result' );
+	} );
+	t.end();
+} );
+
+test( 'Email validation sends nothing to server if email address is not set', function ( t ) {
+	var incompleteResult = { status: 'INCOMPLETE' },
+		postFunctionSpy = sinon.spy(),
+		emailValidator = validation.createEmailAddressValidator(
+			'http://spenden.wikimedia.org/validate-amount',
+			postFunctionSpy
+		),
+		validationResult;
+
+	validationResult = emailValidator.validate( { email: '', otherStuff: 'foo' } );
+
+	t.notOk( postFunctionSpy.called, 'no data is sent ' );
+	t.deepEquals( incompleteResult, validationResult, 'validation function returns incomplete result' );
+	t.end();
+} );
+
 test( 'Address validation is valid for anonymous address', function ( t ) {
 	var positiveResult = { status: 'OK' },
 		postFunctionSpy = sinon.spy(),


### PR DESCRIPTION
Modify the asynchronous form validators to avoid sending incomplete data
to the server which might result in validation error being displayed too
early.
Change the validation result reducers to handle the "INCOMPLETE"
validation result.
Add test cases.