### PR TITLE
Codestyle verification

### DIFF
--- a/cli/ConfigValidation/ValidateConfigCommand.php
+++ b/cli/ConfigValidation/ValidateConfigCommand.php
@@ -25,8 +25,7 @@ class ValidateConfigCommand extends Command {
 	const DEFAULT_SCHEMA = __DIR__ . '/../../app/config/schema.json';
 	const ERROR_RETURN_CODE = 1;
 
-	protected function configure()
-	{
+	protected function configure(): void {
 		$this->setName( self::NAME )
 			->setDescription( 'Validate configuration files' )
 			->setHelp( 'This command merges the specified configuration files and validates them against a JSON schema' )
@@ -50,8 +49,7 @@ class ValidateConfigCommand extends Command {
 			);
 	}
 
-	protected function execute( InputInterface $input, OutputInterface $output )
-	{
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$configObject = $this->loadConfigObjectFromFiles( $input->getArgument( 'config_file' ) );
 
 		if ( $input->getOption( 'dump-config' ) ) {
@@ -78,8 +76,9 @@ class ValidateConfigCommand extends Command {
 	}
 
 	/**
-	 * @param array $configFiles
 	 * @throws \RuntimeException
+	 * @param array $configFiles
+	 * @return \stdClass
 	 */
 	private function loadConfigObjectFromFiles( array $configFiles ): \stdClass {
 		$configReader = new ConfigReader(

--- a/cli/ConfigValidation/ValidateConfigCommand.php
+++ b/cli/ConfigValidation/ValidateConfigCommand.php
@@ -24,6 +24,7 @@ class ValidateConfigCommand extends Command {
 	const NAME = 'validate-config';
 	const DEFAULT_SCHEMA = __DIR__ . '/../../app/config/schema.json';
 	const ERROR_RETURN_CODE = 1;
+	const OK_RETURN_CODE = 0;
 
 	protected function configure(): void {
 		$this->setName( self::NAME )
@@ -64,7 +65,7 @@ class ValidateConfigCommand extends Command {
 		);
 
 		if ( $validator->passes() ) {
-			return null;
+			return self::OK_RETURN_CODE;
 		}
 
 		$renderer = new ValidationErrorRenderer( $schema );

--- a/cli/FundraisingCli.php
+++ b/cli/FundraisingCli.php
@@ -18,7 +18,7 @@ class FundraisingCli {
 	 */
 	private $app;
 
-	public function newApplication() :Application {
+	public function newApplication(): Application {
 		$this->app = new Application();
 		$this->setApplicationInfo();
 		$this->registerCommands();

--- a/composer.json
+++ b/composer.json
@@ -71,8 +71,9 @@
 		"mikey179/vfsStream": "~1.6",
 		"wmde/psr-log-test-doubles": "~2.1",
 
-		"squizlabs/php_codesniffer": "~2.7",
+		"squizlabs/php_codesniffer": "~2.8",
 		"phpmd/phpmd": "~2.3",
+		"slevomat/coding-standard": "^2.3",
 
 		"symfony/browser-kit": "^3.2",
 		"silex/web-profiler": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
 			"@validate-app-config"
 		],
 		"phpcs": [
-			"vendor/bin/phpcs src/ tests/ contexts/ cli/ --standard=phpcs.xml --extensions=php -sp"
+			"vendor/bin/phpcs"
 		],
 		"phpmd": [
 			"vendor/bin/phpmd src/ text phpmd.xml"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bebf3a769c999e665ae317d673cbd3cb",
+    "content-hash": "5dffd6dd7c0ad857fbd14d4f443f7c53",
     "packages": [
         {
             "name": "addwiki/mediawiki-api-base",

--- a/composer.lock
+++ b/composer.lock
@@ -4243,16 +4243,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
                 "shasum": ""
             },
             "require": {
@@ -4317,7 +4317,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-05-03T23:30:39+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "90bc84305c1531583310c88094e92d3c",
+    "content-hash": "bebf3a769c999e665ae317d673cbd3cb",
     "packages": [
         {
             "name": "addwiki/mediawiki-api-base",
@@ -4194,6 +4194,43 @@
             "time": "2017-04-23T23:11:39+00:00"
         },
         {
+            "name": "slevomat/coding-standard",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "aa73a1122ca38ead2c3b07e3086b3b7dd796d018"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aa73a1122ca38ead2c3b07e3086b3b7dd796d018",
+                "reference": "aa73a1122ca38ead2c3b07e3086b3b7dd796d018",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "squizlabs/php_codesniffer": "~2.8.1"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "0.9.2",
+                "phing/phing": "2.16",
+                "phpstan/phpstan": "0.6.4",
+                "phpunit/phpunit": "6.1.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer extends Consistence Coding Standard by providing sniffs with additional checks.",
+            "time": "2017-05-04T14:02:28+00:00"
+        },
+        {
             "name": "sorien/silex-dbal-profiler",
             "version": "2.0.0",
             "source": {
@@ -4243,16 +4280,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97"
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
-                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
                 "shasum": ""
             },
             "require": {
@@ -4317,7 +4354,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-03T23:30:39+00:00"
+            "time": "2017-03-01T22:17:45+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/contexts/DonationContext/src/Validation/DonorValidator.php
+++ b/contexts/DonationContext/src/Validation/DonorValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\DonationContext\Validation;
 
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donor;

--- a/contexts/DonationContext/tests/Data/IncompleteDoctrineDonation.php
+++ b/contexts/DonationContext/tests/Data/IncompleteDoctrineDonation.php
@@ -142,7 +142,7 @@ class IncompleteDoctrineDonation {
 		];
 	}
 
-	private function getPaypalArray():array {
+	private function getPaypalArray(): array {
 		return [
 			'paypal_payer_id' => ValidPayPalNotificationRequest::PAYER_ID,
 			'paypal_subscr_id' => ValidPayPalNotificationRequest::SUBSCRIBER_ID,

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationEventLoggerTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationEventLoggerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Integration\DataAccess;
 

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\MembershipContext\Tests\Unit\UseCases\ApplyForMembership;
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 	- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
-	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards
+	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/src/Standards
 -->
 <ruleset name="FunFunFundraisingFrontend">
     <!--<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace">-->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -122,4 +122,6 @@
     </rule>
 
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSpacingSniff.php" />
+
+    <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Namespaces/UseDoesNotStartWithBackslashSniff.php" />
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -111,4 +111,13 @@
     </rule>
 
     <rule ref="Zend.Files.ClosingTag" />
+
+    <!-- Using 3rd party sniff while Squiz isn't there, yet. https://github.com/squizlabs/PHP_CodeSniffer/issues/911 -->
+    <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php" />
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="2" />
+            <property name="spacesCountAroundEqualsSign" value="1" />
+        </properties>
+    </rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,16 @@
 	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/src/Standards
 -->
 <ruleset name="FunFunFundraisingFrontend">
+
+    <file>src/</file>
+    <file>tests/</file>
+    <file>contexts/</file>
+    <file>cli/</file>
+
+    <arg name="extensions" value="php"/>
+    <arg value="s"/>
+    <arg value="p"/>
+
     <!--<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace">-->
         <!--<exclude name="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace/SpaceBeforeSingleLineCommentSniff.php" />-->
     <!--</rule>-->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -32,8 +32,7 @@
     <rule ref="Generic.Functions.CallTimePassByReference" />
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing" />
 
-    <!-- Does not yet work with PHP7 return types -->
-    <!--<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />-->
+    <rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie" />
 
     <rule ref="Generic.Metrics.NestingLevel">
         <properties>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,6 @@
 <ruleset name="FunFunFundraisingFrontend">
     <!--<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace">-->
         <!--<exclude name="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace/SpaceBeforeSingleLineCommentSniff.php" />-->
-        <!--<exclude name="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace/SpaceyParenthesisSniff.php" />-->
     <!--</rule>-->
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
@@ -124,4 +123,23 @@
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSpacingSniff.php" />
 
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Namespaces/UseDoesNotStartWithBackslashSniff.php" />
+
+    <!-- MediaWiki.WhiteSpace.SpaceyParenthesis replica for up-to-date codesniffer version -->
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1" />
+            <property name="requiredSpacesAfterOpen" value="1" />
+            <property name="requiredSpacesBeforeClose" value="1" />
+        </properties>
+    </rule>
+
+    <rule ref="PEAR.Functions.FunctionCallSignature">
+        <properties>
+            <property name="requiredSpacesAfterOpen" value="1" />
+            <property name="requiredSpacesBeforeClose" value="1" />
+        </properties>
+        <exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+    </rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -120,4 +120,6 @@
             <property name="spacesCountAroundEqualsSign" value="1" />
         </properties>
     </rule>
+
+    <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSpacingSniff.php" />
 </ruleset>

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -428,10 +428,10 @@ class FunFunFactory {
 		};
 
 		$pimple['content_page_selector'] = function () {
-			$json = (new SimpleFileFetcher())->fetchFile($this->getI18nDirectory() . '/data/pages.json');
-			$config = json_decode($json, true) ?? [];
+			$json = (new SimpleFileFetcher())->fetchFile( $this->getI18nDirectory() . '/data/pages.json' );
+			$config = json_decode( $json, true ) ?? [];
 
-			return new PageSelector($config);
+			return new PageSelector( $config );
 		};
 
 		$pimple['content_provider'] = function () {

--- a/src/Factories/TwigFactory.php
+++ b/src/Factories/TwigFactory.php
@@ -20,7 +20,7 @@ class TwigFactory {
 	private $cachePath;
 	private $locale;
 
-	public function __construct(array $config, string $cachePath, string $locale) {
+	public function __construct( array $config, string $cachePath, string $locale ) {
 		$this->config = $config;
 		$this->cachePath = $cachePath;
 		$this->locale = $locale;
@@ -84,6 +84,6 @@ class TwigFactory {
 	}
 
 	public function newTwigEnvironmentConfigurator() {
-		return new TwigEnvironmentConfigurator($this->config, $this->cachePath);
+		return new TwigEnvironmentConfigurator( $this->config, $this->cachePath );
 	}
 }

--- a/src/Factories/TwigFactory.php
+++ b/src/Factories/TwigFactory.php
@@ -26,7 +26,7 @@ class TwigFactory {
 		$this->locale = $locale;
 	}
 
-	public function newFileSystemLoader(): ? Twig_Loader_Filesystem {
+	public function newFileSystemLoader(): ?Twig_Loader_Filesystem {
 		if ( empty( $this->config['loaders']['filesystem'] ) ) {
 			return null;
 		}

--- a/src/Infrastructure/PiwikEvents.php
+++ b/src/Infrastructure/PiwikEvents.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Infrastructure;
 
 /**

--- a/src/Infrastructure/PiwikVariableCollector.php
+++ b/src/Infrastructure/PiwikVariableCollector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Infrastructure;
 
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;

--- a/src/Presentation/ContentPage/ContentNotFoundException.php
+++ b/src/Presentation/ContentPage/ContentNotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Presentation\ContentPage;
 

--- a/src/Presentation/ContentPage/PageNotFoundException.php
+++ b/src/Presentation/ContentPage/PageNotFoundException.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Presentation\ContentPage;
 

--- a/src/Presentation/ContentPage/PageSelector.php
+++ b/src/Presentation/ContentPage/PageSelector.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Presentation\ContentPage;
 

--- a/src/Presentation/DonationConfirmationPageSelector.php
+++ b/src/Presentation/DonationConfirmationPageSelector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation;
 
 /**

--- a/src/Presentation/Presenters/CancelDonationHtmlPresenter.php
+++ b/src/Presentation/Presenters/CancelDonationHtmlPresenter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\CancelDonation\CancelDonationResponse;

--- a/src/Presentation/Presenters/CancelMembershipApplicationHtmlPresenter.php
+++ b/src/Presentation/Presenters/CancelMembershipApplicationHtmlPresenter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
 use WMDE\Fundraising\Frontend\MembershipContext\UseCases\CancelMembershipApplication\CancellationResponse;

--- a/src/Presentation/Presenters/CreditCardPaymentHtmlPresenter.php
+++ b/src/Presentation/Presenters/CreditCardPaymentHtmlPresenter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
 use Symfony\Component\Translation\Translator;

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;

--- a/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Applicant;

--- a/src/Presentation/SelectedConfirmationPage.php
+++ b/src/Presentation/SelectedConfirmationPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation;
 
 /**

--- a/src/Presentation/TemplateTestCampaign.php
+++ b/src/Presentation/TemplateTestCampaign.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Presentation;
 
 /**

--- a/src/Presentation/TwigEnvironmentConfigurator.php
+++ b/src/Presentation/TwigEnvironmentConfigurator.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Presentation;
 

--- a/src/Validation/TextPolicyValidator.php
+++ b/src/Validation/TextPolicyValidator.php
@@ -112,7 +112,7 @@ class TextPolicyValidator {
 		return $matches[0];
 	}
 
-	private function hasBadWordNotMatchingWhiteWords( array $badMatches, array $whiteMatches ):bool {
+	private function hasBadWordNotMatchingWhiteWords( array $badMatches, array $whiteMatches ): bool {
 		return count(
 			array_udiff( $badMatches, $whiteMatches, function( $badMatch, $whiteMatch ) {
 				return !preg_match( $this->composeRegex( [ preg_quote( $badMatch, '#' ) ] ), $whiteMatch );

--- a/tests/EdgeToEdge/TranslatorTest.php
+++ b/tests/EdgeToEdge/TranslatorTest.php
@@ -17,7 +17,7 @@ class TranslatorTest extends WebRouteTestCase {
 	public function testGivenDefinedMessageKey_responseContainsTranslatedMessages() {
 		$client = $this->createClient(
 			[],
-			function (FunFunFactory $factory) {
+			function ( FunFunFactory $factory ) {
 				$factory->setTranslator( $this->newTranslator( [ 'page_not_found' => 'Seite nicht gefunden' ], 'de' ) );
 			}
 		);

--- a/tests/Integration/Factories/TranslationFactoryTest.php
+++ b/tests/Integration/Factories/TranslationFactoryTest.php
@@ -8,7 +8,8 @@ use Symfony\Component\Translation\Loader\ArrayLoader;
 use WMDE\Fundraising\Frontend\Factories\TranslationFactory;
 
 class TranslationFactoryTest extends \PHPUnit\Framework\TestCase {
-	public function testLoadersAreSet(){
+
+	public function testLoadersAreSet(): void {
 		$factory = new TranslationFactory();
 		$loader = new ArrayLoader();
 		$translator = $factory->create( ['array' => $loader] );

--- a/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Tests\Integration\Presentation\Presenters;
 
 use WMDE\Fundraising\Frontend\Infrastructure\PiwikEvents;

--- a/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Tests\Integration\Presentation\Presenters;
 
 use WMDE\Fundraising\Frontend\MembershipContext\Tests\Data\ValidMembershipApplication;

--- a/tests/Integration/Presentation/TwigEnvironmentConfiguratorTest.php
+++ b/tests/Integration/Presentation/TwigEnvironmentConfiguratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\Integration\Presentation;
 

--- a/tests/Integration/Validation/DonorValidatorTest.php
+++ b/tests/Integration/Validation/DonorValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Tests\Integration\Validation;
 
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donor;

--- a/tests/Unit/Factories/TwigFactoryTest.php
+++ b/tests/Unit/Factories/TwigFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace Unit\Factories;
 

--- a/tests/Unit/Infrastructure/PayPalPaymentNotificationVerifierTest.php
+++ b/tests/Unit/Infrastructure/PayPalPaymentNotificationVerifierTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
 
 use GuzzleHttp\Client;

--- a/tests/Unit/Presentation/ContentPage/PageSelectorTest.php
+++ b/tests/Unit/Presentation/ContentPage/PageSelectorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\Unit\Presentation\ContentPage;
 

--- a/tests/Unit/Presentation/TemplateTestCampaignTest.php
+++ b/tests/Unit/Presentation/TemplateTestCampaignTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types = 1 );
+
 namespace WMDE\Fundraising\Tests\Unit\Presentation;
 
 use WMDE\Fundraising\Frontend\Presentation\TemplateTestCampaign;

--- a/tests/Unit/Validation/FieldTextPolicyValidatorTest.php
+++ b/tests/Unit/Validation/FieldTextPolicyValidatorTest.php
@@ -16,21 +16,21 @@ use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
  */
 class FieldTextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenHarmlessText_itSucceeds(){
+	public function testGivenHarmlessText_itSucceeds(): void {
 		$textPolicy = $this->createMock( TextPolicyValidator::class );
 		$textPolicy->method( $this->anything() )->willReturn( true );
 		$validator = new FieldTextPolicyValidator( $textPolicy );
 		$this->assertTrue( $validator->validate( 'tiny cat' )->isSuccessful() );
 	}
 
-	public function testGivenHarmfulText_itFails(){
+	public function testGivenHarmfulText_itFails(): void {
 		$textPolicy = $this->createMock( TextPolicyValidator::class );
 		$textPolicy->method( $this->anything() )->willReturn( false );
 		$validator = new FieldTextPolicyValidator( $textPolicy );
 		$this->assertFalse( $validator->validate( 'mean tiger' )->isSuccessful() );
 	}
 
-	public function testGivenHarmfulText_itProvidesAConstraintViolation(){
+	public function testGivenHarmfulText_itProvidesAConstraintViolation(): void {
 		$textPolicy = $this->createMock( TextPolicyValidator::class );
 		$textPolicy->method( $this->anything() )->willReturn( false );
 		$validator = new FieldTextPolicyValidator( $textPolicy );


### PR DESCRIPTION
Added some checks to automatically verify our existing code style, fixed a few resulting violations. I used 3rd [1] party sniffs as [squiz is not fully supporting php 7.1, yet](https://github.com/squizlabs/PHP_CodeSniffer/issues/911), and some native sniffs replicating the wm-cs behaviour (which do not support modern CodeSniffer versions).

There is one effective change of the application (ValidateConfigCommand.php) where I opted against changing to a wrong mixed return type.

I would also suggest we add the following - some work (many violations), but they are not mere cosmetic but would actually make our code significantly better and more performant [2].
* SlevomatCodingStandard.Classes.ClassConstantVisibility
* SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue
* SlevomatCodingStandard.TypeHints.TypeHintDeclaration (partially)

To avoid misunderstandings: I do not propose to change the code style, but to enforce the *rules* that are already there but not clearly documented/technically checked for, but frowned upon when violated.

[1] https://github.com/slevomat/coding-standard/
[2] http://stackoverflow.com/questions/32940170/are-scalar-and-strict-types-in-php7-a-performance-enhancing-feature