### PR TITLE
content using atomic deploy lives in 'current' dir

### DIFF
--- a/deployment/inventory/production_example
+++ b/deployment/inventory/production_example
@@ -8,7 +8,7 @@ spenden.wikimedia.de ansible_user=deploy
 app_dir = "/usr/share/nginx/www/spenden.wikimedia.de"
 
 # relative dir inside app_dir where the always up-to-date i18n content can be found (deployed independently)
-content_directory = "fundraising-frontend-content"
+content_directory = "fundraising-frontend-content/current"
 
 # Prefix for release directories
 release_prefix = release-


### PR DESCRIPTION
For https://github.com/wmde/fundraising-infrastructure/pull/129