### PR TITLE
Fix Vagrant environment and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ you will need to do additional configuration, as per the configuration section.
 
 System dependencies:
 
-* PHP >= 7
-* php7.0-intl
-* php7.0-curl
-* php7.0-sqlite3 (only needed for running the tests)
+* PHP >= 7.1 with the following extensions:
+    * curl
+    * intl
+    * [kontocheck](http://kontocheck.sourceforge.net/) (only needed when you want to use or test direct debit)
+    * mbstring
+    * sqlite3
+    * xml
 * Node.js and npm (only needed in development for compiling the JavaScript and running the JavaScript tests)
-* [kontocheck extension](http://kontocheck.sourceforge.net/) (only needed when you want to use or test direct debit)
 
 Get a clone of our git repository and then run these commands in it:
 
@@ -61,15 +63,31 @@ connection data. If you're using MySQL, [it's important](http://stackoverflow.co
 For a fully working instance with all payment types and working templates you need to fill out the following
 configuration data:
 
-	 - `cms-wiki-url`
 	 - `bank-data-file`
 	 - `operator-email`
 	 - `operator-displayname-organization`
 	 - `operator-displayname-suborganization`
-	 - `paypal`
+	 - `paypal-donation`
+	 - `paypal-membership`
 	 - `creditcard`
 
-Also, you need to check out the content repository at https://github.com/wmde/fundraising-frontend-content into the directory `app/fundraising-frontend-content`.
+The application needs a copy of the content repository at https://github.com/wmde/fundraising-frontend-content to work properly. 
+On development machines, the content repository is in the composer dev-dependencies. If you put the content repository in another place, you need to configure the paths to it.
+The following example shows the configuration when the content repository is at the same level as the application directory:
+
+    "twig": {
+        "loaders": {
+            "filesystem": {
+                "template-dir": [
+                    "../fundraising-frontend-content/ab_tests/a/templates",
+                    "../fundraising-frontend-content/ab_tests/b/templates",
+                    "../fundraising-frontend-content/templates",
+                    "../fundraising-frontend-content/i18n/%_locale_%/pages"
+                ]
+            }
+        }
+    },
+    "i18n-base-path": "../fundraising-frontend-content/i18n"
 
 ## Running the application
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "install_packages", type: "shell", path: "build/vagrant/install_packages.sh"
   config.vm.provision "install_composer", type: "shell", path: "build/vagrant/install_composer.sh"
   config.vm.provision "install_konto_check", type: "shell", path: "build/vagrant/installKontoCheck.sh"
-  config.vm.provision "configure_app", type: "shell", path: "build/vagrant/configure_app.sh", env: { WIKI_PASSWD: ENV["WIKI_PASSWD"] }
+  config.vm.provision "configure_app", type: "shell", path: "build/vagrant/configure_app.sh"
   config.vm.provision "install_app", type: "shell", path: "build/vagrant/install_app.sh"
   config.vm.provision "configure_db", type: "shell", path: "build/vagrant/configureForMysql.sh", env: { DB_PASSWD: ENV["DB_PASSWD"] }
 

--- a/build/vagrant/config.prod.json
+++ b/build/vagrant/config.prod.json
@@ -8,22 +8,20 @@
 		"port": 3306
 	},
 	"bank-data-file": "/vagrant/res/blz.lut2f",
-	"cms-wiki-api-url": "https://fundraising-cms.wikimedia.de/api.php",
-	"cms-wiki-user": "LocalBot@LocalBot",
-	"cms-wiki-password": "__WIKI_PASSWORD__",
-	"cms-wiki-title-prefix": "Web:Spendenseite-DefaultSkin/test/",
 	"twig": {
 		"enable-cache": true,
 		"loaders": {
-			"wiki": {
-				"enabled": true,
-				"rawpages": []
-			},
 			"filesystem": {
-				"template-dir": [ "app/templates" ]
+				"template-dir": [
+					"vendor/wmde/fundraising-frontend-content/ab_tests/a/templates",
+					"vendor/wmde/fundraising-frontend-content/ab_tests/b/templates",
+					"vendor/wmde/fundraising-frontend-content/templates",
+					"vendor/wmde/fundraising-frontend-content/i18n/%_locale_%/pages"
+				]
 			}
 		}
 	},
+	"i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n",
 	"contact-info": {
 		"organization": {
 			"email": "fake-address@example.com",
@@ -34,5 +32,31 @@
 			"name": "Webmaster"
 		}
 	},
-	"purging-secret": "purgeme"
+	"purging-secret": "purgeme",
+	"paypal-donation": {
+		"base-url": "https://www.sandbox.paypal.com/cgi-bin/webscr?",
+		"account-address": "PAYPAL_USERNAME_IS_MISSING",
+		"notify-url": "http://localhost:31337/handle-paypal-payment-notification",
+		"return-url": "http://localhost:31337/show-donation-confirmation",
+		"cancel-url": "http://localhost:31337/",
+		"item-name": "Test-Spende bei Wikimedia"
+	},
+	"paypal-membership": {
+		"base-url": "https://www.sandbox.paypal.com/cgi-bin/webscr?",
+		"account-address": "PAYPAL_USERNAME_IS_MISSING",
+		"notify-url": "http://localhost:31337/handle-paypal-membership-fee-notification",
+		"return-url": "http://localhost:31337/show-membership-confirmation",
+		"cancel-url": "http://localhost:31337/",
+		"item-name": "Test-Mitgliedschaft bei Wikimedia"
+	},
+	"creditcard": {
+		"access-key": "",
+		"base-url": "https://credit-card.micropayment.de/creditcard/event/index.php?",
+		"project-id": "",
+		"background-color": "000000",
+		"skin": "default",
+		"theme": "x1",
+		"return-url": "https://spenden.wikimedia.de/show-donation-confirmation",
+		"testmode": true
+	}
 }

--- a/build/vagrant/configure_app.sh
+++ b/build/vagrant/configure_app.sh
@@ -8,11 +8,9 @@ systemctl daemon-reload
 systemctl start fundraising_app.service
 
 # Configure app
-if [[ -z "$WIKI_PASSWD" ]]; then
-    WIKI_PASSWD="WIKI PASSWORD MISSING!!!"
+if [ ! -f /vagrant/app/config/config.prod.json ]; then
+    cp /vagrant/build/vagrant/config.prod.json /vagrant/app/config/config.prod.json
 fi
-cp /vagrant/build/vagrant/config.prod.json /vagrant/app/config/config.prod.json
-sed -i -e "s/__WIKI_PASSWORD__/$WIKI_PASSWD/" /vagrant/app/config/config.prod.json
 
 # Log all outgoing mails instead of sending them
 echo "cat >> /tmp/logmail.log" > /usr/local/bin/logmail

--- a/build/vagrant/fundraising_app.service
+++ b/build/vagrant/fundraising_app.service
@@ -3,8 +3,8 @@ Description=PHP Server
 After=home.mount network.target
 
 [Service]
-User=ubuntu
-Group=ubuntu
+User=vagrant
+Group=vagrant
 ExecStart=/usr/bin/php -S 0.0.0.0:8080 -t /vagrant/web
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process


### PR DESCRIPTION
Fix inconsistencies in Vagrant config template and installation scripts
introduced by the move to the Git-based content repository.

Fix systemd service description to match user names, bug introduced by #860

Add dummy paypal and credit card configuration to config template to
make it more obvious what needs to be configured.

Update README to reflect the changes, make dependcies more obvious and
document the changes introduced by #862

Avoid overriding existing configuration files, if one exists.