### PR TITLE
T166143 replaced mailer inheritance with a shared interface

### DIFF
--- a/contexts/DonationContext/src/Infrastructure/DonationConfirmationMailer.php
+++ b/contexts/DonationContext/src/Infrastructure/DonationConfirmationMailer.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\DonationContext\Infrastructure;
 
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankTransferPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
@@ -18,7 +18,7 @@ class DonationConfirmationMailer {
 
 	private $mailer;
 
-	public function __construct( TemplateBasedMailer $mailer ) {
+	public function __construct( TemplateMailerInterface $mailer ) {
 		$this->mailer = $mailer;
 	}
 

--- a/contexts/DonationContext/src/UseCases/CancelDonation/CancelDonationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/CancelDonation/CancelDonationUseCase.php
@@ -10,7 +10,7 @@ use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\DonationReposi
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\GetDonationException;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\StoreDonationException;
 use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationEventLogger;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 
 /**
@@ -26,7 +26,7 @@ class CancelDonationUseCase {
 	private $authorizationService;
 	private $donationLogger;
 
-	public function __construct( DonationRepository $donationRepository, TemplateBasedMailer $mailer,
+	public function __construct( DonationRepository $donationRepository, TemplateMailerInterface $mailer,
 		DonationAuthorizer $authorizationService, DonationEventLogger $donationLogger ) {
 
 		$this->donationRepository = $donationRepository;

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership;
 
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationTokenFetcher;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
@@ -27,7 +27,7 @@ class ApplyForMembershipUseCase {
 	private $piwikTracker;
 
 	public function __construct( ApplicationRepository $repository,
-		ApplicationTokenFetcher $tokenFetcher, TemplateBasedMailer $mailer,
+		ApplicationTokenFetcher $tokenFetcher, TemplateMailerInterface $mailer,
 		MembershipApplicationValidator $validator, ApplyForMembershipPolicyValidator $policyValidator,
 		ApplicationTracker $tracker, ApplicationPiwikTracker $piwikTracker ) {
 

--- a/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\CancelMembershipApplication;
 
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
@@ -22,7 +22,7 @@ class CancelMembershipApplicationUseCase {
 	private $mailer;
 
 	public function __construct( ApplicationAuthorizer $authorizer,
-		ApplicationRepository $repository, TemplateBasedMailer $mailer ) {
+		ApplicationRepository $repository, TemplateMailerInterface $mailer ) {
 
 		$this->authorizer = $authorizer;
 		$this->repository = $repository;

--- a/contexts/MembershipContext/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\HandleSubscriptio
 
 use Psr\Log\LoggerInterface;
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Payment;
@@ -30,7 +30,8 @@ class HandleSubscriptionPaymentNotificationUseCase {
 	private $logger;
 
 	public function __construct( ApplicationRepository $repository, ApplicationAuthorizer $authorizationService,
-								 TemplateBasedMailer $mailer, LoggerInterface $logger ) {
+		TemplateMailerInterface $mailer, LoggerInterface $logger ) {
+
 		$this->repository = $repository;
 		$this->authorizationService = $authorizationService;
 		$this->mailer = $mailer;

--- a/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\HandleSubscriptionSignupNotification;
 
 use Psr\Log\LoggerInterface;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
@@ -27,7 +27,8 @@ class HandleSubscriptionSignupNotificationUseCase {
 	private $logger;
 
 	public function __construct( ApplicationRepository $repository, ApplicationAuthorizer $authorizationService,
-								 TemplateBasedMailer $mailer, LoggerInterface $logger ) {
+		TemplateMailerInterface $mailer, LoggerInterface $logger ) {
+
 		$this->repository = $repository;
 		$this->authorizationService = $authorizationService;
 		$this->mailer = $mailer;

--- a/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
+++ b/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\AddSubscription
 
 use WMDE\Fundraising\Entities\Address;
 use WMDE\Fundraising\Entities\Subscription;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepository;
 use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepositoryException;
@@ -26,7 +26,7 @@ class AddSubscriptionUseCase {
 	private $mailer;
 
 	public function __construct( SubscriptionRepository $subscriptionRepository,
-		SubscriptionValidator $subscriptionValidator, TemplateBasedMailer $mailer ) {
+		SubscriptionValidator $subscriptionValidator, TemplateMailerInterface $mailer ) {
 
 		$this->subscriptionRepository = $subscriptionRepository;
 		$this->subscriptionValidator = $subscriptionValidator;

--- a/contexts/SubscriptionContext/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
+++ b/contexts/SubscriptionContext/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\ConfirmSubscription;
 
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepository;
 use WMDE\Fundraising\Frontend\Validation\ConstraintViolation;
@@ -20,7 +20,7 @@ class ConfirmSubscriptionUseCase {
 
 	private $mailer;
 
-	public function __construct( SubscriptionRepository $subscriptionRepository, TemplateBasedMailer $mailer ) {
+	public function __construct( SubscriptionRepository $subscriptionRepository, TemplateMailerInterface $mailer ) {
 		$this->subscriptionRepository = $subscriptionRepository;
 		$this->mailer = $mailer;
 	}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -79,6 +79,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\ProfilerDataCollector;
 use WMDE\Fundraising\Frontend\Infrastructure\ProfilingDecoratorBuilder;
 use WMDE\Fundraising\Frontend\Infrastructure\RandomTokenGenerator;
 use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\Infrastructure\TokenGenerator;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationTokenFetcher;
@@ -608,7 +609,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newAddSubscriptionMailer(): TemplateBasedMailer {
+	private function newAddSubscriptionMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate(
@@ -622,7 +623,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newConfirmSubscriptionMailer(): TemplateBasedMailer {
+	private function newConfirmSubscriptionMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate(
@@ -634,7 +635,13 @@ class FunFunFactory {
 		);
 	}
 
-	private function newTemplateMailer( Messenger $messenger, TwigTemplate $template, string $messageKey ): TemplateBasedMailer {
+	/**
+	 * Create a new TemplateMailer instance
+	 *
+	 * So much decoration going on that explicitly hinting what we return (Robustness principle) would be confusing
+	 * (you'd expect a TemplateBasedMailer, not a LoggingMailer), so we hint the interface instead.
+	 */
+	private function newTemplateMailer( Messenger $messenger, TwigTemplate $template, string $messageKey ): TemplateMailerInterface {
 		$mailer = new TemplateBasedMailer(
 			$messenger,
 			$template,
@@ -678,7 +685,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newContactUserMailer(): TemplateBasedMailer {
+	private function newContactUserMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate( $this->getTwig(), 'Mail_Contact_Confirm_to_User.txt.twig' ),
@@ -816,7 +823,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newCancelDonationMailer(): TemplateBasedMailer {
+	private function newCancelDonationMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate(
@@ -972,7 +979,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newApplyForMembershipMailer(): TemplateBasedMailer {
+	private function newApplyForMembershipMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getOrganizationMessenger(),
 			new TwigTemplate(
@@ -1029,7 +1036,7 @@ class FunFunFactory {
 		return $this->pimple['membership_application_repository'];
 	}
 
-	private function newCancelMembershipApplicationMailer(): TemplateBasedMailer {
+	private function newCancelMembershipApplicationMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getOrganizationMessenger(),
 			new TwigTemplate(

--- a/src/Infrastructure/LoggingMailer.php
+++ b/src/Infrastructure/LoggingMailer.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
  * @license GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class LoggingMailer extends TemplateBasedMailer {
+class LoggingMailer implements TemplateMailerInterface {
 
 	const CONTEXT_EXCEPTION_KEY = 'exception';
 
@@ -20,16 +20,17 @@ class LoggingMailer extends TemplateBasedMailer {
 	private $logger;
 	private $logLevel;
 
-	public function __construct( TemplateBasedMailer $mailer, LoggerInterface $logger ) {
+	public function __construct( TemplateMailerInterface $mailer, LoggerInterface $logger ) {
 		$this->mailer = $mailer;
 		$this->logger = $logger;
 		$this->logLevel = LogLevel::CRITICAL;
 	}
 
 	/**
+	 * @inheritdoc
 	 * @throws \RuntimeException
 	 */
-	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ) {
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		try {
 			$this->mailer->sendMail( $recipient, $templateArguments );
 		}
@@ -38,5 +39,4 @@ class LoggingMailer extends TemplateBasedMailer {
 			throw $ex;
 		}
 	}
-
 }

--- a/src/Infrastructure/TemplateBasedMailer.php
+++ b/src/Infrastructure/TemplateBasedMailer.php
@@ -11,7 +11,7 @@ use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class TemplateBasedMailer {
+class TemplateBasedMailer implements TemplateMailerInterface {
 
 	private $messenger;
 	private $template;
@@ -24,9 +24,10 @@ class TemplateBasedMailer {
 	}
 
 	/**
+	 * @inheritdoc
 	 * @throws \RuntimeException
 	 */
-	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ) {
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		$this->messenger->sendMessageToUser(
 			new Message(
 				$this->subject,

--- a/src/Infrastructure/TemplateMailerInterface.php
+++ b/src/Infrastructure/TemplateMailerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
+
+interface TemplateMailerInterface {
+
+	/**
+	 * @param EmailAddress $recipient The recipient of the email to send
+	 * @param array $templateArguments Context parameters to use while rendering the template
+	 */
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void;
+}

--- a/src/UseCases/GetInTouch/GetInTouchUseCase.php
+++ b/src/UseCases/GetInTouch/GetInTouchUseCase.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\UseCases\GetInTouch;
 
 use WMDE\Fundraising\Frontend\Infrastructure\OperatorMailer;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\Validation\ValidationResponse;
 use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
@@ -21,7 +21,8 @@ class GetInTouchUseCase {
 	private $userMailer;
 
 	public function __construct( GetInTouchValidator $validator, OperatorMailer $operatorMailer,
-								 TemplateBasedMailer $userMailer ) {
+		TemplateMailerInterface $userMailer ) {
+
 		$this->validator = $validator;
 		$this->operatorMailer = $operatorMailer;
 		$this->userMailer = $userMailer;

--- a/tests/Fixtures/TemplateBasedMailerSpy.php
+++ b/tests/Fixtures/TemplateBasedMailerSpy.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Tests\Fixtures;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_TestCase;
 use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 
@@ -22,7 +21,7 @@ class TemplateBasedMailerSpy extends TemplateBasedMailer {
 		$this->testCase = $testCase;
 	}
 
-	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ) {
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		$this->sendMailCalls[] = [ $recipient, $templateArguments ];
 	}
 

--- a/tests/Unit/Infrastructure/LoggingMailerTest.php
+++ b/tests/Unit/Infrastructure/LoggingMailerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use WMDE\Fundraising\Frontend\Infrastructure\LoggingMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class LoggingMailerTest extends TestCase {
+
+	public function testImplementsInterface(): void {
+		$class = new ReflectionClass( LoggingMailer::class );
+		$this->assertTrue( $class->implementsInterface( TemplateMailerInterface::class ) );
+	}
+}

--- a/tests/Unit/Infrastructure/TemplateBasedMailerTest.php
+++ b/tests/Unit/Infrastructure/TemplateBasedMailerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class TemplateBasedMailerTest extends TestCase {
+
+	public function testImplementsInterface(): void {
+		$class = new ReflectionClass( TemplateBasedMailer::class );
+		$this->assertTrue( $class->implementsInterface( TemplateMailerInterface::class ) );
+	}
+}


### PR DESCRIPTION
Fixes phpstan issue:
"__construct() does not call parent constructor" in
src/Infrastructure/LoggingMailer.php

see story, https://github.com/wmde/FundraisingFrontend/tree/hey-stan