### PR TITLE
T162439: fix missing link tracking

### DIFF
--- a/app/ab_test/b/templates/Membership_Application_Form_NoPhone.html.twig
+++ b/app/ab_test/b/templates/Membership_Application_Form_NoPhone.html.twig
@@ -60,8 +60,7 @@
 						<strong>Mehr Informationen</strong>
 					</p>
 					<p>
-						Erfahren Sie <a href="http://wikimedia.de/wiki/Mitgliedschaft" target="_blank">mehr</a>
-						&uuml;ber Wikimedia Deutschland e. V. und seine Aktivit&auml;ten.
+						Erfahren Sie <a href="http://wikimedia.de/wiki/Mitgliedschaft{% if trackOutgoingLinks is defined and trackOutgoingLinks == true %}?piwik_campaign=Spendenseite&piwik_kwd=membership-form-sidebar{% endif %}" target="_blank">mehr</a>
 					</p>
 				</div>
 			</div>
@@ -446,7 +445,7 @@
 						<span class="icon-angle-left"></span>Zur&uuml;ck zur Wikipedia
 					</a>
 
-					<a href="http://wikimedia.de" class="f-right">
+					<a href="http://wikimedia.de{% if trackOutgoingLinks is defined and trackOutgoingLinks == true %}?piwik_campaign=Spendenseite&piwik_kwd=membership-form-bottom{% endif %}" class="f-right">
 						Mehr Infos zu Wikimedia<span class="icon-angle-right _icon-right"></span>
 					</a>
 				</div>


### PR DESCRIPTION
While the tracking is working in the non-test template (`app/templates/Membership_Application_Form.html.twig`), it is missing in the test template.