### PR TITLE
apply page title convention to route redirection

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -517,7 +517,7 @@ $app->get( '/spenden/{page}', function( Application $app, Request $request, stri
 	// See https://serverfault.com/questions/805881/nginx-populate-request-uri-with-rewritten-url
 	switch ( $page ) {
 		case 'Mitgliedschaft':
-			return ( new RouteRedirectionHandler( $app, $request->getQueryString() ) )->handle( '/page/MembershipApplication' );
+			return ( new RouteRedirectionHandler( $app, $request->getQueryString() ) )->handle( '/page/Membership_Application' );
 		default:
 			return ( new RouteRedirectionHandler( $app, $request->getQueryString() ) )->handle( '/page/' . $page );
 	}

--- a/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
+++ b/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
@@ -14,11 +14,11 @@ class RouteRedirectionTest extends WebRouteTestCase {
 
 	public function simplePageDisplayProvider() {
 		return [
-			[ '/spenden/Mitgliedschaft', '/page/MembershipApplication' ],
+			[ '/spenden/Mitgliedschaft', '/page/Membership_Application' ],
 			[ '/spenden/Fördermitgliedschaft', '/page/Fördermitgliedschaft' ],
 			[ '/spenden/Kontaktformular', '/page/Kontaktformular' ],
 			[ '/spenden/Ihre_Spende_wirkt', '/page/Ihre_Spende_wirkt' ],
-			[ '/spenden/Mitgliedschaft?bar=baz&foo=bar', '/page/MembershipApplication?bar=baz&foo=bar' ],
+			[ '/spenden/Mitgliedschaft?bar=baz&foo=bar', '/page/Membership_Application?bar=baz&foo=bar' ],
 		];
 	}
 


### PR DESCRIPTION
The page `MembershipApplication` was renamed to `Membership_Application` which breaks the route redirection.