### PR TITLE
Locale based templates

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -20,6 +20,7 @@
 			"array": {}
 		}
 	},
+	"i18n-base-path": "",
 	"default-layout-templates": {
 		"header": "Page_Header.html.twig",
 		"footer": "Page_Footer.html.twig",

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -12,7 +12,8 @@
 		"loaders": {
 			"filesystem": {
 				"template-dir": [
-					"tests/templates"
+					"tests/templates",
+					"tests/templates/%_locale_%/pages"
 				]
 			},
 			"array": {

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -156,6 +156,12 @@
         "no-js-notice"
       ]
     },
+    "i18n-base-path": {
+      "type": "string",
+      "title": "Base path for i18n files",
+      "description": "Base path for files related to internationalization. Must be a path (without trailing slash) that contains subfolders named according to the Locale ID defined in ICU (e.g. en_US).",
+      "default": ""
+    },
     "contact-info": {
       "type": "object",
       "title": "Contact information",

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -285,40 +285,13 @@ class FunFunFactory {
 				'json' => $translationFactory->newJsonLoader()
 			];
 			$locale = $this->config['locale'];
+			$messagesPath = __DIR__ . '/../../' . $this->config['i18n-base-path'] . '/' . $locale;
 			$translator = $translationFactory->create( $loaders, $locale );
-			$translator->addResource(
-				'json',
-				__DIR__ . '/../../app/fundraising-frontend-content/i18n/' . $locale . '/messages.json',
-				$locale
-			);
-
-			$translator->addResource(
-				'json',
-				__DIR__ . '/../../app/fundraising-frontend-content/i18n/' . $locale . '/paymentTypes.json',
-				$locale,
-				'paymentTypes'
-			);
-
-			$translator->addResource(
-				'json',
-				__DIR__ . '/../../app/fundraising-frontend-content/i18n/' . $locale . '/paymentIntervals.json',
-				$locale,
-				'paymentIntervals'
-			);
-
-			$translator->addResource(
-				'json',
-				__DIR__ . '/../../app/fundraising-frontend-content/i18n/' . $locale . '/paymentStatus.json',
-				$locale,
-				'paymentStatus'
-			);
-
-			$translator->addResource(
-				'json',
-				__DIR__ . '/../../app/fundraising-frontend-content/i18n/' . $locale . '/validations.json',
-				$locale,
-				'validations'
-			);
+			$translator->addResource( 'json', $messagesPath . '/messages.json', $locale );
+			$translator->addResource( 'json', $messagesPath . '/paymentTypes.json', $locale, 'paymentTypes' );
+			$translator->addResource( 'json', $messagesPath . '/paymentIntervals.json', $locale, 'paymentIntervals' );
+			$translator->addResource( 'json', $messagesPath . '/paymentStatus.json', $locale, 'paymentStatus' );
+			$translator->addResource( 'json', $messagesPath . '/validations.json', $locale, 'validations' );
 
 			return $translator;
 		};

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -307,7 +307,12 @@ class FunFunFactory {
 		};
 
 		$pimple['twig_factory'] = function () {
-			return new TwigEnvironmentConfigurator( $this->pimple['twig_environment'], $this->config['twig'], $this->getCachePath() . '/twig' );
+			return new TwigEnvironmentConfigurator(
+				$this->pimple['twig_environment'],
+				$this->config['twig'],
+				$this->getCachePath() . '/twig',
+				$this->config['locale']
+			);
 		};
 
 		$pimple['twig'] = function() {

--- a/src/Factories/TwigEnvironmentConfigurator.php
+++ b/src/Factories/TwigEnvironmentConfigurator.php
@@ -20,16 +20,19 @@ use WMDE\Fundraising\Frontend\Presentation\FilePrefixer;
  */
 class TwigEnvironmentConfigurator {
 
-	const DEFAULT_TEMPLATE_DIR = 'app/fundraising-frontend-content/templates';
+	private const DEFAULT_TEMPLATE_DIR = 'app/fundraising-frontend-content/templates';
+	private const LOCALE_PLACEHOLDER = '%_locale_%';
 
 	private $twig;
 	private $config;
 	private $cachePath;
+	private $locale;
 
-	public function __construct( Twig_Environment $twig, array $config, string $cachePath ) {
+	public function __construct( Twig_Environment $twig, array $config, string $cachePath, string $locale ) {
 		$this->twig = $twig;
 		$this->config = $config;
 		$this->cachePath = $cachePath;
+		$this->locale = $locale;
 	}
 
 	public function getEnvironment( array $loaders, array $extensions, array $filters ): Twig_Environment {
@@ -97,12 +100,16 @@ class TwigEnvironmentConfigurator {
 		return array_map(
 			function( $dir ) use ( $root ) {
 				if ( strlen( $dir ) == 0 || $dir{0} != '/' ) {
-					return $root . $dir;
+					$dir = $root . $dir;
 				}
-				return $dir;
+				return $this->insertLocale( $dir );
 			},
 			$dirs
 		);
+	}
+
+	private function insertLocale( string $path ): string {
+		return str_replace( self::LOCALE_PLACEHOLDER, $this->locale, $path );
 	}
 
 	public function newArrayLoader() {

--- a/tests/EdgeToEdge/Routes/DisplayPageRouteTest.php
+++ b/tests/EdgeToEdge/Routes/DisplayPageRouteTest.php
@@ -135,4 +135,10 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 		$this->assert404( $client->getResponse() );
 	}
 
+	public function testWhenRequestedPageIsTranslated_itIsDisplayed() {
+		$client = $this->createClient();
+		$client->request( 'GET', '/page/Translated_Page' );
+		$this->assertContains( 'This is just a test.', $client->getResponse()->getContent() );
+	}
+
 }

--- a/tests/Integration/Factories/TwigEnvironmentConfiguratorTest.php
+++ b/tests/Integration/Factories/TwigEnvironmentConfiguratorTest.php
@@ -18,6 +18,8 @@ use WMDE\Fundraising\Frontend\Presentation\FilePrefixer;
  */
 class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 
+	private const LOCALE = 'de_DE';
+
 	public function testTwigInstanceUsesDollarPlaceholdersForVariables() {
 		$factory = new TwigEnvironmentConfigurator(
 			$this->newTwigEnvironment(),
@@ -27,7 +29,8 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 					'array' => [ 'variableReplacement.twig' => '{$ testvar $}' ]
 				]
 			],
-			'/tmp/fun'
+			'/tmp/fun',
+			self::LOCALE
 		);
 		$twig = $factory->getEnvironment( [ $factory->newArrayLoader() ], [], [] );
 		$result = $twig->render( 'variableReplacement.twig', [ 'testvar' => 'Meeow!' ] );
@@ -49,7 +52,12 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 		$thirdLoader = $this->createMock( Twig_LoaderInterface::class );
 		$thirdLoader->expects( $this->never() )->method( $this->anything() );
 
-		$factory = new TwigEnvironmentConfigurator( $this->newTwigEnvironment(), [ 'enable-cache' => false ], '/tmp/fun' );
+		$factory = new TwigEnvironmentConfigurator(
+			$this->newTwigEnvironment(),
+			[ 'enable-cache' => false ],
+			'/tmp/fun',
+			self::LOCALE
+		);
 		$twig = $factory->getEnvironment( [ $firstLoader, $secondLoader, $thirdLoader ], [], [] );
 		$result = $twig->render( 'Canis_silvestris' );
 		$this->assertSame( 'Meeow!', $result );
@@ -65,7 +73,9 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 					]
 				]
 			],
-			'/tmp/fun' );
+			'/tmp/fun',
+			self::LOCALE
+		);
 		$loader = $factory->newFileSystemLoader();
 		$this->assertSame( [ __DIR__ . '/../../templates' ], $loader->getPaths() );
 	}
@@ -80,7 +90,8 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 					]
 				]
 			],
-			'/tmp/fun'
+			'/tmp/fun',
+			self::LOCALE
 		);
 		$loader = $factory->newFileSystemLoader();
 		$realPath = realpath( $loader->getPaths()[0] );
@@ -103,7 +114,8 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 					'array' => [ 'filePrefix.twig' => '{$ "testfile.js"|prefix_file $}' ]
 				]
 			],
-			'/tmp/fun'
+			'/tmp/fun',
+			self::LOCALE
 		);
 
 		$filters = [ $factory->newFilePrefixFilter( $prefixer ) ];
@@ -115,4 +127,31 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 	private function newTwigEnvironment(): Twig_Environment {
 		return new Twig_Environment();
 	}
+
+	public function testLocalePlaceholderIsBeingReplaced() {
+		$expectedPaths = [
+			realpath( __DIR__ . '/../../templates' ),
+			realpath( __DIR__ . '/../../templates/' . self::LOCALE . '/pages' )
+		];
+		$factory = new TwigEnvironmentConfigurator(
+			$this->newTwigEnvironment(),
+			[
+				'enable-cache' => false,
+				'loaders' => [
+					'filesystem' => [
+						'template-dir' => [
+							'tests/templates',
+							'tests/templates/%_locale_%/pages'
+						]
+					]
+				]
+			],
+			'/tmp/fun',
+			self::LOCALE
+		);
+
+		$loaders = $factory->newFileSystemLoader();
+		$this->assertSame( $expectedPaths, $loaders->getPaths() );
+	}
+
 }

--- a/tests/Integration/Factories/TwigEnvironmentConfiguratorTest.php
+++ b/tests/Integration/Factories/TwigEnvironmentConfiguratorTest.php
@@ -21,20 +21,26 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 	private const LOCALE = 'de_DE';
 
 	public function testTwigInstanceUsesDollarPlaceholdersForVariables() {
-		$factory = new TwigEnvironmentConfigurator(
-			$this->newTwigEnvironment(),
+		$factory = $this->newTwigEnvironmentConfigurator(
 			[
 				'enable-cache' => false,
 				'loaders' => [
 					'array' => [ 'variableReplacement.twig' => '{$ testvar $}' ]
 				]
-			],
-			'/tmp/fun',
-			self::LOCALE
+			]
 		);
 		$twig = $factory->getEnvironment( [ $factory->newArrayLoader() ], [], [] );
 		$result = $twig->render( 'variableReplacement.twig', [ 'testvar' => 'Meeow!' ] );
 		$this->assertSame( 'Meeow!', $result );
+	}
+
+	private function newTwigEnvironmentConfigurator( array $config ): TwigEnvironmentConfigurator {
+		return new TwigEnvironmentConfigurator(
+			$this->newTwigEnvironment(),
+			$config,
+			'/tmp/fun',
+			self::LOCALE
+		);
 	}
 
 	public function testTwigInstancesTryAllLoadersUntilTemplateIsFound() {
@@ -52,47 +58,32 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 		$thirdLoader = $this->createMock( Twig_LoaderInterface::class );
 		$thirdLoader->expects( $this->never() )->method( $this->anything() );
 
-		$factory = new TwigEnvironmentConfigurator(
-			$this->newTwigEnvironment(),
-			[ 'enable-cache' => false ],
-			'/tmp/fun',
-			self::LOCALE
-		);
+		$factory = $this->newTwigEnvironmentConfigurator( [ 'enable-cache' => false ] );
 		$twig = $factory->getEnvironment( [ $firstLoader, $secondLoader, $thirdLoader ], [], [] );
 		$result = $twig->render( 'Canis_silvestris' );
 		$this->assertSame( 'Meeow!', $result );
 	}
 
 	public function testFilesystemLoaderConvertsStringPathToArray() {
-		$factory = new TwigEnvironmentConfigurator(
-			$this->newTwigEnvironment(),
-			[
-				'loaders' => [
-					'filesystem' => [
-						'template-dir' => __DIR__ . '/../../templates'
-					]
+		$factory = $this->newTwigEnvironmentConfigurator( [
+			'loaders' => [
+				'filesystem' => [
+					'template-dir' => __DIR__ . '/../../templates'
 				]
-			],
-			'/tmp/fun',
-			self::LOCALE
-		);
+			]
+		] );
 		$loader = $factory->newFileSystemLoader();
 		$this->assertSame( [ __DIR__ . '/../../templates' ], $loader->getPaths() );
 	}
 
 	public function testFilesystemLoaderPrependsRelativePathsToArray() {
-		$factory = new TwigEnvironmentConfigurator(
-			$this->newTwigEnvironment(),
-			[
+		$factory = $this->newTwigEnvironmentConfigurator( [
 				'loaders' => [
 					'filesystem' => [
 						'template-dir' => 'tests/templates'
 					]
 				]
-			],
-			'/tmp/fun',
-			self::LOCALE
-		);
+		] );
 		$loader = $factory->newFileSystemLoader();
 		$realPath = realpath( $loader->getPaths()[0] );
 		$this->assertFalse( $realPath === false, 'path does not exist' );
@@ -106,17 +97,12 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( 'baaaaad.testfile.js' )
 			->with( 'testfile.js' );
 
-		$factory = new TwigEnvironmentConfigurator(
-			$this->newTwigEnvironment(),
-			[
-				'enable-cache' => false,
-				'loaders' => [
-					'array' => [ 'filePrefix.twig' => '{$ "testfile.js"|prefix_file $}' ]
-				]
-			],
-			'/tmp/fun',
-			self::LOCALE
-		);
+		$factory = $this->newTwigEnvironmentConfigurator( [
+			'enable-cache' => false,
+			'loaders' => [
+				'array' => [ 'filePrefix.twig' => '{$ "testfile.js"|prefix_file $}' ]
+			]
+		] );
 
 		$filters = [ $factory->newFilePrefixFilter( $prefixer ) ];
 		$twig = $factory->getEnvironment( [ $factory->newArrayLoader() ], [], $filters );
@@ -133,22 +119,17 @@ class TwigEnvironmentConfiguratorTest extends \PHPUnit\Framework\TestCase {
 			realpath( __DIR__ . '/../../templates' ),
 			realpath( __DIR__ . '/../../templates/' . self::LOCALE . '/pages' )
 		];
-		$factory = new TwigEnvironmentConfigurator(
-			$this->newTwigEnvironment(),
-			[
-				'enable-cache' => false,
-				'loaders' => [
-					'filesystem' => [
-						'template-dir' => [
-							'tests/templates',
-							'tests/templates/%_locale_%/pages'
-						]
+		$factory = $this->newTwigEnvironmentConfigurator( [
+			'enable-cache' => false,
+			'loaders' => [
+				'filesystem' => [
+					'template-dir' => [
+						'tests/templates',
+						'tests/templates/%_locale_%/pages'
 					]
 				]
-			],
-			'/tmp/fun',
-			self::LOCALE
-		);
+			]
+		] );
 
 		$loaders = $factory->newFileSystemLoader();
 		$this->assertSame( $expectedPaths, $loaders->getPaths() );

--- a/tests/templates/de_DE/pages/Translated_Page.html.twig
+++ b/tests/templates/de_DE/pages/Translated_Page.html.twig
@@ -1,0 +1,1 @@
+This is just a test.


### PR DESCRIPTION
This PR replaces the approach in #849. There may now be a locale placeholder in the template path definition of the configuration files.