### PR TITLE
Re-enabled camel case sniff for non test methods

### DIFF
--- a/app/RouteHandlers/AddSubscriptionHandler.php
+++ b/app/RouteHandlers/AddSubscriptionHandler.php
@@ -30,9 +30,9 @@ class AddSubscriptionHandler {
 		$responseModel = $useCase->addSubscription( $this->createSubscriptionRequest( $request ) );
 
 		if ( $this->app['request_stack.is_json'] ) {
-			return $this->app->json( $this->ffFactory->newAddSubscriptionJSONPresenter()->present( $responseModel ) );
+			return $this->app->json( $this->ffFactory->newAddSubscriptionJsonPresenter()->present( $responseModel ) );
 		} elseif ( $request->query->has( 'callback' ) ) {
-			return $this->app->json( $this->ffFactory->newAddSubscriptionJSONPresenter()->present( $responseModel ) )
+			return $this->app->json( $this->ffFactory->newAddSubscriptionJsonPresenter()->present( $responseModel ) )
 				->setCallback( $request->query->get( 'callback' ) );
 		}
 
@@ -44,7 +44,7 @@ class AddSubscriptionHandler {
 		}
 
 		return new Response(
-			$this->ffFactory->newAddSubscriptionHTMLPresenter()->present( $responseModel, $request->request->all() )
+			$this->ffFactory->newAddSubscriptionHtmlPresenter()->present( $responseModel, $request->request->all() )
 		);
 	}
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -77,7 +77,7 @@ $app->after( function( Request $request, Response $response, Application $app ) 
 
 $app->error( function ( AccessDeniedException $e ) use ( $ffFactory ) {
 	return new Response(
-		$ffFactory->newAccessDeniedHTMLPresenter()->present( $e ),
+		$ffFactory->newAccessDeniedHtmlPresenter()->present( $e ),
 		403,
 		[ 'X-Status-Code' => 403 ]
 	);
@@ -89,7 +89,7 @@ $app->error( function ( NotFoundHttpException $e ) use ( $ffFactory, $app ) {
 	}
 
 	return new Response(
-		$ffFactory->newPageNotFoundHTMLPresenter()->present(),
+		$ffFactory->newPageNotFoundHtmlPresenter()->present(),
 		404,
 		[ 'X-Status-Code' => 404 ]
 	);
@@ -115,7 +115,7 @@ $app->error( function ( \Exception $e, Request $request, $code ) use ( $ffFactor
 	}
 
 	return new Response(
-		$ffFactory->newInternalErrorHTMLPresenter()->present( $e ),
+		$ffFactory->newInternalErrorHtmlPresenter()->present( $e ),
 		$code
 	);
 } );

--- a/app/routes.php
+++ b/app/routes.php
@@ -315,7 +315,7 @@ $app->post(
 		if ( $contactFormResponse->isSuccessful() ) {
 			return $app->redirect( $app['url_generator']->generate( 'page', [ 'pageName' => 'Kontakt_Bestaetigung' ] ) );
 		}
-		return $ffFactory->newGetInTouchHTMLPresenter()->present( $contactFormResponse, $request->request->all() );
+		return $ffFactory->newGetInTouchHtmlPresenter()->present( $contactFormResponse, $request->request->all() );
 	}
 );
 

--- a/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
@@ -47,7 +47,7 @@ class HandlePayPalPaymentNotificationUseCase {
 			return $this->createUnhandledResponse( 'Unhandled PayPal instant payment notification' );
 		}
 
-		if ( $this->transactionIsSubscriptionRelatedButNotAPayment( $request ) ) {
+		if ( $this->isSubscriptionRelatedNonPaymentTransaction( $request ) ) {
 			return $this->createUnhandledResponse( 'Unhandled PayPal subscription notification' );
 		}
 
@@ -128,7 +128,7 @@ class HandlePayPalPaymentNotificationUseCase {
 		}
 	}
 
-	private function transactionIsSubscriptionRelatedButNotAPayment( PayPalPaymentNotificationRequest $request ): bool {
+	private function isSubscriptionRelatedNonPaymentTransaction( PayPalPaymentNotificationRequest $request ): bool {
 		return $request->isForRecurringPayment() && !$request->isRecurringPaymentCompletion();
 	}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -52,7 +52,8 @@
     <rule ref="Generic.NamingConventions" />
     <!-- TODO: create variation of this sniff that allows underscores in test methods -->
     <rule ref="Generic.NamingConventions.CamelCapsFunctionName.ScopeNotCamelCaps">
-        <severity>0</severity>
+        <!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
+        <exclude-pattern>*Test\.php</exclude-pattern>
     </rule>
 
     <rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
@@ -68,7 +69,8 @@
     <rule ref="PSR1" />
     <!-- TODO: create variation of this sniff that allows underscores in test methods -->
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
-        <severity>0</severity>
+        <!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
+        <exclude-pattern>*Test\.php</exclude-pattern>
     </rule>
 
     <rule ref="PSR2.Classes.PropertyDeclaration" />

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -471,7 +471,7 @@ class FunFunFactory {
 		return $this->pimple['template_name_validator'];
 	}
 
-	public function newAddSubscriptionHTMLPresenter(): AddSubscriptionHtmlPresenter {
+	public function newAddSubscriptionHtmlPresenter(): AddSubscriptionHtmlPresenter {
 		return new AddSubscriptionHtmlPresenter( $this->getIncludeTemplate( 'Subscription_Form.html.twig' ), $this->getTranslator() );
 	}
 
@@ -482,11 +482,11 @@ class FunFunFactory {
 		);
 	}
 
-	public function newAddSubscriptionJSONPresenter(): AddSubscriptionJsonPresenter {
+	public function newAddSubscriptionJsonPresenter(): AddSubscriptionJsonPresenter {
 		return new AddSubscriptionJsonPresenter( $this->getTranslator() );
 	}
 
-	public function newGetInTouchHTMLPresenter(): GetInTouchHtmlPresenter {
+	public function newGetInTouchHtmlPresenter(): GetInTouchHtmlPresenter {
 		return new GetInTouchHtmlPresenter( $this->getIncludeTemplate( 'Kontaktformular.html.twig' ), $this->getTranslator() );
 	}
 
@@ -760,11 +760,11 @@ class FunFunFactory {
 		return new EmailAddress( $this->config['contact-info']['organization']['email'] );
 	}
 
-	public function newInternalErrorHTMLPresenter(): InternalErrorHtmlPresenter {
+	public function newInternalErrorHtmlPresenter(): InternalErrorHtmlPresenter {
 		return new InternalErrorHtmlPresenter( $this->getIncludeTemplate( 'Error_Page.html.twig' ) );
 	}
 
-	public function newAccessDeniedHTMLPresenter(): InternalErrorHtmlPresenter {
+	public function newAccessDeniedHtmlPresenter(): InternalErrorHtmlPresenter {
 		return new InternalErrorHtmlPresenter( $this->getLayoutTemplate( 'Access_Denied.twig' ) );
 	}
 
@@ -1293,7 +1293,7 @@ class FunFunFactory {
 		);
 	}
 
-	public function newPageNotFoundHTMLPresenter(): PageNotFoundPresenter {
+	public function newPageNotFoundHtmlPresenter(): PageNotFoundPresenter {
 		return new PageNotFoundPresenter( $this->getLayoutTemplate( 'Page_not_found.html.twig' ) );
 	}
 


### PR DESCRIPTION
Based on PHPCS config I found in the backend repo