### PR TITLE
Mark getIncludeTemplate as deprecated

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -520,6 +520,8 @@ class FunFunFactory {
 	/**
 	 * Get a layouted template that includes another template
 	 *
+	 * @deprecated Change the template to use extend and block and call getLayoutTemplate instead.
+	 *
 	 * @param string $templateName Template to include
 	 * @return TwigTemplate
 	 */


### PR DESCRIPTION
This getIncludeTemplate method was important to leave out "extends" and
"block" syntax out of templates that were stored in the CMS wiki. Now
that all templates are file-based, they should use the Twig extension
mechanism.