### PR TITLE
T166143 Introducing phpstan + fixing smells

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - composer ci
   - travis_retry vendor/bin/phpunit tests/System/
   - composer install --ignore-platform-reqs --no-dev
-  - docker run -v $PWD:/app --rm wmde/fundraising-frontend-phpstan analyse -c phpstan.neon --level 1 cli/ contexts/ src/
+  - docker run -v $PWD:/app --rm wmde/fundraising-frontend-phpstan analyse -c phpstan.neon --level 1 --no-progress cli/ contexts/ src/
 
 after_success:
   - if [ "$TYPE" == "coverage" ]; then bash build/travis/uploadCoverage.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 dist: trusty
 
-sudo: false
-
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
 
 sudo: false
 
+services:
+  - docker
+
 install:
   - travis_retry composer install
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ before_script:
 script:
   - composer ci
   - travis_retry vendor/bin/phpunit tests/System/
+  - composer install --ignore-platform-reqs --no-dev
+  - docker run -v $PWD:/app --rm phpstan/phpstan analyse src
 
 after_success:
   - if [ "$TYPE" == "coverage" ]; then bash build/travis/uploadCoverage.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 matrix:
@@ -32,6 +34,8 @@ script:
   - composer ci
   - travis_retry vendor/bin/phpunit tests/System/
   - composer install --ignore-platform-reqs --no-dev
+  - docker ps
+  - docker images
   - docker run -v $PWD:/app --rm phpstan/phpstan analyse src
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 dist: trusty
 
+sudo: false
+
+services:
+  - docker
+
 language: php
 
 matrix:
@@ -15,10 +20,8 @@ matrix:
 #  allow_failures: # We allow this one to fail so fast_finish causes the build to not wait for it
 #  - env: DB=sqlite; TYPE=coverage
 
-sudo: false
-
-services:
-  - docker
+before_install:
+  - docker build -t wmde/fundraising-frontend-phpstan docker/phpstan
 
 install:
   - travis_retry composer install
@@ -34,9 +37,7 @@ script:
   - composer ci
   - travis_retry vendor/bin/phpunit tests/System/
   - composer install --ignore-platform-reqs --no-dev
-  - docker ps
-  - docker images
-  - docker run -v $PWD:/app --rm phpstan/phpstan analyse src
+  - docker run -v $PWD:/app --rm wmde/fundraising-frontend-phpstan analyse src
 
 after_success:
   - if [ "$TYPE" == "coverage" ]; then bash build/travis/uploadCoverage.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - composer ci
   - travis_retry vendor/bin/phpunit tests/System/
   - composer install --ignore-platform-reqs --no-dev
-  - docker run -v $PWD:/app --rm wmde/fundraising-frontend-phpstan analyse src
+  - docker run -v $PWD:/app --rm wmde/fundraising-frontend-phpstan analyse -c phpstan.neon --level 1 cli/ contexts/ src/
 
 after_success:
   - if [ "$TYPE" == "coverage" ]; then bash build/travis/uploadCoverage.sh; fi

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The "add donation" form can then be found at http://localhost:8000/index.php
 
 ## Running the tests
 
-**Full CI run**
+## Full CI run
 
     composer ci
 
@@ -100,7 +100,7 @@ For style checks only
 
 	composer cs ; npm run cs
     
-**PHP**
+## PHP
 
 For tests only
 
@@ -114,7 +114,21 @@ For one context only
 
     vendor/bin/phpunit contexts/DonationContext/
 
-**JS**
+### phpstan
+
+Static code analysis can be performed via [phpstan](https://github.com/phpstan/phpstan/), either via
+
+    composer stan
+    
+while dev-dependencies are present, or via
+
+    docker build -t wmde/fundraising-frontend-phpstan docker/phpstan
+    docker run -v $PWD:/app --rm wmde/fundraising-frontend-phpstan analyse -c phpstan.neon --level 1 --no-progress cli/ contexts/ src/
+
+in the absence of dev-dependencies (i.e. to simulate the vendor/ code on production).
+These tasks are also performed during the [travis](.travis.yml) runs.
+
+## JS
 
 For a full JS CI run
 

--- a/composer.json
+++ b/composer.json
@@ -114,8 +114,7 @@
 			"@test",
 			"@cs",
 			"npm run ci",
-			"@validate-app-config",
-			"@stan"
+			"@validate-app-config"
 		],
 		"phpcs": [
 			"vendor/bin/phpcs"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 		"symfony/console": "^3.2",
 		"piwik/piwik-php-tracker": "^1.0",
 		"wmde/fundraising-content-provider": "^2.0",
-		"guzzlehttp/guzzle": "^6.0"
+		"guzzlehttp/guzzle": "^6.0",
+		"symfony/stopwatch": "^3.3"
 	},
 	"repositories": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,8 @@
 			"@test",
 			"@cs",
 			"npm run ci",
-			"@validate-app-config"
+			"@validate-app-config",
+			"@stan"
 		],
 		"phpcs": [
 			"vendor/bin/phpcs"
@@ -122,7 +123,12 @@
 		"phpmd": [
 			"vendor/bin/phpmd src/ text phpmd.xml"
 		],
-		"validate-app-config": "./console validate-config app/config/config.dist.json app/config/config.test.json"
+		"validate-app-config": "./console validate-config app/config/config.dist.json app/config/config.test.json",
+		"stan": [
+			"composer install --ignore-platform-reqs --no-dev",
+			"docker run -v $PWD:/app --rm phpstan/phpstan analyse src"
+		]
+
 	},
 	"config": {
 		"discard-changes": true

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,8 @@
 		"silex/web-profiler": "~2.0",
 		"sorien/silex-dbal-profiler": "~2.0",
 		"wmde/fundraising-frontend-content": "dev-test",
-		"symfony/css-selector": "^3.2"
+		"symfony/css-selector": "^3.2",
+		"phpstan/phpstan": "^0.7.0"
 	},
 	"autoload": {
 		"psr-4": {
@@ -123,11 +124,7 @@
 			"vendor/bin/phpmd src/ text phpmd.xml"
 		],
 		"validate-app-config": "./console validate-config app/config/config.dist.json app/config/config.test.json",
-		"stan": [
-			"composer install --ignore-platform-reqs --no-dev",
-			"docker run -v $PWD:/app --rm phpstan/phpstan analyse src"
-		]
-
+		"stan": "./vendor/bin/phpstan analyse -c phpstan.neon --level 1 cli/ contexts/ src/"
 	},
 	"config": {
 		"discard-changes": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e27236f0d6df6a76f11fafc041a82fea",
+    "content-hash": "57b7cb6aea2e2275702dc6f385bcdda4",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2798,6 +2798,550 @@
             "time": "2017-04-12T18:52:22+00:00"
         },
         {
+            "name": "nette/bootstrap",
+            "version": "v2.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/bootstrap.git",
+                "reference": "2c27747f5aff2e436ebf542e0ea566bea1db2d53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/bootstrap/zipball/2c27747f5aff2e436ebf542e0ea566bea1db2d53",
+                "reference": "2c27747f5aff2e436ebf542e0ea566bea1db2d53",
+                "shasum": ""
+            },
+            "require": {
+                "nette/di": "~2.4.7",
+                "nette/utils": "~2.4",
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "latte/latte": "~2.2",
+                "nette/application": "~2.3",
+                "nette/caching": "~2.3",
+                "nette/database": "~2.3",
+                "nette/forms": "~2.3",
+                "nette/http": "~2.4.0",
+                "nette/mail": "~2.3",
+                "nette/robot-loader": "^2.4.2 || ^3.0",
+                "nette/safe-stream": "~2.2",
+                "nette/security": "~2.3",
+                "nette/tester": "~2.0",
+                "tracy/tracy": "^2.4.1"
+            },
+            "suggest": {
+                "nette/robot-loader": "to use Configurator::createRobotLoader()",
+                "tracy/tracy": "to use Configurator::enableTracy()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Bootstrap",
+            "homepage": "https://nette.org",
+            "time": "2017-02-19T22:15:02+00:00"
+        },
+        {
+            "name": "nette/caching",
+            "version": "v2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/caching.git",
+                "reference": "2436e530484a346d0a246733519ceaa40b943bd6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/caching/zipball/2436e530484a346d0a246733519ceaa40b943bd6",
+                "reference": "2436e530484a346d0a246733519ceaa40b943bd6",
+                "shasum": ""
+            },
+            "require": {
+                "nette/finder": "^2.2 || ~3.0.0",
+                "nette/utils": "^2.4 || ~3.0.0",
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "latte/latte": "^2.4",
+                "nette/di": "^2.4 || ~3.0.0",
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.4"
+            },
+            "suggest": {
+                "ext-pdo_sqlite": "to use SQLiteStorage or SQLiteJournal"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Caching Component",
+            "homepage": "https://nette.org",
+            "time": "2017-01-29T20:40:55+00:00"
+        },
+        {
+            "name": "nette/di",
+            "version": "v2.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/di.git",
+                "reference": "b3fe8551162279216e251e49b406e55cd2d255d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/di/zipball/b3fe8551162279216e251e49b406e55cd2d255d5",
+                "reference": "b3fe8551162279216e251e49b406e55cd2d255d5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "nette/neon": "^2.3.3 || ~3.0.0",
+                "nette/php-generator": "^2.6.1 || ~3.0.0",
+                "nette/utils": "^2.4.3 || ~3.0.0",
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "nette/bootstrap": "<2.4",
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Dependency Injection Component",
+            "homepage": "https://nette.org",
+            "time": "2017-03-14T17:16:14+00:00"
+        },
+        {
+            "name": "nette/finder",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/finder.git",
+                "reference": "5cabd5fe89f9903715359a403b820c7f94f9bb5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/finder/zipball/5cabd5fe89f9903715359a403b820c7f94f9bb5e",
+                "reference": "5cabd5fe89f9903715359a403b820c7f94f9bb5e",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "~2.4",
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Finder: Files Searching",
+            "homepage": "https://nette.org",
+            "time": "2016-05-17T15:49:06+00:00"
+        },
+        {
+            "name": "nette/neon",
+            "version": "v2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "1a78ff64b1e161ebccc03bdf9366450a69365f5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/1a78ff64b1e161ebccc03bdf9366450a69365f5b",
+                "reference": "1a78ff64b1e161ebccc03bdf9366450a69365f5b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "Nette NEON: parser & generator for Nette Object Notation",
+            "homepage": "http://ne-on.org",
+            "time": "2017-01-13T08:00:19+00:00"
+        },
+        {
+            "name": "nette/php-generator",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/php-generator.git",
+                "reference": "8605fd18857a4beef4aa0afc19eb9a7f876237e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/8605fd18857a4beef4aa0afc19eb9a7f876237e8",
+                "reference": "8605fd18857a4beef4aa0afc19eb9a7f876237e8",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^2.4.2 || ~3.0.0",
+                "php": ">=7.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🐘 Generates neat PHP code for you. Supports new PHP 7.1 features.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "code",
+                "nette",
+                "php",
+                "scaffolding"
+            ],
+            "time": "2017-03-18T15:20:10+00:00"
+        },
+        {
+            "name": "nette/robot-loader",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/robot-loader.git",
+                "reference": "459fc6bf08f0fd7f6889897e3acdff523dbf1159"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/robot-loader/zipball/459fc6bf08f0fd7f6889897e3acdff523dbf1159",
+                "reference": "459fc6bf08f0fd7f6889897e3acdff523dbf1159",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "nette/finder": "^2.3 || ^3.0",
+                "nette/utils": "^2.4 || ^3.0",
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🍀 RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "autoload",
+                "class",
+                "interface",
+                "nette",
+                "trait"
+            ],
+            "time": "2017-02-10T13:44:22+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v2.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "266160aec0d99516e0ea510de1dfa24a0dc1e76e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/266160aec0d99516e0ea510de1dfa24a0dc1e76e",
+                "reference": "266160aec0d99516e0ea510de1dfa24a0dc1e76e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "tracy/tracy": "^2.3"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize() and toAscii()",
+                "ext-intl": "for script transliteration in Strings::webalize() and toAscii()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "Nette Utility Classes",
+            "homepage": "https://nette.org",
+            "time": "2017-04-26T10:04:49+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "2b9e2f71b722f7c53918ab0c25f7646c2013f17d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2b9e2f71b722f7c53918ab0c25f7646c2013f17d",
+                "reference": "2b9e2f71b722f7c53918ab0c25f7646c2013f17d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0|~5.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2017-03-05T18:23:57+00:00"
+        },
+        {
             "name": "ockcyp/covers-validator",
             "version": "dev-master",
             "source": {
@@ -3307,6 +3851,60 @@
                 "stub"
             ],
             "time": "2017-03-02T20:05:34+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "8da03c084b2c8e4a92d48f6926f6191c2c7783ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8da03c084b2c8e4a92d48f6926f6191c2c7783ad",
+                "reference": "8da03c084b2c8e4a92d48f6926f6191c2c7783ad",
+                "shasum": ""
+            },
+            "require": {
+                "nette/bootstrap": "^2.4 || ^3.0",
+                "nette/caching": "^2.4 || ^3.0",
+                "nette/di": "^2.4 || ^3.0",
+                "nette/robot-loader": "^2.4.2 || ^3.0",
+                "nette/utils": "^2.4 || ^3.0",
+                "nikic/php-parser": "^2.1 || ^3.0.2",
+                "php": "~7.0",
+                "symfony/console": "~2.7 || ~3.0",
+                "symfony/finder": "~2.7 || ~3.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "~0.13.0",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpunit/phpunit": "^6.0.7",
+                "satooshi/php-coveralls": "^1.0",
+                "slevomat/coding-standard": "^2.0"
+            },
+            "bin": [
+                "bin/phpstan"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "time": "2017-05-14T20:37:59+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4595,6 +5193,55 @@
             "time": "2017-04-12T14:13:17+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v3.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "9cf076f8f492f4b1ffac40aae9c2d287b4ca6930"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9cf076f8f492f4b1ffac40aae9c2d287b4ca6930",
+                "reference": "9cf076f8f492f4b1ffac40aae9c2d287b4ca6930",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-12T14:13:17+00:00"
+        },
+        {
             "name": "symfony/polyfill-php70",
             "version": "v1.3.0",
             "source": {
@@ -5136,7 +5783,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/test"
             },
-            "time": "2017-05-30 12:29:02"
+            "time": "2017-05-30T12:29:02+00:00"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "57b7cb6aea2e2275702dc6f385bcdda4",
+    "content-hash": "f3aa471083e3b986baf760ae1308df06",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2255,6 +2255,55 @@
                 "url"
             ],
             "time": "2017-04-12T14:13:17+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "602a15299dc01556013b07167d4f5d3a60e90d15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/602a15299dc01556013b07167d4f5d3a60e90d15",
+                "reference": "602a15299dc01556013b07167d4f5d3a60e90d15",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-04-12T14:14:56+00:00"
         },
         {
             "name": "symfony/translation",
@@ -5301,55 +5350,6 @@
             "time": "2016-11-14T01:06:16+00:00"
         },
         {
-            "name": "symfony/stopwatch",
-            "version": "v3.2.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "5a0105afb670dbd38f521105c444de1b8e10cfe3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5a0105afb670dbd38f521105c444de1b8e10cfe3",
-                "reference": "5a0105afb670dbd38f521105c444de1b8e10cfe3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Stopwatch\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Stopwatch Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-04-12T14:13:17+00:00"
-        },
-        {
             "name": "symfony/var-dumper",
             "version": "v3.2.8",
             "source": {
@@ -5783,7 +5783,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/test"
             },
-            "time": "2017-05-30T12:29:02+00:00"
+            "time": "2017-05-30 12:29:02"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/contexts/DonationContext/src/Infrastructure/DonationConfirmationMailer.php
+++ b/contexts/DonationContext/src/Infrastructure/DonationConfirmationMailer.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\DonationContext\Infrastructure;
 
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankTransferPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentMethod;
@@ -18,7 +18,7 @@ class DonationConfirmationMailer {
 
 	private $mailer;
 
-	public function __construct( TemplateBasedMailer $mailer ) {
+	public function __construct( TemplateMailerInterface $mailer ) {
 		$this->mailer = $mailer;
 	}
 

--- a/contexts/DonationContext/src/UseCases/CancelDonation/CancelDonationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/CancelDonation/CancelDonationUseCase.php
@@ -10,7 +10,7 @@ use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\DonationReposi
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\GetDonationException;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\StoreDonationException;
 use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationEventLogger;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 
 /**
@@ -26,7 +26,7 @@ class CancelDonationUseCase {
 	private $authorizationService;
 	private $donationLogger;
 
-	public function __construct( DonationRepository $donationRepository, TemplateBasedMailer $mailer,
+	public function __construct( DonationRepository $donationRepository, TemplateMailerInterface $mailer,
 		DonationAuthorizer $authorizationService, DonationEventLogger $donationLogger ) {
 
 		$this->donationRepository = $donationRepository;

--- a/contexts/MembershipContext/src/Domain/Model/Application.php
+++ b/contexts/MembershipContext/src/Domain/Model/Application.php
@@ -40,6 +40,7 @@ class Application {
 	private $payment;
 	private $needsModeration;
 	private $isCancelled;
+	private $isConfirmed;
 	private $isDeleted;
 
 	public static function newApplication( string $type, Applicant $applicant, Payment $payment ): self {

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership;
 
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationTokenFetcher;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
@@ -27,7 +27,7 @@ class ApplyForMembershipUseCase {
 	private $piwikTracker;
 
 	public function __construct( ApplicationRepository $repository,
-		ApplicationTokenFetcher $tokenFetcher, TemplateBasedMailer $mailer,
+		ApplicationTokenFetcher $tokenFetcher, TemplateMailerInterface $mailer,
 		MembershipApplicationValidator $validator, ApplyForMembershipPolicyValidator $policyValidator,
 		ApplicationTracker $tracker, ApplicationPiwikTracker $piwikTracker ) {
 

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
@@ -23,6 +23,7 @@ class ApplyForMembershipUseCase {
 	private $mailer;
 	private $validator;
 	private $policyValidator;
+	private $membershipApplicationTracker;
 	private $piwikTracker;
 
 	public function __construct( ApplicationRepository $repository,

--- a/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\CancelMembershipApplication;
 
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
@@ -22,7 +22,7 @@ class CancelMembershipApplicationUseCase {
 	private $mailer;
 
 	public function __construct( ApplicationAuthorizer $authorizer,
-		ApplicationRepository $repository, TemplateBasedMailer $mailer ) {
+		ApplicationRepository $repository, TemplateMailerInterface $mailer ) {
 
 		$this->authorizer = $authorizer;
 		$this->repository = $repository;

--- a/contexts/MembershipContext/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\HandleSubscriptio
 
 use Psr\Log\LoggerInterface;
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Payment;
@@ -30,7 +30,8 @@ class HandleSubscriptionPaymentNotificationUseCase {
 	private $logger;
 
 	public function __construct( ApplicationRepository $repository, ApplicationAuthorizer $authorizationService,
-								 TemplateBasedMailer $mailer, LoggerInterface $logger ) {
+		TemplateMailerInterface $mailer, LoggerInterface $logger ) {
+
 		$this->repository = $repository;
 		$this->authorizationService = $authorizationService;
 		$this->mailer = $mailer;

--- a/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\HandleSubscriptionSignupNotification;
 
 use Psr\Log\LoggerInterface;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
@@ -27,7 +27,8 @@ class HandleSubscriptionSignupNotificationUseCase {
 	private $logger;
 
 	public function __construct( ApplicationRepository $repository, ApplicationAuthorizer $authorizationService,
-								 TemplateBasedMailer $mailer, LoggerInterface $logger ) {
+		TemplateMailerInterface $mailer, LoggerInterface $logger ) {
+
 		$this->repository = $repository;
 		$this->authorizationService = $authorizationService;
 		$this->mailer = $mailer;

--- a/contexts/PaymentContext/src/UseCases/CheckIban/CheckIbanUseCase.php
+++ b/contexts/PaymentContext/src/UseCases/CheckIban/CheckIbanUseCase.php
@@ -15,6 +15,9 @@ use WMDE\Fundraising\Frontend\Validation\IbanValidator;
  */
 class CheckIbanUseCase {
 
+	private $bankDataConverter;
+	private $ibanValidator;
+
 	public function __construct( BankDataConverter $bankDataConverter, IbanValidator $ibanValidator ) {
 		$this->bankDataConverter = $bankDataConverter;
 		$this->ibanValidator = $ibanValidator;

--- a/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
+++ b/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
@@ -71,16 +71,7 @@ class AddSubscriptionUseCase {
 	}
 
 	private function newMailAddressFromSubscription( Subscription $subscription ): EmailAddress {
-		return new EmailAddress(
-			$subscription->getEmail(),
-			implode(
-				' ',
-				[
-					$subscription->getAddress()->getFirstName(),
-					$subscription->getAddress()->getLastName()
-				]
-			)
-		);
+		return new EmailAddress( $subscription->getEmail() );
 	}
 
 	private function createSubscriptionFromRequest( SubscriptionRequest $subscriptionRequest ): Subscription {

--- a/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
+++ b/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\AddSubscription
 
 use WMDE\Fundraising\Entities\Address;
 use WMDE\Fundraising\Entities\Subscription;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepository;
 use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepositoryException;
@@ -26,7 +26,7 @@ class AddSubscriptionUseCase {
 	private $mailer;
 
 	public function __construct( SubscriptionRepository $subscriptionRepository,
-		SubscriptionValidator $subscriptionValidator, TemplateBasedMailer $mailer ) {
+		SubscriptionValidator $subscriptionValidator, TemplateMailerInterface $mailer ) {
 
 		$this->subscriptionRepository = $subscriptionRepository;
 		$this->subscriptionValidator = $subscriptionValidator;

--- a/contexts/SubscriptionContext/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
+++ b/contexts/SubscriptionContext/src/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCase.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\ConfirmSubscription;
 
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepository;
 use WMDE\Fundraising\Frontend\Validation\ConstraintViolation;
@@ -20,7 +20,7 @@ class ConfirmSubscriptionUseCase {
 
 	private $mailer;
 
-	public function __construct( SubscriptionRepository $subscriptionRepository, TemplateBasedMailer $mailer ) {
+	public function __construct( SubscriptionRepository $subscriptionRepository, TemplateMailerInterface $mailer ) {
 		$this->subscriptionRepository = $subscriptionRepository;
 		$this->mailer = $mailer;
 	}

--- a/contexts/SubscriptionContext/tests/Integration/UseCases/AddSubscription/AddSubscriptionUseCaseTest.php
+++ b/contexts/SubscriptionContext/tests/Integration/UseCases/AddSubscription/AddSubscriptionUseCaseTest.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\SubscriptionContext\Tests\Integration\UseCases\AddSubscription;
 
-use PHPUnit_Framework_MockObject_MockObject;
 use WMDE\Fundraising\Entities\Subscription;
 use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
@@ -14,14 +13,17 @@ use WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\AddSubscription\Subsc
 use WMDE\Fundraising\Frontend\SubscriptionContext\Validation\SubscriptionValidator;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\FailedValidationResult;
 use WMDE\Fundraising\Frontend\Validation\ValidationResult;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+use ReflectionClass;
 
 /**
- * @covers WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\AddSubscription\AddSubscriptionUseCase
+ * @covers \WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\AddSubscription\AddSubscriptionUseCase
  *
  * @license GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >
  */
-class AddSubscriptionUseCaseTest extends \PHPUnit\Framework\TestCase {
+class AddSubscriptionUseCaseTest extends TestCase {
 
 	/**
 	 * @var PHPUnit_Framework_MockObject_MockObject|SubscriptionRepository
@@ -139,4 +141,19 @@ class AddSubscriptionUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->addSubscription( $request );
 	}
 
+	public function testNewMailAddressFromSubscription(): void {
+		$useCase = new AddSubscriptionUseCase( $this->repo, $this->validator, $this->mailer );
+		$class = new ReflectionClass( AddSubscriptionUseCase::class );
+
+		$method = $class->getMethod( 'newMailAddressFromSubscription' );
+		$method->setAccessible( true );
+
+		$subscription = $this->createMock( Subscription::class );
+		$subscription->expects( $this->once() )->method( 'getEmail' )->willReturn( 'lorem@ipsum.com' );
+
+		$email = $method->invoke( $useCase, $subscription );
+
+		$this->assertInstanceOf( EmailAddress::class, $email );
+		$this->assertSame( 'lorem@ipsum.com', $email->getFullAddress() );
+	}
 }

--- a/docker/phpstan/Dockerfile
+++ b/docker/phpstan/Dockerfile
@@ -3,35 +3,35 @@
 
 FROM phpstan/phpstan:latest
 
-RUN echo "go" \
-    # for intl
-    && apk add --no-cache --virtual .persistent-deps icu-dev \
-    # for curl
-    && apk add --no-cache --virtual .persistent-deps curl-dev \
-    # for xml
-    && apk add --no-cache --virtual .persistent-deps libxml2-dev \
-    # compare vagrant/install_packages.sh
-    && docker-php-ext-configure intl --enable-intl \
-    && docker-php-ext-install intl curl xml pdo_mysql mbstring
+RUN \
+	# for intl
+	apk add --no-cache --virtual .persistent-deps icu-dev && \
+	# for curl
+	apk add --no-cache --virtual .persistent-deps curl-dev && \
+	# for xml
+	apk add --no-cache --virtual .persistent-deps libxml2-dev && \
+	# compare vagrant/install_packages.sh
+	docker-php-ext-configure intl --enable-intl && \
+	docker-php-ext-install intl curl xml pdo_mysql mbstring
 
+# compare vagrant/installKontoCheck.sh
 ENV KONTOCHECK_VERSION 5.8
 
-RUN echo "go" \
-    # compare vagrant/installKontoCheck.sh
-    && docker-php-source extract \
-    && cd /tmp \
-    && curl -Ls -o konto_check-$KONTOCHECK_VERSION.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/konto_check-$KONTOCHECK_VERSION.zip/download \
-    && curl -Ls -o php7.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/php7.zip/download \
-    && unzip konto_check-*.zip \
-    && unzip php7.zip \
-    && cd konto_check-5.* \
-    && cp blz.lut2f /etc/blz.lut \
-    && unzip php.zip \
-    && cd php \
-    && cp /tmp/php/konto_check.c . \
-    && sed -i -e 's/Z_TYPE_PP/Z_TYPE_P/g' konto_check.c \
-    && sed -i -e 's/Z_LVAL_PP/Z_LVAL_P/g' konto_check.c \
-    && docker-php-ext-configure /tmp/konto_check-$KONTOCHECK_VERSION/php \
-    && docker-php-ext-install /tmp/konto_check-$KONTOCHECK_VERSION/php \
-    && docker-php-source delete
-
+RUN \
+	docker-php-source extract && \
+	cd /tmp && \
+	curl -Ls -o konto_check-$KONTOCHECK_VERSION.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/konto_check-$KONTOCHECK_VERSION.zip/download && \
+	curl -Ls -o php7.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/php7.zip/download && \
+	unzip konto_check-*.zip && \
+	unzip php7.zip && \
+	cd konto_check-5.* && \
+	cp blz.lut2f /etc/blz.lut && \
+	unzip php.zip && \
+	cd php && \
+	cp /tmp/php/konto_check.c . && \
+	# see https://sourceforge.net/p/kontocheck/bugs/17/
+	sed -i -e 's/Z_TYPE_PP/Z_TYPE_P/g' konto_check.c && \
+	sed -i -e 's/Z_LVAL_PP/Z_LVAL_P/g' konto_check.c && \
+	docker-php-ext-configure /tmp/konto_check-$KONTOCHECK_VERSION/php && \
+	docker-php-ext-install /tmp/konto_check-$KONTOCHECK_VERSION/php && \
+	docker-php-source delete

--- a/docker/phpstan/Dockerfile
+++ b/docker/phpstan/Dockerfile
@@ -3,6 +3,35 @@
 
 FROM phpstan/phpstan:latest
 
-RUN apk add --no-cache --virtual .persistent-deps icu-dev libxml2-dev \
+RUN echo "go" \
+    # for intl
+    && apk add --no-cache --virtual .persistent-deps icu-dev \
+    # for curl
+    && apk add --no-cache --virtual .persistent-deps curl-dev \
+    # for xml
+    && apk add --no-cache --virtual .persistent-deps libxml2-dev \
+    # compare vagrant/install_packages.sh
     && docker-php-ext-configure intl --enable-intl \
-    && docker-php-ext-install intl
+    && docker-php-ext-install intl curl xml pdo_mysql mbstring
+
+ENV KONTOCHECK_VERSION 5.8
+
+RUN echo "go" \
+    # compare vagrant/installKontoCheck.sh
+    && docker-php-source extract \
+    && cd /tmp \
+    && curl -Ls -o konto_check-$KONTOCHECK_VERSION.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/konto_check-$KONTOCHECK_VERSION.zip/download \
+    && curl -Ls -o php7.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/php7.zip/download \
+    && unzip konto_check-*.zip \
+    && unzip php7.zip \
+    && cd konto_check-5.* \
+    && cp blz.lut2f /etc/blz.lut \
+    && unzip php.zip \
+    && cd php \
+    && cp /tmp/php/konto_check.c . \
+    && sed -i -e 's/Z_TYPE_PP/Z_TYPE_P/g' konto_check.c \
+    && sed -i -e 's/Z_LVAL_PP/Z_LVAL_P/g' konto_check.c \
+    && docker-php-ext-configure /tmp/konto_check-$KONTOCHECK_VERSION/php \
+    && docker-php-ext-install /tmp/konto_check-$KONTOCHECK_VERSION/php \
+    && docker-php-source delete
+

--- a/docker/phpstan/Dockerfile
+++ b/docker/phpstan/Dockerfile
@@ -1,0 +1,8 @@
+# phpstan in docker
+# used as sanity check of code when installed via "composer install --no-dev" (so on prod) w/o other dev tools to check
+
+FROM phpstan/phpstan:latest
+
+RUN apk add --no-cache --virtual .persistent-deps icu-dev libxml2-dev \
+    && docker-php-ext-configure intl --enable-intl \
+    && docker-php-ext-install intl

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+  excludes_analyse:
+    - */contexts/DonationContext/tests/*
+    - */contexts/MembershipContext/tests/*
+    - */contexts/PaymentContext/tests/*
+    - */contexts/SubscriptionContext/tests/*

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -13,9 +13,6 @@ use Doctrine\ORM\EntityManager;
 use FileFetcher\ErrorLoggingFileFetcher;
 use FileFetcher\SimpleFileFetcher;
 use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Handler\CurlHandler;
-use GuzzleHttp\HandlerStack;
 use NumberFormatter;
 use Pimple\Container;
 use Psr\Log\LoggerInterface;
@@ -263,22 +260,6 @@ class FunFunFactory {
 
 		$pimple['greeting_generator'] = function() {
 			return new GreetingGenerator();
-		};
-
-		$pimple['guzzle_client'] = function() {
-			$middlewareFactory = new MiddlewareFactory();
-			$middlewareFactory->setLogger( $this->getLogger() );
-
-			$handlerStack = HandlerStack::create( new CurlHandler() );
-			$handlerStack->push( $middlewareFactory->retry() );
-
-			$guzzle = new Client( [
-				'cookies' => true,
-				'handler' => $handlerStack,
-				'headers' => [ 'User-Agent' => 'WMDE Fundraising Frontend' ],
-			] );
-
-			return $this->addProfilingDecorator( $guzzle, 'Guzzle Client' );
 		};
 
 		$pimple['translator'] = function() {
@@ -586,10 +567,6 @@ class FunFunFactory {
 			$this->config['referrer-generalization']['default'],
 			$this->config['referrer-generalization']['domain-map']
 		);
-	}
-
-	private function getGuzzleClient(): ClientInterface {
-		return $this->pimple['guzzle_client'];
 	}
 
 	public function getLogger(): LoggerInterface {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -79,6 +79,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\ProfilerDataCollector;
 use WMDE\Fundraising\Frontend\Infrastructure\ProfilingDecoratorBuilder;
 use WMDE\Fundraising\Frontend\Infrastructure\RandomTokenGenerator;
 use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\Infrastructure\TokenGenerator;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationTokenFetcher;
@@ -608,7 +609,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newAddSubscriptionMailer(): TemplateBasedMailer {
+	private function newAddSubscriptionMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate(
@@ -622,7 +623,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newConfirmSubscriptionMailer(): TemplateBasedMailer {
+	private function newConfirmSubscriptionMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate(
@@ -634,7 +635,13 @@ class FunFunFactory {
 		);
 	}
 
-	private function newTemplateMailer( Messenger $messenger, TwigTemplate $template, string $messageKey ): TemplateBasedMailer {
+	/**
+	 * Create a new TemplateMailer instance
+	 *
+	 * So much decoration going on that explicitly hinting what we return (Robustness principle) would be confusing
+	 * (you'd expect a TemplateBasedMailer, not a LoggingMailer), so we hint the interface instead.
+	 */
+	private function newTemplateMailer( Messenger $messenger, TwigTemplate $template, string $messageKey ): TemplateMailerInterface {
 		$mailer = new TemplateBasedMailer(
 			$messenger,
 			$template,
@@ -678,7 +685,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newContactUserMailer(): TemplateBasedMailer {
+	private function newContactUserMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate( $this->getTwig(), 'Mail_Contact_Confirm_to_User.txt.twig' ),
@@ -816,7 +823,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newCancelDonationMailer(): TemplateBasedMailer {
+	private function newCancelDonationMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getSuborganizationMessenger(),
 			new TwigTemplate(
@@ -972,7 +979,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function newApplyForMembershipMailer(): TemplateBasedMailer {
+	private function newApplyForMembershipMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getOrganizationMessenger(),
 			new TwigTemplate(
@@ -1029,7 +1036,7 @@ class FunFunFactory {
 		return $this->pimple['membership_application_repository'];
 	}
 
-	private function newCancelMembershipApplicationMailer(): TemplateBasedMailer {
+	private function newCancelMembershipApplicationMailer(): TemplateMailerInterface {
 		return $this->newTemplateMailer(
 			$this->getOrganizationMessenger(),
 			new TwigTemplate(

--- a/src/Infrastructure/LoggingMailer.php
+++ b/src/Infrastructure/LoggingMailer.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
  * @license GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class LoggingMailer extends TemplateBasedMailer {
+class LoggingMailer implements TemplateMailerInterface {
 
 	const CONTEXT_EXCEPTION_KEY = 'exception';
 
@@ -20,16 +20,17 @@ class LoggingMailer extends TemplateBasedMailer {
 	private $logger;
 	private $logLevel;
 
-	public function __construct( TemplateBasedMailer $mailer, LoggerInterface $logger ) {
+	public function __construct( TemplateMailerInterface $mailer, LoggerInterface $logger ) {
 		$this->mailer = $mailer;
 		$this->logger = $logger;
 		$this->logLevel = LogLevel::CRITICAL;
 	}
 
 	/**
+	 * @inheritdoc
 	 * @throws \RuntimeException
 	 */
-	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ) {
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		try {
 			$this->mailer->sendMail( $recipient, $templateArguments );
 		}
@@ -38,5 +39,4 @@ class LoggingMailer extends TemplateBasedMailer {
 			throw $ex;
 		}
 	}
-
 }

--- a/src/Infrastructure/TemplateBasedMailer.php
+++ b/src/Infrastructure/TemplateBasedMailer.php
@@ -11,7 +11,7 @@ use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class TemplateBasedMailer {
+class TemplateBasedMailer implements TemplateMailerInterface {
 
 	private $messenger;
 	private $template;
@@ -24,9 +24,10 @@ class TemplateBasedMailer {
 	}
 
 	/**
+	 * @inheritdoc
 	 * @throws \RuntimeException
 	 */
-	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ) {
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		$this->messenger->sendMessageToUser(
 			new Message(
 				$this->subject,

--- a/src/Infrastructure/TemplateMailerInterface.php
+++ b/src/Infrastructure/TemplateMailerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
+
+interface TemplateMailerInterface {
+
+	/**
+	 * @param EmailAddress $recipient The recipient of the email to send
+	 * @param array $templateArguments Context parameters to use while rendering the template
+	 */
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void;
+}

--- a/src/Presentation/Presenters/CreditCardNotificationPresenter.php
+++ b/src/Presentation/Presenters/CreditCardNotificationPresenter.php
@@ -13,6 +13,8 @@ use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
  */
 class CreditCardNotificationPresenter {
 
+	private $template;
+
 	public function __construct( TwigTemplate $template ) {
 		$this->template = $template;
 	}

--- a/src/UseCases/GetInTouch/GetInTouchUseCase.php
+++ b/src/UseCases/GetInTouch/GetInTouchUseCase.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\UseCases\GetInTouch;
 
 use WMDE\Fundraising\Frontend\Infrastructure\OperatorMailer;
-use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\Validation\ValidationResponse;
 use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
@@ -21,7 +21,8 @@ class GetInTouchUseCase {
 	private $userMailer;
 
 	public function __construct( GetInTouchValidator $validator, OperatorMailer $operatorMailer,
-								 TemplateBasedMailer $userMailer ) {
+		TemplateMailerInterface $userMailer ) {
+
 		$this->validator = $validator;
 		$this->operatorMailer = $operatorMailer;
 		$this->userMailer = $userMailer;

--- a/tests/Fixtures/TemplateBasedMailerSpy.php
+++ b/tests/Fixtures/TemplateBasedMailerSpy.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Tests\Fixtures;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_TestCase;
 use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 
@@ -22,7 +21,7 @@ class TemplateBasedMailerSpy extends TemplateBasedMailer {
 		$this->testCase = $testCase;
 	}
 
-	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ) {
+	public function sendMail( EmailAddress $recipient, array $templateArguments = [] ): void {
 		$this->sendMailCalls[] = [ $recipient, $templateArguments ];
 	}
 

--- a/tests/Unit/Infrastructure/LoggingMailerTest.php
+++ b/tests/Unit/Infrastructure/LoggingMailerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use WMDE\Fundraising\Frontend\Infrastructure\LoggingMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class LoggingMailerTest extends TestCase {
+
+	public function testImplementsInterface(): void {
+		$class = new ReflectionClass( LoggingMailer::class );
+		$this->assertTrue( $class->implementsInterface( TemplateMailerInterface::class ) );
+	}
+}

--- a/tests/Unit/Infrastructure/TemplateBasedMailerTest.php
+++ b/tests/Unit/Infrastructure/TemplateBasedMailerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateBasedMailer;
+use WMDE\Fundraising\Frontend\Infrastructure\TemplateMailerInterface;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class TemplateBasedMailerTest extends TestCase {
+
+	public function testImplementsInterface(): void {
+		$class = new ReflectionClass( TemplateBasedMailer::class );
+		$this->assertTrue( $class->implementsInterface( TemplateMailerInterface::class ) );
+	}
+}


### PR DESCRIPTION
This introduces an additional static code analysis tool, [phpstan](https://github.com/phpstan/phpstan/) that detects code smells.  Amongst others, it detects the usage of classes that are not defined. In order to address the initial problem T166143, phpstan is run against the project with composer installed in --no-dev mode. Consequently, phpstan can not be set-up as a dev-dependency itself, and is run in a dedicated docker container instead.

This PR also fixes many smaller smells detected by phpstan.

e8462c2, 009ab1f were reviewed already in #887 and #888 respectively.