### PR TITLE
Fix delay-in-days schema check

### DIFF
--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -47,7 +47,8 @@
 		"notify-url": "http://my.donation.app/handler/paypal",
 		"return-url": "http://my.donation.app/membership/confirm",
 		"cancel-url": "http://my.donation.app/membership/cancel",
-		"item-name": "Your membership"
+		"item-name": "Your membership",
+		"delay-in-days": 90
 	},
 	"creditcard": {
 		"base-url": "http://thatother.paymentprovider.com?",

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -467,13 +467,13 @@
           "title": "Payment item name",
           "description": "The \"item\" that shows up in the payment, i.e. what is paid for",
           "default": ""
+        },
+        "delay-in-days": {
+          "type": "int",
+          "title": "Delay in days",
+          "description": "Number of days until the first payment will be made",
+          "default": 90
         }
-      },
-      "delay-in-days": {
-        "type": "int",
-        "title": "Delay in days",
-        "description": "Number of days until the first payment will be made",
-        "default": 90
       },
       "additionalProperties": false,
       "required": [


### PR DESCRIPTION
The property definition was at the wrong hierarchy level. To avoid
Regressions, delay-in-days is now part of the test configuration.