### PR TITLE
Switch Vagrant base image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.box_check_update = false
 


### PR DESCRIPTION
The canonical ubuntu base images have numerous problems, outlined in
https://github.com/mitchellh/vagrant/issues/7155#issuecomment-228568200

These problems can leave you in a state where the app directory cannot be
mounted because the guest additions are out of date and the guest
additions cannot be updated because of the VM configuration.