### PR TITLE
Removed addPayPalData from Donation and Application

### DIFF
--- a/contexts/DonationContext/src/Domain/Model/Donation.php
+++ b/contexts/DonationContext/src/Domain/Model/Donation.php
@@ -229,20 +229,6 @@ class Donation {
 	}
 
 	/**
-	 * @param PayPalData $payPalData
-	 * @throws RuntimeException
-	 */
-	public function addPayPalData( PayPalData $payPalData ) {
-		$paymentMethod = $this->payment->getPaymentMethod();
-
-		if ( !( $paymentMethod instanceof PayPalPayment ) ) {
-			throw new RuntimeException( 'Cannot set PayPal data on a non PayPal payment' );
-		}
-
-		$paymentMethod->addPayPalData( $payPalData );
-	}
-
-	/**
 	 * @param CreditCardTransactionData $creditCardData
 	 *
 	 * @throws RuntimeException

--- a/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
@@ -80,7 +80,9 @@ class HandlePayPalPaymentNotificationUseCase {
 	}
 
 	private function handleRequestForDonation( PayPalPaymentNotificationRequest $request, Donation $donation ): PaypalNotificationResponse {
-		if ( !( $donation->getPayment()->getPaymentMethod() instanceof PayPalPayment ) ) {
+		$paymentMethod = $donation->getPayment()->getPaymentMethod();
+
+		if ( !( $paymentMethod instanceof PayPalPayment ) ) {
 			return $this->createUnhandledResponse( 'Trying to handle IPN for non-Paypal donation' );
 		}
 
@@ -91,7 +93,7 @@ class HandlePayPalPaymentNotificationUseCase {
 			return $this->createChildDonation( $donation, $request );
 		}
 
-		$donation->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
+		$paymentMethod->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
 
 		try {
 			$donation->confirmBooked();

--- a/contexts/DonationContext/tests/Unit/Domain/Model/DonationTest.php
+++ b/contexts/DonationContext/tests/Unit/Domain/Model/DonationTest.php
@@ -110,13 +110,6 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$donation->confirmBooked();
 	}
 
-	public function testAddingPayPalDataToNoPayPalDonationCausesException() {
-		$donation = ValidDonation::newDirectDebitDonation();
-
-		$this->expectException( RuntimeException::class );
-		$donation->addPayPalData( new PayPalData() );
-	}
-
 	/**
 	 * @dataProvider statusesThatDoNotAllowForBookingProvider
 	 */

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
@@ -121,7 +121,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		$application->setPaymentType( $paymentMethod->getType() );
 		if ( $paymentMethod instanceof DirectDebitPayment ) {
 			$this->setBankDataFields( $application, $paymentMethod->getBankData() );
-		} elseif ( $paymentMethod instanceof PayPalPayment && $paymentMethod->getPayPalData() !== null ) {
+		} elseif ( $paymentMethod instanceof PayPalPayment && $paymentMethod->getPayPalData() != new PayPalData() ) {
 			$this->setPayPalDataFields( $application, $paymentMethod->getPayPalData() );
 		}
 	}

--- a/contexts/MembershipContext/src/Domain/Model/Application.php
+++ b/contexts/MembershipContext/src/Domain/Model/Application.php
@@ -124,20 +124,6 @@ class Application {
 		$this->isConfirmed = self::IS_CONFIRMED;
 	}
 
-	/**
-	 * @param PayPalData $payPalData
-	 * @throws RuntimeException
-	 */
-	public function addPayPalData( PayPalData $payPalData ) {
-		$paymentMethod = $this->payment->getPaymentMethod();
-
-		if ( !( $paymentMethod instanceof PayPalPayment ) ) {
-			throw new RuntimeException( 'Cannot set PayPal data on a non PayPal payment' );
-		}
-
-		$paymentMethod->addPayPalData( $payPalData );
-	}
-
 	public function confirmSubscriptionCreated() {
 		if ( !$this->hasExternalPayment() ) {
 			throw new RuntimeException( 'Only external payments can be confirmed as booked' );
@@ -168,10 +154,9 @@ class Application {
 
 	public function notifyOfFirstPaymentDate( string $firstPaymentDate ) {
 		$paymentMethod = $this->getPayment()->getPaymentMethod();
+
 		if ( $paymentMethod instanceof PayPalPayment ) {
-			$payPalData = $paymentMethod->getPayPalData() ?: new PayPalData();
-			$payPalData->setFirstPaymentDate( $firstPaymentDate );
-			$this->addPayPalData( $payPalData );
+			$paymentMethod->getPayPalData()->setFirstPaymentDate( $firstPaymentDate );
 		}
 	}
 

--- a/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
@@ -51,7 +51,9 @@ class HandleSubscriptionSignupNotificationUseCase {
 
 	private function handleRequestForMembershipApplication( SubscriptionSignupRequest $request,
 															Application $application ): PaypalNotificationResponse {
-		if ( !( $application->getPayment()->getPaymentMethod() instanceof PayPalPayment ) ) {
+		$paymentMethod = $application->getPayment()->getPaymentMethod();
+
+		if ( !( $paymentMethod instanceof PayPalPayment ) ) {
 			return $this->createUnhandledResponse( 'Trying to handle IPN for non-PayPal membership application' );
 		}
 
@@ -59,7 +61,7 @@ class HandleSubscriptionSignupNotificationUseCase {
 			return $this->createUnhandledResponse( 'Wrong access code for membership application' );
 		}
 
-		$application->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
+		$paymentMethod->addPayPalData( $this->newPayPalDataFromRequest( $request ) );
 
 		try {
 			$application->confirmSubscriptionCreated();

--- a/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
+++ b/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
@@ -105,8 +105,8 @@ class ValidMembershipApplication {
 		);
 	}
 
-	public static function newDomainEntityUsingPayPal(): Application {
-		return ( new self() )->createApplicationUsingPayPal();
+	public static function newDomainEntityUsingPayPal( PayPalData $payPalData = null ): Application {
+		return ( new self() )->createApplicationUsingPayPal( $payPalData );
 	}
 
 	public static function newConfirmedSubscriptionDomainEntity(): Application {
@@ -154,12 +154,12 @@ class ValidMembershipApplication {
 		);
 	}
 
-	private function createApplicationUsingPayPal(): Application {
+	private function createApplicationUsingPayPal( $payPalData ): Application {
 		$self = ( new self() );
 		return Application::newApplication(
 			self::MEMBERSHIP_TYPE,
 			$self->newApplicant( $self->newPersonApplicantName() ),
-			$this->newPayPalPayment()
+			$this->newPayPalPayment( $payPalData )
 		);
 	}
 

--- a/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
@@ -280,9 +280,8 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 			$payPalData->setFirstPaymentDate( self::FIRST_PAYMENT_DATE );
 			$payPalData->freeze();
 
-			$expectedApplication = ValidMembershipApplication::newDomainEntityUsingPayPal();
+			$expectedApplication = ValidMembershipApplication::newDomainEntityUsingPayPal( $payPalData );
 			$expectedApplication->assignId( 1 );
-			$expectedApplication->addPayPalData( $payPalData );
 
 			$this->assertEquals( $expectedApplication, $application );
 		} );


### PR DESCRIPTION
Following up to my comments on https://github.com/wmde/FundraisingFrontend/pull/904

---

I'd like to clean this up a bit further though do not understand the current situation well enough (which indicates cleanup would be good :p). This PR itself is finished though.

Do I understand correctly that the (non-empty) PayPalData thing gets created only when we get a specific notification from PayPal (one for Donation, one for Membership applications), and that afterwards it does not get modified? Except for the new `notifyOfFirstPaymentDate` in Application, which sets just one field.

And is `notifyOfFirstPaymentDate` supposed to always be called before the callback from PayPal that sets the whole object gets invoked? Do we need to retain the old value that was already set then or should we just store the info from the last paypall call?

Disregarding `notifyOfFirstPaymentDate`, does modification ever make sense? `PayPalPayment` has `addPayPalData`, the name of which is a misleading, since it overrides what was set before. Perhaps this should (before introduction of `notifyOfFirstPaymentDate` have thrown an exception when trying to set stuff when it is already set?)