### PR TITLE
fix path to a/b test templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ The following example shows the configuration when the content repository is at 
         "loaders": {
             "filesystem": {
                 "template-dir": [
-                    "../fundraising-frontend-content/ab_tests/a/templates",
-                    "../fundraising-frontend-content/ab_tests/b/templates",
+                    "../fundraising-frontend-content/ab_test/a/templates",
+                    "../fundraising-frontend-content/ab_test/b/templates",
                     "../fundraising-frontend-content/templates",
                     "../fundraising-frontend-content/i18n/%_locale_%/pages"
                 ]

--- a/build/vagrant/config.prod.json
+++ b/build/vagrant/config.prod.json
@@ -13,8 +13,8 @@
 		"loaders": {
 			"filesystem": {
 				"template-dir": [
-					"vendor/wmde/fundraising-frontend-content/ab_tests/a/templates",
-					"vendor/wmde/fundraising-frontend-content/ab_tests/b/templates",
+					"vendor/wmde/fundraising-frontend-content/ab_test/a/templates",
+					"vendor/wmde/fundraising-frontend-content/ab_test/b/templates",
 					"vendor/wmde/fundraising-frontend-content/templates",
 					"vendor/wmde/fundraising-frontend-content/i18n/%_locale_%/pages"
 				]


### PR DESCRIPTION
Fix #864 is not working because of incorrect path definition for a/b testing.