### PR TITLE
Add working dev default for i18n-base-path setting

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -20,7 +20,7 @@
 			"array": {}
 		}
 	},
-	"i18n-base-path": "",
+	"i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n",
 	"default-layout-templates": {
 		"header": "Page_Header.html.twig",
 		"footer": "Page_Footer.html.twig",


### PR DESCRIPTION
Without this you need to do extra config for the stuff to work
after dev installation.

Kinda part of https://phabricator.wikimedia.org/T163918