### PR TITLE
T167879 Sofort Add donation

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -96,6 +96,7 @@ class AddDonationHandler {
 			case PaymentType::SOFORT:
 				$httpResponse = $this->app->redirect(
 					$this->ffFactory->newSofortUrlGeneratorForDonations()->generateUrl(
+						// @todo Is id the right criteria to pass? Will be put in the reason field. Cp. WQ-Code debate
 						$responseModel->getDonation()->getId(),
 						$responseModel->getDonation()->getAmount(),
 						$responseModel->getAccessToken()

--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -93,6 +93,15 @@ class AddDonationHandler {
 					)
 				);
 				break;
+			case PaymentType::SOFORT:
+				$httpResponse = $this->app->redirect(
+					$this->ffFactory->newSofortUrlGeneratorForDonations()->generateUrl(
+						$responseModel->getDonation()->getId(),
+						$responseModel->getDonation()->getAmount(),
+						$responseModel->getAccessToken()
+					)
+				);
+				break;
 			case PaymentType::CREDIT_CARD:
 				$httpResponse = new Response(
 					$this->ffFactory->newCreditCardPaymentHtmlPresenter()->present( $responseModel )

--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -80,7 +80,6 @@ class AddDonationHandler {
 					),
 					Response::HTTP_SEE_OTHER
 				);
-
 				break;
 			case PaymentType::PAYPAL:
 				$httpResponse = $this->app->redirect(
@@ -96,8 +95,8 @@ class AddDonationHandler {
 			case PaymentType::SOFORT:
 				$httpResponse = $this->app->redirect(
 					$this->ffFactory->newSofortUrlGeneratorForDonations()->generateUrl(
-						// @todo Is the id the right criteria to pass? Will be put in the reason field. Cp. WQ-Code debate
 						$responseModel->getDonation()->getId(),
+						$responseModel->getDonation()->getPayment()->getPaymentMethod()->getUuid(),
 						$responseModel->getDonation()->getAmount(),
 						$responseModel->getAccessToken()
 					)

--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -96,7 +96,7 @@ class AddDonationHandler {
 			case PaymentType::SOFORT:
 				$httpResponse = $this->app->redirect(
 					$this->ffFactory->newSofortUrlGeneratorForDonations()->generateUrl(
-						// @todo Is id the right criteria to pass? Will be put in the reason field. Cp. WQ-Code debate
+						// @todo Is the id the right criteria to pass? Will be put in the reason field. Cp. WQ-Code debate
 						$responseModel->getDonation()->getId(),
 						$responseModel->getDonation()->getAmount(),
 						$responseModel->getAccessToken()

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -119,6 +119,12 @@
 		"return-url": "https://spenden.wikimedia.de/show-donation-confirmation",
 		"testmode": true
 	},
+	"sofort": {
+		"config-key": "",
+		"return-url": "",
+		"cancel-url": "",
+		"item-name": ""
+	},
 	"confirmation-pages": {
 		"default": "Donation_Confirmation.html.twig",
 		"campaigns": [

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -121,9 +121,9 @@
 	},
 	"sofort": {
 		"config-key": "",
+		"reason-text-translation-key": "SUB",
 		"return-url": "",
-		"cancel-url": "",
-		"item-name": ""
+		"cancel-url": ""
 	},
 	"confirmation-pages": {
 		"default": "Donation_Confirmation.html.twig",
@@ -151,7 +151,8 @@
 			"paymentStatus": "paymentStatus.json",
 			"validations": "validations.json",
 			"pageTitles": "pageTitles.json",
-			"membershipTypes": "membershipTypes.json"
+			"membershipTypes": "membershipTypes.json",
+			"paymentSubjects": "paymentSubjects.json"
 		}
 	},
 	"payment-types": {

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -121,7 +121,6 @@
 	},
 	"sofort": {
 		"config-key": "",
-		"reason-text-translation-key": "SUB",
 		"return-url": "",
 		"cancel-url": ""
 	},
@@ -151,8 +150,7 @@
 			"paymentStatus": "paymentStatus.json",
 			"validations": "validations.json",
 			"pageTitles": "pageTitles.json",
-			"membershipTypes": "membershipTypes.json",
-			"paymentSubjects": "paymentSubjects.json"
+			"membershipTypes": "membershipTypes.json"
 		}
 	},
 	"payment-types": {

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -169,7 +169,7 @@
 			"donation-enabled": true
 		},
 		"SUB": {
-			"donation-enabled": true
+			"donation-enabled": false
 		}
 	}
 }

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -63,8 +63,7 @@
 	"sofort": {
 		"config-key": "fff:ggg:hhh:iii",
 		"return-url": "http://my.donation.app/show-donation-confirmation",
-		"cancel-url": "http://my.donation.app/donation/cancel",
-		"reason-text-translation-key": "SUB"
+		"cancel-url": "http://my.donation.app/donation/cancel"
 	},
 	"confirmation-pages": {
 		"default": "DonationConfirmation.twig",

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -64,7 +64,7 @@
 		"config-key": "fff:ggg:hhh:iii",
 		"return-url": "http://my.donation.app/show-donation-confirmation",
 		"cancel-url": "http://my.donation.app/donation/cancel",
-		"item-name": "Danke für Ihre Spende"
+		"item-name": "Danke fuer Ihre Spende"
 	},
 	"confirmation-pages": {
 		"default": "DonationConfirmation.twig",

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -64,7 +64,7 @@
 		"config-key": "fff:ggg:hhh:iii",
 		"return-url": "http://my.donation.app/show-donation-confirmation",
 		"cancel-url": "http://my.donation.app/donation/cancel",
-		"item-name": "Danke fuer Ihre Spende"
+		"reason-text-translation-key": "SUB"
 	},
 	"confirmation-pages": {
 		"default": "DonationConfirmation.twig",

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -86,5 +86,22 @@
 		"siteUrlBase": "http://test-spenden.wikimedia.local"
 	},
 	"purging-secret": "Not so secret, testing",
-	"i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n"
+	"i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n",
+	"payment-types": {
+		"BEZ": {
+			"donation-enabled": true
+		},
+		"UEB": {
+			"donation-enabled": true
+		},
+		"MCP": {
+			"donation-enabled": true
+		},
+		"PPL": {
+			"donation-enabled": true
+		},
+		"SUB": {
+			"donation-enabled": true
+		}
+	}
 }

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -60,6 +60,12 @@
 		"testmode": true,
 		"access-key": "Not a real access key"
 	},
+	"sofort": {
+		"config-key": "fff:ggg:hhh:iii",
+		"return-url": "http://my.donation.app/show-donation-confirmation",
+		"cancel-url": "http://my.donation.app/donation/cancel",
+		"item-name": "Danke für Ihre Spende"
+	},
 	"confirmation-pages": {
 		"default": "DonationConfirmation.twig",
 		"campaigns": [

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -567,9 +567,9 @@
           "title": "The API key for communication",
           "minLength": 1
         },
-        "item-name": {
+        "reason-text-translation-key": {
           "type": "string",
-          "title": "Subject to use when generating bank transfers",
+          "title": "The key from content:i18n/*/messages/paymentSubjects.json to use when generating bank transfer reason",
           "minLength": 1
         },
         "return-url": {
@@ -586,7 +586,7 @@
       "additionalProperties": false,
       "required": [
         "config-key",
-        "item-name",
+        "reason-text-translation-key",
         "return-url",
         "cancel-url"
       ]

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -567,11 +567,6 @@
           "title": "The API key for communication",
           "minLength": 1
         },
-        "reason-text-translation-key": {
-          "type": "string",
-          "title": "The key from content:i18n/*/messages/paymentSubjects.json to use when generating bank transfer reason",
-          "minLength": 1
-        },
         "return-url": {
           "type": "string",
           "title": "Return URL",
@@ -586,7 +581,6 @@
       "additionalProperties": false,
       "required": [
         "config-key",
-        "reason-text-translation-key",
         "return-url",
         "cancel-url"
       ]

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -558,6 +558,39 @@
         "testmode"
       ]
     },
+    "sofort": {
+      "type": "object",
+      "title": "Configuration for the Sofortüberweisung payment provider",
+      "properties": {
+        "config-key": {
+          "type": "string",
+          "title": "The API key for communication",
+          "minLength": 1
+        },
+        "item-name": {
+          "type": "string",
+          "title": "Subject to use when generating bank transfers",
+          "minLength": 1
+        },
+        "return-url": {
+          "type": "string",
+          "title": "Return URL",
+          "minLength": 1
+        },
+        "cancel-url": {
+          "type": "string",
+          "title": "Cancel URL",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "config-key",
+        "item-name",
+        "return-url",
+        "cancel-url"
+      ]
+    },
     "confirmation-pages": {
       "type": "object",
       "title": "Confirmation page template selection configuration",
@@ -720,6 +753,7 @@
     "paypal-donation",
     "paypal-membership",
     "creditcard",
+    "sofort",
     "confirmation-pages",
     "piwik",
     "translation",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
 		"symfony/browser-kit": "^3.2",
 		"silex/web-profiler": "~2.0",
 		"sorien/silex-dbal-profiler": "~2.0",
-		"wmde/fundraising-frontend-content": "dev-sofort",
+		"wmde/fundraising-frontend-content": "dev-test",
 		"symfony/css-selector": "^3.2",
 		"phpstan/phpstan": "^0.7.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
 		"symfony/console": "^3.2",
 		"piwik/piwik-php-tracker": "^1.0",
 		"guzzlehttp/guzzle": "^6.0",
-		"symfony/stopwatch": "^3.3"
+		"symfony/stopwatch": "^3.3",
+		"sofort/sofortlib-php": "^3.2"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7eb3835ed59ffe01118996a174d546ed",
+    "content-hash": "a5f60fce76f25a12679b34e33728582c",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1756,6 +1756,48 @@
                 "microframework"
             ],
             "time": "2017-05-03T15:21:42+00:00"
+        },
+        {
+            "name": "sofort/sofortlib-php",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sofort/sofortlib-php.git",
+                "reference": "35362fee0427d0811cbab0ba35435920b14f22d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sofort/sofortlib-php/zipball/35362fee0427d0811cbab0ba35435920b14f22d6",
+                "reference": "35362fee0427d0811cbab0ba35435920b14f22d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.10"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5.1"
+            },
+            "suggest": {
+                "ext-curl": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sofort\\SofortLib\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3"
+            ],
+            "authors": [
+                {
+                    "name": "Sofort GmbH",
+                    "email": "opensource@sofort.com"
+                }
+            ],
+            "description": "SOFORT API wrapper for PHP",
+            "time": "2016-11-22T14:45:03+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -5875,7 +5917,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/sofort"
             },
-            "time": "2017-06-29T09:21:20+00:00"
+            "time": "2017-06-29 09:21:20"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/composer.lock
+++ b/composer.lock
@@ -5880,12 +5880,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content.git",
-                "reference": "e3d834967d8979241f72e215a720f9e8deadb2ee"
+                "reference": "1d1a2f3f876add99c307da9a67fed477939e2277"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/e3d834967d8979241f72e215a720f9e8deadb2ee",
-                "reference": "e3d834967d8979241f72e215a720f9e8deadb2ee",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/1d1a2f3f876add99c307da9a67fed477939e2277",
+                "reference": "1d1a2f3f876add99c307da9a67fed477939e2277",
                 "shasum": ""
             },
             "require-dev": {
@@ -5917,7 +5917,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/sofort"
             },
-            "time": "2017-06-29 09:21:20"
+            "time": "2017-07-06T10:33:36+00:00"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5f60fce76f25a12679b34e33728582c",
+    "content-hash": "abaab64de21fe61aabca596d82655e6a",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -5876,16 +5876,16 @@
         },
         {
             "name": "wmde/fundraising-frontend-content",
-            "version": "dev-sofort",
+            "version": "dev-test",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content.git",
-                "reference": "1d1a2f3f876add99c307da9a67fed477939e2277"
+                "reference": "f5f292f74695f8d8f3ba4f820c238903c7709da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/1d1a2f3f876add99c307da9a67fed477939e2277",
-                "reference": "1d1a2f3f876add99c307da9a67fed477939e2277",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/f5f292f74695f8d8f3ba4f820c238903c7709da2",
+                "reference": "f5f292f74695f8d8f3ba4f820c238903c7709da2",
                 "shasum": ""
             },
             "require-dev": {
@@ -5915,9 +5915,9 @@
             ],
             "description": "i18n for FundraisingFrontend",
             "support": {
-                "source": "https://github.com/wmde/fundraising-frontend-content/tree/sofort"
+                "source": "https://github.com/wmde/fundraising-frontend-content/tree/test"
             },
-            "time": "2017-07-06T10:33:36+00:00"
+            "time": "2017-07-06T13:44:34+00:00"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/contexts/DonationContext/src/Domain/Model/Donation.php
+++ b/contexts/DonationContext/src/Domain/Model/Donation.php
@@ -248,7 +248,7 @@ class Donation {
 	}
 
 	public function hasExternalPayment(): bool {
-		return in_array( $this->getPaymentType(), [ PaymentType::PAYPAL, PaymentType::CREDIT_CARD ] );
+		return in_array( $this->getPaymentType(), [ PaymentType::PAYPAL, PaymentType::CREDIT_CARD, PaymentType::SOFORT ] );
 	}
 
 	private function isIncomplete(): bool {

--- a/contexts/DonationContext/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -20,6 +20,7 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentWithoutAssociatedData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalData;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalPayment;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\SofortPayment;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\TransferCodeGenerator;
 
 /**
@@ -150,19 +151,20 @@ class AddDonationUseCase {
 	}
 
 	private function getPaymentMethodFromRequest( AddDonationRequest $donationRequest ): PaymentMethod {
-		if ( $donationRequest->getPaymentType() === PaymentType::BANK_TRANSFER ) {
-			return new BankTransferPayment( $this->transferCodeGenerator->generateTransferCode() );
-		}
+		$paymentType = $donationRequest->getPaymentType();
 
-		if ( $donationRequest->getPaymentType() === PaymentType::DIRECT_DEBIT ) {
-			return new DirectDebitPayment( $donationRequest->getBankData() );
+		switch ( $paymentType ) {
+			case PaymentType::BANK_TRANSFER:
+				return new BankTransferPayment( $this->transferCodeGenerator->generateTransferCode() );
+			case PaymentType::DIRECT_DEBIT:
+				return new DirectDebitPayment( $donationRequest->getBankData() );
+			case PaymentType::PAYPAL:
+				return new PayPalPayment( new PayPalData() );
+			case PaymentType::SOFORT:
+				return new SofortPayment( $this->transferCodeGenerator->generateTransferCode() );
+			default:
+				return new PaymentWithoutAssociatedData( $paymentType );
 		}
-
-		if ( $donationRequest->getPaymentType() === PaymentType::PAYPAL ) {
-			return new PayPalPayment( new PayPalData() );
-		}
-
-		return new PaymentWithoutAssociatedData( $donationRequest->getPaymentType() );
 	}
 
 	private function newTrackingInfoFromRequest( AddDonationRequest $request ): DonationTrackingInfo {

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
@@ -19,7 +19,7 @@ use WMDE\Fundraising\Frontend\Validation\PaymentDataValidator;
 use WMDE\Fundraising\Frontend\Validation\ValidationResult;
 
 /**
- * @covers WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationValidator
+ * @covers \WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\AddDonationValidator
  *
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
@@ -198,7 +198,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 
 	private function newDonationValidator(): AddDonationValidator {
 		return new AddDonationValidator(
-			new PaymentDataValidator( 1.0, 100000 ),
+			new PaymentDataValidator( 1.0, 100000, [ 'BEZ' ] ),
 			$this->newBankDataValidator(),
 			$this->newMockEmailValidator()
 		);

--- a/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\PaymentContext\Domain\Model;
+
+class SofortPayment implements PaymentMethod {
+
+	private $uuid;
+
+	public function __construct( string $uuid ) {
+		$this->uuid = $uuid;
+	}
+
+	public function getType(): string {
+		return PaymentType::SOFORT;
+	}
+
+	public function getUuid(): string {
+		return $this->uuid;
+	}
+}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -917,8 +917,16 @@ class FunFunFactory {
 	}
 
 	public function newSofortUrlGeneratorForDonations(): SofortUrlGenerator {
-		$config = SofortUrlConfig::newFromConfig( $this->config['sofort'] );
-		return new SofortUrlGenerator( $config, new Sofortueberweisung( $config->getConfigkey() ) );
+		$config = $this->config['sofort'];
+
+		return new SofortUrlGenerator(
+			new SofortUrlConfig(
+				$this->getTranslator()->trans( $config[ 'reason-text-translation-key' ], [], 'paymentSubjects' ),
+				$config[ 'return-url' ],
+				$config[ 'cancel-url' ]
+			),
+			new Sofortueberweisung( $config[ 'config-key' ] )
+		);
 	}
 
 	private function newCreditCardUrlGenerator() {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -17,6 +17,7 @@ use NumberFormatter;
 use Pimple\Container;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Sofort\SofortLib\Sofortueberweisung;
 use Swift_MailTransport;
 use Swift_NullTransport;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -40,6 +41,8 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\PaymentDelayCalculator;
 use WMDE\Fundraising\Frontend\Presentation\ContentPage\PageSelector;
 use WMDE\Fundraising\Frontend\Presentation\Honorifics;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\PageNotFoundPresenter;
+use WMDE\Fundraising\Frontend\Presentation\SofortUrlConfig;
+use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
 use WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchUseCase;
 use WMDE\Fundraising\Frontend\Infrastructure\Cache\AuthorizedCachePurger;
 use WMDE\Fundraising\Frontend\DonationContext\Authorization\DonationAuthorizer;
@@ -911,6 +914,11 @@ class FunFunFactory {
 
 	private function getPayPalUrlConfigForMembershipApplications() {
 		return PayPalUrlConfig::newFromConfig( $this->config['paypal-membership'] );
+	}
+
+	public function newSofortUrlGeneratorForDonations(): SofortUrlGenerator {
+		$config = SofortUrlConfig::newFromConfig( $this->config['sofort'] );
+		return new SofortUrlGenerator( $config, new Sofortueberweisung( $config->getConfigkey() ) );
 	}
 
 	private function newCreditCardUrlGenerator() {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -17,7 +17,6 @@ use NumberFormatter;
 use Pimple\Container;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Sofort\SofortLib\Sofortueberweisung;
 use Swift_MailTransport;
 use Swift_NullTransport;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -43,6 +42,7 @@ use WMDE\Fundraising\Frontend\Presentation\Honorifics;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\PageNotFoundPresenter;
 use WMDE\Fundraising\Frontend\Presentation\SofortUrlConfig;
 use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
+use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Client as SofortClient;
 use WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchUseCase;
 use WMDE\Fundraising\Frontend\Infrastructure\Cache\AuthorizedCachePurger;
 use WMDE\Fundraising\Frontend\DonationContext\Authorization\DonationAuthorizer;
@@ -925,7 +925,7 @@ class FunFunFactory {
 				$config['return-url'],
 				$config['cancel-url']
 			),
-			new Sofortueberweisung( $config['config-key'] )
+			new SofortClient( $config['config-key'] )
 		);
 	}
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -439,6 +439,11 @@ class FunFunFactory {
 			return new DefaultPaymentDelayCalculator( $this->getPayPalUrlConfigForMembershipApplications()->getDelayInDays() );
 		};
 
+		$pimple['sofort-client'] = function () {
+			$config = $this->config['sofort'];
+			return new SofortClient( $config['config-key'] );
+		};
+
 		return $pimple;
 	}
 
@@ -925,8 +930,16 @@ class FunFunFactory {
 				$config['return-url'],
 				$config['cancel-url']
 			),
-			new SofortClient( $config['config-key'] )
+			$this->getSofortClient()
 		);
+	}
+
+	public function setSofortClient( SofortClient $client ): void {
+		$this->pimple['sofort-client'] = $client;
+	}
+
+	private function getSofortClient(): SofortClient {
+		return $this->pimple['sofort-client'];
 	}
 
 	private function newCreditCardUrlGenerator() {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -36,6 +36,7 @@ use WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership\Appl
 use WMDE\Fundraising\Frontend\MembershipContext\UseCases\HandleSubscriptionPaymentNotification\HandleSubscriptionPaymentNotificationUseCase;
 use WMDE\Fundraising\Frontend\MembershipContext\UseCases\HandleSubscriptionSignupNotification\HandleSubscriptionSignupNotificationUseCase;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\DefaultPaymentDelayCalculator;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\PaymentDelayCalculator;
 use WMDE\Fundraising\Frontend\Presentation\ContentPage\PageSelector;
 use WMDE\Fundraising\Frontend\Presentation\Honorifics;
@@ -955,7 +956,11 @@ class FunFunFactory {
 	}
 
 	public function newPaymentDataValidator(): PaymentDataValidator {
-		return new PaymentDataValidator( $this->config['donation-minimum-amount'], $this->config['donation-maximum-amount'] );
+		return new PaymentDataValidator(
+			$this->config['donation-minimum-amount'],
+			$this->config['donation-maximum-amount'],
+			PaymentType::getPaymentTypes()
+		);
 	}
 
 	private function newAmountFormatter(): AmountFormatter {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -927,7 +927,7 @@ class FunFunFactory {
 
 		return new SofortUrlGenerator(
 			new SofortUrlConfig(
-				$this->getTranslator()->trans( $config['reason-text-translation-key'], [], 'paymentSubjects' ),
+				$this->getTranslator()->trans( 'item_name_donation', [], 'messages' ),
 				$config['return-url'],
 				$config['cancel-url']
 			),

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -959,7 +959,7 @@ class FunFunFactory {
 		return new PaymentDataValidator(
 			$this->config['donation-minimum-amount'],
 			$this->config['donation-maximum-amount'],
-			PaymentType::getPaymentTypes()
+			$this->getEnabledDonationPaymentTypes()
 		);
 	}
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -921,11 +921,11 @@ class FunFunFactory {
 
 		return new SofortUrlGenerator(
 			new SofortUrlConfig(
-				$this->getTranslator()->trans( $config[ 'reason-text-translation-key' ], [], 'paymentSubjects' ),
-				$config[ 'return-url' ],
-				$config[ 'cancel-url' ]
+				$this->getTranslator()->trans( $config['reason-text-translation-key'], [], 'paymentSubjects' ),
+				$config['return-url'],
+				$config['cancel-url']
 			),
-			new Sofortueberweisung( $config[ 'config-key' ] )
+			new Sofortueberweisung( $config['config-key'] )
 		);
 	}
 

--- a/src/Infrastructure/Sofort/Transfer/Client.php
+++ b/src/Infrastructure/Sofort/Transfer/Client.php
@@ -1,0 +1,54 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer;
+
+use RuntimeException;
+use Sofort\SofortLib\Sofortueberweisung;
+
+class Client {
+
+	/**
+	 * @var Sofortueberweisung
+	 */
+	private $api;
+
+	public function __construct( string $configkey ) {
+		$this->api = new Sofortueberweisung( $configkey );
+	}
+
+	public function setApi( Sofortueberweisung $sofortueberweisung ): void {
+		$this->api = $sofortueberweisung;
+	}
+
+	public function get( Request $request ): Response {
+
+		// mapping Euro amount to 3rd party float
+		$this->api->setAmount( $request->getAmount()->getEuroFloat() );
+
+		$this->api->setCurrencyCode( $request->getCurrencyCode() );
+
+		$reasons = $request->getReasons();
+
+		$this->api->setReason( $reasons[0] ?? '', $reasons[1] ?? '' );
+
+		$this->api->setSuccessUrl( $request->getSuccessUrl(), true );
+		$this->api->setAbortUrl( $request->getAbortUrl() );
+		$this->api->setNotificationUrl( $request->getNotificationUrl() );
+
+		$this->api->sendRequest();
+
+		if ( $this->api->isError() ) {
+			throw new RuntimeException( $this->api->getError() );
+		}
+
+		$response = new Response();
+		// @todo Do we have use for that?
+		// unique transaction-ID useful to check payment status
+		$response->setTransactionId( $this->api->getTransactionId() );
+		$response->setPaymentUrl( $this->api->getPaymentUrl() );
+
+		return $response;
+	}
+}

--- a/src/Infrastructure/Sofort/Transfer/Client.php
+++ b/src/Infrastructure/Sofort/Transfer/Client.php
@@ -7,6 +7,9 @@ namespace WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer;
 use RuntimeException;
 use Sofort\SofortLib\Sofortueberweisung;
 
+/**
+ * Facade in front of Sofortueberweisung, an API to generate URLs of Sofort's checkout process
+ */
 class Client {
 
 	/**
@@ -14,23 +17,36 @@ class Client {
 	 */
 	private $api;
 
+	/**
+	 * @param string $configkey The secret key to use for Sofort API communication
+	 */
 	public function __construct( string $configkey ) {
 		$this->api = new Sofortueberweisung( $configkey );
 	}
 
+	/**
+	 * Set API to use instead of the one chosen by the facade
+	 *
+	 * @param Sofortueberweisung $sofortueberweisung
+	 */
 	public function setApi( Sofortueberweisung $sofortueberweisung ): void {
 		$this->api = $sofortueberweisung;
 	}
 
+	/**
+	 * @throws RuntimeException
+	 *
+	 * @param Request $request
+	 * @return Response
+	 */
 	public function get( Request $request ): Response {
 
-		// mapping Euro amount to 3rd party float
+		// Mapping currency amount to 3rd party float format. Known flaw
 		$this->api->setAmount( $request->getAmount()->getEuroFloat() );
 
 		$this->api->setCurrencyCode( $request->getCurrencyCode() );
 
 		$reasons = $request->getReasons();
-
 		$this->api->setReason( $reasons[0] ?? '', $reasons[1] ?? '' );
 
 		$this->api->setSuccessUrl( $request->getSuccessUrl(), true );
@@ -44,10 +60,8 @@ class Client {
 		}
 
 		$response = new Response();
-		// @todo Do we have use for that?
-		// unique transaction-ID useful to check payment status
-		$response->setTransactionId( $this->api->getTransactionId() );
 		$response->setPaymentUrl( $this->api->getPaymentUrl() );
+		$response->setTransactionId( $this->api->getTransactionId() );
 
 		return $response;
 	}

--- a/src/Infrastructure/Sofort/Transfer/Client.php
+++ b/src/Infrastructure/Sofort/Transfer/Client.php
@@ -17,27 +17,21 @@ class Client {
 	 */
 	private $api;
 
-	/**
-	 * @param string $configkey The secret key to use for Sofort API communication
-	 */
 	public function __construct( string $configkey ) {
 		$this->api = new Sofortueberweisung( $configkey );
 	}
 
 	/**
 	 * Set API to use instead of the one chosen by the facade
-	 *
-	 * @param Sofortueberweisung $sofortueberweisung
 	 */
 	public function setApi( Sofortueberweisung $sofortueberweisung ): void {
 		$this->api = $sofortueberweisung;
 	}
 
 	/**
-	 * @throws RuntimeException
+	 * Perform the given request and return a response
 	 *
-	 * @param Request $request
-	 * @return Response
+	 * @throws RuntimeException
 	 */
 	public function get( Request $request ): Response {
 

--- a/src/Infrastructure/Sofort/Transfer/Request.php
+++ b/src/Infrastructure/Sofort/Transfer/Request.php
@@ -33,72 +33,42 @@ class Request {
 	 */
 	private $reasons = [ '', '' ];
 
-	/**
-	 * @return Euro
-	 */
 	public function getAmount(): Euro {
 		return $this->amount;
 	}
 
-	/**
-	 * @param Euro $amount
-	 */
 	public function setAmount( Euro $amount ): void {
 		$this->amount = $amount;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getCurrencyCode(): string {
 		return $this->currencyCode;
 	}
 
-	/**
-	 * @param string $currencyCode
-	 */
 	public function setCurrencyCode( string $currencyCode ): void {
 		$this->currencyCode = $currencyCode;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getSuccessUrl(): string {
 		return $this->successUrl;
 	}
 
-	/**
-	 * @param string $successUrl
-	 */
 	public function setSuccessUrl( string $successUrl ): void {
 		$this->successUrl = $successUrl;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getAbortUrl(): string {
 		return $this->abortUrl;
 	}
 
-	/**
-	 * @param string $abortUrl
-	 */
 	public function setAbortUrl( string $abortUrl ): void {
 		$this->abortUrl = $abortUrl;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getNotificationUrl(): string {
 		return $this->notificationUrl;
 	}
 
-	/**
-	 * @param string $notificationUrl
-	 */
 	public function setNotificationUrl( string $notificationUrl ): void {
 		$this->notificationUrl = $notificationUrl;
 	}

--- a/src/Infrastructure/Sofort/Transfer/Request.php
+++ b/src/Infrastructure/Sofort/Transfer/Request.php
@@ -1,0 +1,119 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer;
+
+use WMDE\Euro\Euro;
+
+class Request {
+
+	/**
+	 * @var Euro
+	 */
+	private $amount;
+	/**
+	 * @var string
+	 */
+	private $currencyCode = '';
+	/**
+	 * @var string
+	 */
+	private $successUrl = '';
+	/**
+	 * @var string
+	 */
+	private $abortUrl = '';
+	/**
+	 * @var string
+	 */
+	private $notificationUrl = '';
+	/**
+	 * @var string[]
+	 */
+	private $reasons = [ '', '' ];
+
+	/**
+	 * @return Euro
+	 */
+	public function getAmount(): Euro {
+		return $this->amount;
+	}
+
+	/**
+	 * @param Euro $amount
+	 */
+	public function setAmount( Euro $amount ): void {
+		$this->amount = $amount;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCurrencyCode(): string {
+		return $this->currencyCode;
+	}
+
+	/**
+	 * @param string $currencyCode
+	 */
+	public function setCurrencyCode( string $currencyCode ): void {
+		$this->currencyCode = $currencyCode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSuccessUrl(): string {
+		return $this->successUrl;
+	}
+
+	/**
+	 * @param string $successUrl
+	 */
+	public function setSuccessUrl( string $successUrl ): void {
+		$this->successUrl = $successUrl;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAbortUrl(): string {
+		return $this->abortUrl;
+	}
+
+	/**
+	 * @param string $abortUrl
+	 */
+	public function setAbortUrl( string $abortUrl ): void {
+		$this->abortUrl = $abortUrl;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getNotificationUrl(): string {
+		return $this->notificationUrl;
+	}
+
+	/**
+	 * @param string $notificationUrl
+	 */
+	public function setNotificationUrl( string $notificationUrl ): void {
+		$this->notificationUrl = $notificationUrl;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getReasons(): array {
+		return $this->reasons;
+	}
+
+	/**
+	 * @param string[] $reasons
+	 */
+	public function setReasons( array $reasons ): void {
+		$this->reasons = $reasons;
+	}
+}

--- a/src/Infrastructure/Sofort/Transfer/Response.php
+++ b/src/Infrastructure/Sofort/Transfer/Response.php
@@ -15,30 +15,18 @@ class Response {
 	 */
 	private $paymentUrl = '';
 
-	/**
-	 * @return string
-	 */
 	public function getTransactionId(): string {
 		return $this->transactionId;
 	}
 
-	/**
-	 * @param mixed $transactionId
-	 */
-	public function setTransactionId( $transactionId ): void {
+	public function setTransactionId( string $transactionId ): void {
 		$this->transactionId = $transactionId;
 	}
 
-	/**
-	 * @return string
-	 */
 	public function getPaymentUrl(): string {
 		return $this->paymentUrl;
 	}
 
-	/**
-	 * @param string $paymentUrl
-	 */
 	public function setPaymentUrl( string $paymentUrl ): void {
 		$this->paymentUrl = $paymentUrl;
 	}

--- a/src/Infrastructure/Sofort/Transfer/Response.php
+++ b/src/Infrastructure/Sofort/Transfer/Response.php
@@ -18,14 +18,14 @@ class Response {
 	/**
 	 * @return string
 	 */
-	public function getTransactionId() {
+	public function getTransactionId(): string {
 		return $this->transactionId;
 	}
 
 	/**
 	 * @param mixed $transactionId
 	 */
-	public function setTransactionId( $transactionId ) {
+	public function setTransactionId( $transactionId ): void {
 		$this->transactionId = $transactionId;
 	}
 
@@ -39,7 +39,7 @@ class Response {
 	/**
 	 * @param string $paymentUrl
 	 */
-	public function setPaymentUrl( string $paymentUrl ) {
+	public function setPaymentUrl( string $paymentUrl ): void {
 		$this->paymentUrl = $paymentUrl;
 	}
 }

--- a/src/Infrastructure/Sofort/Transfer/Response.php
+++ b/src/Infrastructure/Sofort/Transfer/Response.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer;
+
+class Response {
+
+	/**
+	 * @var string
+	 */
+	private $transactionId = '';
+	/**
+	 * @var string
+	 */
+	private $paymentUrl = '';
+
+	/**
+	 * @return string
+	 */
+	public function getTransactionId() {
+		return $this->transactionId;
+	}
+
+	/**
+	 * @param mixed $transactionId
+	 */
+	public function setTransactionId( $transactionId ) {
+		$this->transactionId = $transactionId;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getPaymentUrl(): string {
+		return $this->paymentUrl;
+	}
+
+	/**
+	 * @param string $paymentUrl
+	 */
+	public function setPaymentUrl( string $paymentUrl ) {
+		$this->paymentUrl = $paymentUrl;
+	}
+}

--- a/src/Presentation/SofortUrlConfig.php
+++ b/src/Presentation/SofortUrlConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Presentation;
+
+class SofortUrlConfig {
+
+	private $configkey;
+	private $itemName;
+	private $returnUrl;
+	private $cancelUrl;
+
+	public function __construct( string $configkey, string $itemName, string $returnUrl, string $cancelUrl ) {
+		$this->configkey = $configkey;
+		$this->returnUrl = $returnUrl;
+		$this->cancelUrl = $cancelUrl;
+		$this->itemName = $itemName;
+	}
+
+	public function getConfigkey(): string {
+		return $this->configkey;
+	}
+
+	public function getItemName(): string {
+		return $this->itemName;
+	}
+
+	public function getReturnUrl(): string {
+		return $this->returnUrl;
+	}
+
+	public function getCancelUrl(): string {
+		return $this->cancelUrl;
+	}
+}

--- a/src/Presentation/SofortUrlConfig.php
+++ b/src/Presentation/SofortUrlConfig.php
@@ -6,29 +6,18 @@ namespace WMDE\Fundraising\Frontend\Presentation;
 
 class SofortUrlConfig {
 
-	private const CONFIG_CONFIGKEY = 'config-key';
-	private const CONFIG_ITEMNAME = 'item-name';
-	private const CONFIG_RETURNURL = 'return-url';
-	private const CONFIG_CANCELURL = 'cancel-url';
-
-	private $configkey;
-	private $itemName;
+	private $reasonText;
 	private $returnUrl;
 	private $cancelUrl;
 
-	private function __construct( string $configkey, string $itemName, string $returnUrl, string $cancelUrl ) {
-		$this->configkey = $configkey;
+	public function __construct( string $reasonText, string $returnUrl, string $cancelUrl ) {
+		$this->reasonText = $reasonText;
 		$this->returnUrl = $returnUrl;
 		$this->cancelUrl = $cancelUrl;
-		$this->itemName = $itemName;
 	}
 
-	public function getConfigkey(): string {
-		return $this->configkey;
-	}
-
-	public function getItemName(): string {
-		return $this->itemName;
+	public function getReasonText(): string {
+		return $this->reasonText;
 	}
 
 	public function getReturnUrl(): string {
@@ -37,29 +26,5 @@ class SofortUrlConfig {
 
 	public function getCancelUrl(): string {
 		return $this->cancelUrl;
-	}
-
-	/**
-	 * @param string[] $config
-	 * @return PayPalUrlConfig
-	 * @throws \RuntimeException
-	 */
-	public static function newFromConfig( array $config ): self {
-		return ( new self(
-			$config[self::CONFIG_CONFIGKEY],
-			$config[self::CONFIG_ITEMNAME],
-			$config[self::CONFIG_RETURNURL],
-			$config[self::CONFIG_CANCELURL]
-		) )->assertNoEmptyFields();
-	}
-
-	private function assertNoEmptyFields(): self {
-		foreach ( get_object_vars( $this ) as $fieldName => $fieldValue ) {
-			if ( empty( $fieldValue ) ) {
-				throw new \RuntimeException( "Configuration variable '$fieldName' can not be empty" );
-			}
-		}
-
-		return $this;
 	}
 }

--- a/src/Presentation/SofortUrlConfig.php
+++ b/src/Presentation/SofortUrlConfig.php
@@ -6,12 +6,17 @@ namespace WMDE\Fundraising\Frontend\Presentation;
 
 class SofortUrlConfig {
 
+	private const CONFIG_CONFIGKEY = 'config-key';
+	private const CONFIG_ITEMNAME = 'item-name';
+	private const CONFIG_RETURNURL = 'return-url';
+	private const CONFIG_CANCELURL = 'cancel-url';
+
 	private $configkey;
 	private $itemName;
 	private $returnUrl;
 	private $cancelUrl;
 
-	public function __construct( string $configkey, string $itemName, string $returnUrl, string $cancelUrl ) {
+	private function __construct( string $configkey, string $itemName, string $returnUrl, string $cancelUrl ) {
 		$this->configkey = $configkey;
 		$this->returnUrl = $returnUrl;
 		$this->cancelUrl = $cancelUrl;
@@ -32,5 +37,29 @@ class SofortUrlConfig {
 
 	public function getCancelUrl(): string {
 		return $this->cancelUrl;
+	}
+
+	/**
+	 * @param string[] $config
+	 * @return PayPalUrlConfig
+	 * @throws \RuntimeException
+	 */
+	public static function newFromConfig( array $config ): self {
+		return ( new self(
+			$config[self::CONFIG_CONFIGKEY],
+			$config[self::CONFIG_ITEMNAME],
+			$config[self::CONFIG_RETURNURL],
+			$config[self::CONFIG_CANCELURL]
+		) )->assertNoEmptyFields();
+	}
+
+	private function assertNoEmptyFields(): self {
+		foreach ( get_object_vars( $this ) as $fieldName => $fieldValue ) {
+			if ( empty( $fieldValue ) ) {
+				throw new \RuntimeException( "Configuration variable '$fieldName' can not be empty" );
+			}
+		}
+
+		return $this;
 	}
 }

--- a/src/Presentation/SofortUrlConfig.php
+++ b/src/Presentation/SofortUrlConfig.php
@@ -6,8 +6,17 @@ namespace WMDE\Fundraising\Frontend\Presentation;
 
 class SofortUrlConfig {
 
+	/**
+	 * @var string
+	 */
 	private $reasonText;
+	/**
+	 * @var string
+	 */
 	private $returnUrl;
+	/**
+	 * @var string
+	 */
 	private $cancelUrl;
 
 	public function __construct( string $reasonText, string $returnUrl, string $cancelUrl ) {

--- a/src/Presentation/SofortUrlGenerator.php
+++ b/src/Presentation/SofortUrlGenerator.php
@@ -9,6 +9,9 @@ use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Request;
 use WMDE\Euro\Euro;
 use RuntimeException;
 
+/**
+ * Generate the URL of the Sofort checkout process
+ */
 class SofortUrlGenerator {
 
 	private const CURRENCY = 'EUR';
@@ -27,8 +30,15 @@ class SofortUrlGenerator {
 		$this->client = $client;
 	}
 
+	/**
+	 * Generate a URL to use (refer the donor to) to finalize a purchase on a 3rd party payment provider page
+	 *
+	 * @param int $itemId Id of the item to pay
+	 * @param Euro $amount The amount of money to pay
+	 * @param string $accessToken A token to return to the payment process after completing the 3rd party process
+	 * @return string
+	 */
 	public function generateUrl( int $itemId, Euro $amount, string $accessToken ): string {
-
 		$request = new Request();
 		$request->setAmount( $amount );
 		$request->setCurrencyCode( self::CURRENCY );

--- a/src/Presentation/SofortUrlGenerator.php
+++ b/src/Presentation/SofortUrlGenerator.php
@@ -1,0 +1,60 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Presentation;
+
+use Sofort\SofortLib\Sofortueberweisung;
+use WMDE\Euro\Euro;
+use RuntimeException;
+
+class SofortUrlGenerator {
+
+	private const CURRENCY = 'EUR';
+
+	/**
+	 * @var \WMDE\Fundraising\Frontend\Presentation\SofortUrlConfig
+	 */
+	private $config;
+	/**
+	 * @var \Sofort\SofortLib\Sofortueberweisung
+	 */
+	private $api;
+
+	public function __construct( SofortUrlConfig $config, Sofortueberweisung $api ) {
+		$this->config = $config;
+		$this->api = $api;
+	}
+
+	public function generateUrl( string $itemId, Euro $amount, string $accessToken ): string {
+		$this->api->setAmount( $amount->getEuroString() );
+		$this->api->setCurrencyCode( self::CURRENCY );
+		$this->api->setReason( $this->config->getItemName(), $itemId );
+
+		$this->api->setSuccessUrl(
+			$this->config->getReturnUrl() . '?' . http_build_query( [
+				'id' => $itemId,
+				'accessToken' => $accessToken
+			] ),
+			true
+		);
+		$this->api->setAbortUrl( $this->config->getCancelUrl() );
+
+		// @todo Do we need that?
+		//$this->api->setNotificationUrl('YOUR_NOTIFICATION_URL');
+		// @todo Research what this does
+		//$this->api->setCustomerprotection(true);
+
+		$this->api->sendRequest();
+
+		if ( $this->api->isError() ) {
+			throw new RuntimeException( 'Could not generate Sofort URL: ' . $this->api->getError() );
+		}
+
+		// @todo Do we have use for that?
+		// unique transaction-ID useful to check payment status
+		$transactionId = $this->api->getTransactionId();
+
+		return $this->api->getPaymentUrl();
+	}
+}

--- a/src/Presentation/SofortUrlGenerator.php
+++ b/src/Presentation/SofortUrlGenerator.php
@@ -33,19 +33,20 @@ class SofortUrlGenerator {
 	/**
 	 * Generate a URL to use (refer the donor to) to finalize a purchase on a 3rd party payment provider page
 	 *
-	 * @param int $itemId Id of the item to pay
+	 * @param int $internalItemId Internal (WMDE-use only) Id of the item to pay
+	 * @param string $externalItemId External (3rd parties may use to reference the item with this) Id of the item to pay
 	 * @param Euro $amount The amount of money to pay
 	 * @param string $accessToken A token to return to the payment process after completing the 3rd party process
 	 * @return string
 	 */
-	public function generateUrl( int $itemId, Euro $amount, string $accessToken ): string {
+	public function generateUrl( int $internalItemId, string $externalItemId, Euro $amount, string $accessToken ): string {
 		$request = new Request();
 		$request->setAmount( $amount );
 		$request->setCurrencyCode( self::CURRENCY );
-		$request->setReasons( [ $this->config->getReasonText(), $itemId ] );
+		$request->setReasons( [ $this->config->getReasonText(), $externalItemId ] );
 		$request->setSuccessUrl(
 			$this->config->getReturnUrl() . '?' . http_build_query( [
-				'id' => $itemId,
+				'id' => $internalItemId,
 				'accessToken' => $accessToken
 			] )
 		);

--- a/src/Presentation/SofortUrlGenerator.php
+++ b/src/Presentation/SofortUrlGenerator.php
@@ -42,8 +42,6 @@ class SofortUrlGenerator {
 
 		// @todo Do we need that?
 		//$this->api->setNotificationUrl('YOUR_NOTIFICATION_URL');
-		// @todo Research what this does
-		//$this->api->setCustomerprotection(true);
 
 		$this->api->sendRequest();
 

--- a/src/Presentation/SofortUrlGenerator.php
+++ b/src/Presentation/SofortUrlGenerator.php
@@ -29,7 +29,7 @@ class SofortUrlGenerator {
 	public function generateUrl( int $itemId, Euro $amount, string $accessToken ): string {
 		$this->api->setAmount( $amount->getEuroString() );
 		$this->api->setCurrencyCode( self::CURRENCY );
-		$this->api->setReason( $this->config->getItemName(), $itemId );
+		$this->api->setReason( $this->config->getReasonText(), $itemId );
 
 		$this->api->setSuccessUrl(
 			$this->config->getReturnUrl() . '?' . http_build_query( [

--- a/src/Presentation/SofortUrlGenerator.php
+++ b/src/Presentation/SofortUrlGenerator.php
@@ -26,7 +26,7 @@ class SofortUrlGenerator {
 		$this->api = $api;
 	}
 
-	public function generateUrl( string $itemId, Euro $amount, string $accessToken ): string {
+	public function generateUrl( int $itemId, Euro $amount, string $accessToken ): string {
 		$this->api->setAmount( $amount->getEuroString() );
 		$this->api->setCurrencyCode( self::CURRENCY );
 		$this->api->setReason( $this->config->getItemName(), $itemId );

--- a/src/Validation/PaymentDataValidator.php
+++ b/src/Validation/PaymentDataValidator.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Validation;
 
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
 
 /**
  * @licence GNU GPL v2+
@@ -14,27 +13,30 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
  */
 class PaymentDataValidator {
 
-	const VIOLATION_AMOUNT_NOT_NUMERIC = 'Amount is not numeric';
-	const VIOLATION_AMOUNT_TOO_LOW = 'Amount too low';
-	const VIOLATION_AMOUNT_TOO_HIGH = 'Amount too high';
-	const VIOLATION_UNKNOWN_PAYMENT_TYPE = 'Unknown payment type';
+	private const VIOLATION_AMOUNT_NOT_NUMERIC = 'Amount is not numeric';
+	private const VIOLATION_AMOUNT_TOO_LOW = 'Amount too low';
+	private const VIOLATION_AMOUNT_TOO_HIGH = 'Amount too high';
+	private const VIOLATION_UNKNOWN_PAYMENT_TYPE = 'Unknown payment type';
 
-	const SOURCE_AMOUNT = 'amount';
-	const SOURCE_PAYMENT_TYPE = 'paymentType';
+	private const SOURCE_AMOUNT = 'amount';
+	private const SOURCE_PAYMENT_TYPE = 'paymentType';
 
 	private $minAmount;
 	private $maxAmount;
+	private $allowedTypes = [];
 
 	private $minAmountPerType;
 
 	/**
 	 * @param float $minAmount
 	 * @param float $maxAmount
+	 * @param array $allowedTypes
 	 * @param float[] $minAmountPerType keys from the PaymentType enum
 	 */
-	public function __construct( float $minAmount, float $maxAmount, array $minAmountPerType = [] ) {
+	public function __construct( float $minAmount, float $maxAmount, array $allowedTypes, array $minAmountPerType = [] ) {
 		$this->minAmount = $minAmount;
 		$this->maxAmount = $maxAmount;
+		$this->allowedTypes = $allowedTypes;
 		$this->minAmountPerType = $minAmountPerType;
 	}
 
@@ -45,7 +47,7 @@ class PaymentDataValidator {
 	 * @return ValidationResult
 	 */
 	public function validate( $amount, string $paymentType ): ValidationResult {
-		if ( !in_array( $paymentType, PaymentType::getPaymentTypes() ) ) {
+		if ( !in_array( $paymentType, $this->allowedTypes ) ) {
 			return new ValidationResult( new ConstraintViolation(
 				$paymentType,
 				self::VIOLATION_UNKNOWN_PAYMENT_TYPE,
@@ -91,5 +93,4 @@ class PaymentDataValidator {
 
 		return $this->minAmount;
 	}
-
 }

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -12,6 +12,8 @@ use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker;
 use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\FixedTokenGenerator;
+use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Client as SofortClient;
+use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Response as SofortResponse;
 
 /**
  * @licence GNU GPL v2+
@@ -345,11 +347,43 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'thatother.paymentprovider.com', $response->getContent() );
 	}
 
+	public function testValidSofortInput_RedirectsTo3rdPartyPage() {
+
+		$response = new SofortResponse();
+		$response->setPaymentUrl( 'https://bankingpin.please' );
+
+		$client = $this->createClient( [], function ( FunFunFactory $factory ) use ( $response ) {
+			$sofortClient = $this->createMock( SofortClient::class );
+			$sofortClient
+				->method( 'get' )
+				->willReturn( $response );
+			$factory->setSofortClient( $sofortClient );
+		} );
+
+		$client->followRedirects( false );
+		$client->request(
+			'POST',
+			'/donation/add',
+			$this->newValidSofortInput()
+		);
+
+		$this->assertTrue( $client->getResponse()->isRedirect( 'https://bankingpin.please' ) );
+	}
+
 	private function newValidCreditCardInput() {
 		return [
 			'betrag' => '12,34',
 			'zahlweise' => 'MCP',
 			'periode' => 3,
+			'addressType' => 'anonym',
+		];
+	}
+
+	private function newValidSofortInput() {
+		return [
+			'betrag' => '100,00',
+			'zahlweise' => 'SUB',
+			'periode' => 0,
 			'addressType' => 'anonym',
 		];
 	}
@@ -721,5 +755,4 @@ class AddDonationRouteTest extends WebRouteTestCase {
 			$this->assertSame( '', $data['bankname'] );
 		} );
 	}
-
 }

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -347,7 +347,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'thatother.paymentprovider.com', $response->getContent() );
 	}
 
-	public function testValidSofortInput_RedirectsTo3rdPartyPage() {
+	public function testValidSofortInput_redirectsTo3rdPartyPage(): void {
 
 		$response = new SofortResponse();
 		$response->setPaymentUrl( 'https://bankingpin.please' );
@@ -379,7 +379,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function newValidSofortInput() {
+	private function newValidSofortInput(): array {
 		return [
 			'betrag' => '100,00',
 			'zahlweise' => 'SUB',

--- a/tests/Unit/Infrastructure/Sofort/Transfer/ClientTest.php
+++ b/tests/Unit/Infrastructure/Sofort/Transfer/ClientTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure\Sofort\Transfer;
+
+use PHPUnit\Framework\TestCase;
+use Sofort\SofortLib\Sofortueberweisung;
+use WMDE\Euro\Euro;
+use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Client;
+use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Request;
+use RuntimeException;
+
+class ClientTest extends TestCase {
+
+	public function testGet(): void {
+		$client = new Client( '47:11:00' );
+
+		$amount = Euro::newFromCents( 500 );
+		$amountConvertedToFloat = $amount->getEuroFloat();
+
+		$api = $this->createMock( Sofortueberweisung::class );
+		$api
+			->expects( $this->once() )
+			->method( 'setAmount' )
+			->with( $amountConvertedToFloat )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setCurrencyCode' )
+			->with( 'EUR' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setReason' )
+			->with( 'Donation', '529836' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setSuccessUrl' )
+			->with( 'https://us.org/yes?id=529836&accessToken=letmein', true )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setAbortUrl' )
+			->with( 'https://us.org/no' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setNotificationUrl' )
+			->with( 'https://us.org/callback' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'sendRequest' )
+			->willReturn( null );
+		$api
+			->expects( $this->once() )
+			->method( 'isError' )
+			->willReturn( false );
+		$api
+			->expects( $this->never() )
+			->method( 'getError' );
+		$api
+			->expects( $this->once() )
+			->method( 'getTransactionId' )
+			->willReturn( 'tr4ns4ct10n' );
+		$api
+			->expects( $this->once() )
+			->method( 'getPaymentUrl' )
+			->willReturn( 'https://awsomepaymentprovider.tld/784trhhrf4' );
+
+		$client->setApi( $api );
+
+		$request = new Request();
+		$request->setAmount( $amount );
+		$request->setCurrencyCode( 'EUR' );
+		$request->setReasons( [ 'Donation', '529836' ] );
+		$request->setSuccessUrl( 'https://us.org/yes?id=529836&accessToken=letmein' );
+		$request->setAbortUrl( 'https://us.org/no' );
+		$request->setNotificationUrl( 'https://us.org/callback' );
+		$response = $client->get( $request );
+
+		$this->assertSame( 'https://awsomepaymentprovider.tld/784trhhrf4', $response->getPaymentUrl() );
+		$this->assertSame( 'tr4ns4ct10n', $response->getTransactionId() );
+	}
+
+	public function testWhenApiReturnsErrorAnExceptionWithApiErrorMessageIsThrown(): void {
+		$client = new Client( '47:11:00' );
+
+		$api = $this->createMock( Sofortueberweisung::class );
+
+		$api
+			->expects( $this->once() )
+			->method( 'isError' )
+			->willReturn( true );
+		$api
+			->expects( $this->once() )
+			->method( 'getError' )
+			->willReturn( 'boo boo' );
+
+		$client->setApi( $api );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'boo boo' );
+
+		$request = new Request();
+		$request->setAmount( Euro::newFromCents( 500 ) );
+		$request->setCurrencyCode( 'EUR' );
+		$request->setReasons( [ 'Donation', '529836' ] );
+		$request->setSuccessUrl( 'https://us.org/yes?id=529836&accessToken=letmein' );
+		$request->setAbortUrl( 'https://us.org/no' );
+		$request->setNotificationUrl( 'https://us.org/callback' );
+
+		$client->get( $request );
+	}
+}

--- a/tests/Unit/Infrastructure/Sofort/Transfer/ClientTest.php
+++ b/tests/Unit/Infrastructure/Sofort/Transfer/ClientTest.php
@@ -11,6 +11,9 @@ use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Client;
 use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Request;
 use RuntimeException;
 
+/**
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Client
+ */
 class ClientTest extends TestCase {
 
 	public function testGet(): void {
@@ -20,53 +23,37 @@ class ClientTest extends TestCase {
 		$amountConvertedToFloat = $amount->getEuroFloat();
 
 		$api = $this->createMock( Sofortueberweisung::class );
+
 		$api
-			->expects( $this->once() )
 			->method( 'setAmount' )
-			->with( $amountConvertedToFloat )
-			->willReturnSelf();
+			->with( $amountConvertedToFloat );
 		$api
-			->expects( $this->once() )
 			->method( 'setCurrencyCode' )
-			->with( 'EUR' )
-			->willReturnSelf();
+			->with( 'EUR' );
 		$api
-			->expects( $this->once() )
 			->method( 'setReason' )
-			->with( 'Donation', '529836' )
-			->willReturnSelf();
+			->with( 'Donation', '529836' );
 		$api
-			->expects( $this->once() )
 			->method( 'setSuccessUrl' )
-			->with( 'https://us.org/yes?id=529836&accessToken=letmein', true )
-			->willReturnSelf();
+			->with( 'https://us.org/yes?id=529836&accessToken=letmein', true );
 		$api
-			->expects( $this->once() )
 			->method( 'setAbortUrl' )
-			->with( 'https://us.org/no' )
-			->willReturnSelf();
+			->with( 'https://us.org/no' );
 		$api
-			->expects( $this->once() )
 			->method( 'setNotificationUrl' )
-			->with( 'https://us.org/callback' )
-			->willReturnSelf();
+			->with( 'https://us.org/callback' );
 		$api
-			->expects( $this->once() )
-			->method( 'sendRequest' )
-			->willReturn( null );
+			->method( 'sendRequest' );
 		$api
-			->expects( $this->once() )
 			->method( 'isError' )
 			->willReturn( false );
 		$api
 			->expects( $this->never() )
 			->method( 'getError' );
 		$api
-			->expects( $this->once() )
 			->method( 'getTransactionId' )
 			->willReturn( 'tr4ns4ct10n' );
 		$api
-			->expects( $this->once() )
 			->method( 'getPaymentUrl' )
 			->willReturn( 'https://awsomepaymentprovider.tld/784trhhrf4' );
 
@@ -91,11 +78,9 @@ class ClientTest extends TestCase {
 		$api = $this->createMock( Sofortueberweisung::class );
 
 		$api
-			->expects( $this->once() )
 			->method( 'isError' )
 			->willReturn( true );
 		$api
-			->expects( $this->once() )
 			->method( 'getError' )
 			->willReturn( 'boo boo' );
 

--- a/tests/Unit/Infrastructure/Sofort/Transfer/RequestTest.php
+++ b/tests/Unit/Infrastructure/Sofort/Transfer/RequestTest.php
@@ -8,6 +8,9 @@ use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Request;
 use PHPUnit\Framework\TestCase;
 use WMDE\Euro\Euro;
 
+/**
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Request
+ */
 class RequestTest extends TestCase {
 
 	public function testAccessors(): void {
@@ -33,4 +36,3 @@ class RequestTest extends TestCase {
 		$this->assertSame( 'notify', $request->getNotificationUrl() );
 	}
 }
-

--- a/tests/Unit/Infrastructure/Sofort/Transfer/RequestTest.php
+++ b/tests/Unit/Infrastructure/Sofort/Transfer/RequestTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure\Sofort\Transfer;
+
+use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Request;
+use PHPUnit\Framework\TestCase;
+use WMDE\Euro\Euro;
+
+class RequestTest extends TestCase {
+
+	public function testAccessors(): void {
+		$request = new Request();
+
+		$amount = Euro::newFromCents( 999 );
+		$request->setAmount( $amount );
+		$this->assertSame( $amount, $request->getAmount() );
+
+		$request->setCurrencyCode( 'EUR' );
+		$this->assertSame( 'EUR', $request->getCurrencyCode() );
+
+		$request->setReasons( [ 'a', 'b' ] );
+		$this->assertSame( [ 'a', 'b' ], $request->getReasons() );
+
+		$request->setSuccessUrl( 'success' );
+		$this->assertSame( 'success', $request->getSuccessUrl() );
+
+		$request->setAbortUrl( 'abort' );
+		$this->assertSame( 'abort', $request->getAbortUrl() );
+
+		$request->setNotificationUrl( 'notify' );
+		$this->assertSame( 'notify', $request->getNotificationUrl() );
+	}
+}
+

--- a/tests/Unit/Infrastructure/Sofort/Transfer/ResponseTest.php
+++ b/tests/Unit/Infrastructure/Sofort/Transfer/ResponseTest.php
@@ -7,9 +7,12 @@ namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure\Sofort\Transfer;
 use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Response;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Response
+ */
 class ResponseTest extends TestCase {
 
-	public function testResponse(): void {
+	public function testAccessors(): void {
 		$response = new Response();
 
 		$this->assertSame( '', $response->getPaymentUrl() );
@@ -18,7 +21,7 @@ class ResponseTest extends TestCase {
 		$response->setPaymentUrl( 'foo.com' );
 		$response->setTransactionId( '12345' );
 
-		$this->assertEquals( 'foo.com', $response->getPaymentUrl() );
-		$this->assertEquals( '12345', $response->getTransactionId() );
+		$this->assertSame( 'foo.com', $response->getPaymentUrl() );
+		$this->assertSame( '12345', $response->getTransactionId() );
 	}
 }

--- a/tests/Unit/Infrastructure/Sofort/Transfer/ResponseTest.php
+++ b/tests/Unit/Infrastructure/Sofort/Transfer/ResponseTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure\Sofort\Transfer;
+
+use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Response;
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase {
+
+	public function testResponse(): void {
+		$response = new Response();
+
+		$this->assertSame( '', $response->getPaymentUrl() );
+		$this->assertSame( '', $response->getTransactionId() );
+
+		$response->setPaymentUrl( 'foo.com' );
+		$response->setTransactionId( '12345' );
+
+		$this->assertEquals( 'foo.com', $response->getPaymentUrl() );
+		$this->assertEquals( '12345', $response->getTransactionId() );
+	}
+}

--- a/tests/Unit/Presentation/SofortUrlGeneratorTest.php
+++ b/tests/Unit/Presentation/SofortUrlGeneratorTest.php
@@ -13,12 +13,7 @@ use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
 class SofortUrlGeneratorTest extends TestCase {
 
 	public function testGenerateUrlSuccess(): void {
-		$config = SofortUrlConfig::newFromConfig( [
-			'config-key' => 'fff',
-			'item-name' => 'Donation',
-			'return-url' => 'https://us.org/yes',
-			'cancel-url' => 'https://us.org/no'
-		] );
+		$config = new SofortUrlConfig( 'Donation','https://us.org/yes','https://us.org/no' );
 
 		$api = $this->createMock( Sofortueberweisung::class );
 		$api
@@ -74,12 +69,7 @@ class SofortUrlGeneratorTest extends TestCase {
 	}
 
 	public function testGenerateUrlApiError(): void {
-		$config = SofortUrlConfig::newFromConfig( [
-			'config-key' => 'ggg',
-			'item-name' => 'Buy',
-			'return-url' => 'https://irreleva.nt',
-			'cancel-url' => 'http://irreleva.nt'
-		] );
+		$config = new SofortUrlConfig( 'Your purchase','https://irreleva.nt','http://irreleva.nt' );
 
 		$api = $this->createMock( Sofortueberweisung::class );
 

--- a/tests/Unit/Presentation/SofortUrlGeneratorTest.php
+++ b/tests/Unit/Presentation/SofortUrlGeneratorTest.php
@@ -13,6 +13,9 @@ use WMDE\Fundraising\Frontend\Infrastructure\Sofort\Transfer\Response;
 use WMDE\Fundraising\Frontend\Presentation\SofortUrlConfig;
 use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
 
+/**
+ * @covers \WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator
+ */
 class SofortUrlGeneratorTest extends TestCase {
 
 	public function testWhenClientReturnsSuccessResponseAUrlIsReturned(): void {

--- a/tests/Unit/Presentation/SofortUrlGeneratorTest.php
+++ b/tests/Unit/Presentation/SofortUrlGeneratorTest.php
@@ -13,7 +13,12 @@ use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
 class SofortUrlGeneratorTest extends TestCase {
 
 	public function testGenerateUrlSuccess(): void {
-		$config = new SofortUrlConfig( 'fff', 'Donation', 'https://us.org/yes', 'https://us.org/no' );
+		$config = SofortUrlConfig::newFromConfig( [
+			'config-key' => 'fff',
+			'item-name' => 'Donation',
+			'return-url' => 'https://us.org/yes',
+			'cancel-url' => 'https://us.org/no'
+		] );
 
 		$api = $this->createMock( Sofortueberweisung::class );
 		$api
@@ -29,12 +34,12 @@ class SofortUrlGeneratorTest extends TestCase {
 		$api
 			->expects( $this->once() )
 			->method( 'setReason' )
-			->with( 'Donation', 'idofdonation' )
+			->with( 'Donation', 529836 )
 			->willReturnSelf();
 		$api
 			->expects( $this->once() )
 			->method( 'setSuccessUrl' )
-			->with( 'https://us.org/yes?id=idofdonation&accessToken=letmein', true )
+			->with( 'https://us.org/yes?id=529836&accessToken=letmein', true )
 			->willReturnSelf();
 		$api
 			->expects( $this->once() )
@@ -64,12 +69,17 @@ class SofortUrlGeneratorTest extends TestCase {
 		$sut = new SofortUrlGenerator( $config, $api );
 		$this->assertSame(
 			'https://awsomepaymentprovider.tld/784trhhrf4',
-			$sut->generateUrl( 'idofdonation', Euro::newFromCents( 500 ), 'letmein' )
+			$sut->generateUrl( 529836, Euro::newFromCents( 500 ), 'letmein' )
 		);
 	}
 
 	public function testGenerateUrlApiError(): void {
-		$config = new SofortUrlConfig( 'ggg', 'Buy', 'https://irreleva.nt', 'http://irreleva.nt' );
+		$config = SofortUrlConfig::newFromConfig( [
+			'config-key' => 'ggg',
+			'item-name' => 'Buy',
+			'return-url' => 'https://irreleva.nt',
+			'cancel-url' => 'http://irreleva.nt'
+		] );
 
 		$api = $this->createMock( Sofortueberweisung::class );
 
@@ -87,6 +97,6 @@ class SofortUrlGeneratorTest extends TestCase {
 		$this->expectException( \RuntimeException::class );
 		$this->expectExceptionMessage( 'Could not generate Sofort URL: boo boo' );
 
-		$sut->generateUrl( 'idofdonation', Euro::newFromCents( 300 ), 'letmein' );
+		$sut->generateUrl( 529837, Euro::newFromCents( 300 ), 'letmein' );
 	}
 }

--- a/tests/Unit/Presentation/SofortUrlGeneratorTest.php
+++ b/tests/Unit/Presentation/SofortUrlGeneratorTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\Unit\Presentation;
 
+use RuntimeException;
 use PHPUnit\Framework\TestCase;
 use Sofort\SofortLib\Sofortueberweisung;
 use WMDE\Euro\Euro;
@@ -12,7 +13,7 @@ use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
 
 class SofortUrlGeneratorTest extends TestCase {
 
-	public function testGenerateUrlSuccess(): void {
+	public function testWhenApiReturnsSuccessfullyAUrlIsReturned(): void {
 		$config = new SofortUrlConfig( 'Donation', 'https://us.org/yes', 'https://us.org/no' );
 
 		$api = $this->createMock( Sofortueberweisung::class );
@@ -61,14 +62,14 @@ class SofortUrlGeneratorTest extends TestCase {
 			->method( 'getPaymentUrl' )
 			->willReturn( 'https://awsomepaymentprovider.tld/784trhhrf4' );
 
-		$sut = new SofortUrlGenerator( $config, $api );
+		$urlGenerator = new SofortUrlGenerator( $config, $api );
 		$this->assertSame(
 			'https://awsomepaymentprovider.tld/784trhhrf4',
-			$sut->generateUrl( 529836, Euro::newFromCents( 500 ), 'letmein' )
+			$urlGenerator->generateUrl( 529836, Euro::newFromCents( 500 ), 'letmein' )
 		);
 	}
 
-	public function testGenerateUrlApiError(): void {
+	public function testWhenApiReturnsErrorAnExceptionWithApiErrorMessageIsThrown(): void {
 		$config = new SofortUrlConfig( 'Your purchase', 'https://irreleva.nt', 'http://irreleva.nt' );
 
 		$api = $this->createMock( Sofortueberweisung::class );
@@ -82,11 +83,11 @@ class SofortUrlGeneratorTest extends TestCase {
 			->method( 'getError' )
 			->willReturn( 'boo boo' );
 
-		$sut = new SofortUrlGenerator( $config, $api );
+		$urlGenerator = new SofortUrlGenerator( $config, $api );
 
-		$this->expectException( \RuntimeException::class );
+		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( 'Could not generate Sofort URL: boo boo' );
 
-		$sut->generateUrl( 529837, Euro::newFromCents( 300 ), 'letmein' );
+		$urlGenerator->generateUrl( 529837, Euro::newFromCents( 300 ), 'letmein' );
 	}
 }

--- a/tests/Unit/Presentation/SofortUrlGeneratorTest.php
+++ b/tests/Unit/Presentation/SofortUrlGeneratorTest.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
 class SofortUrlGeneratorTest extends TestCase {
 
 	public function testGenerateUrlSuccess(): void {
-		$config = new SofortUrlConfig( 'Donation','https://us.org/yes','https://us.org/no' );
+		$config = new SofortUrlConfig( 'Donation', 'https://us.org/yes', 'https://us.org/no' );
 
 		$api = $this->createMock( Sofortueberweisung::class );
 		$api
@@ -69,7 +69,7 @@ class SofortUrlGeneratorTest extends TestCase {
 	}
 
 	public function testGenerateUrlApiError(): void {
-		$config = new SofortUrlConfig( 'Your purchase','https://irreleva.nt','http://irreleva.nt' );
+		$config = new SofortUrlConfig( 'Your purchase', 'https://irreleva.nt', 'http://irreleva.nt' );
 
 		$api = $this->createMock( Sofortueberweisung::class );
 

--- a/tests/Unit/Presentation/SofortUrlGeneratorTest.php
+++ b/tests/Unit/Presentation/SofortUrlGeneratorTest.php
@@ -26,8 +26,8 @@ class SofortUrlGeneratorTest extends TestCase {
 		$request = new Request();
 		$request->setAmount( $amount );
 		$request->setCurrencyCode( 'EUR' );
-		$request->setReasons( [ 'Donation', '529836' ] );
-		$request->setSuccessUrl( 'https://us.org/yes?id=529836&accessToken=letmein' );
+		$request->setReasons( [ 'Donation', 'wx529836' ] );
+		$request->setSuccessUrl( 'https://us.org/yes?id=44&accessToken=letmein' );
 		$request->setAbortUrl( 'https://us.org/no' );
 		$request->setNotificationUrl( '' );
 
@@ -45,7 +45,7 @@ class SofortUrlGeneratorTest extends TestCase {
 		$urlGenerator = new SofortUrlGenerator( $config, $client );
 		$this->assertSame(
 			'https://awsomepaymentprovider.tld/784trhhrf4',
-			$urlGenerator->generateUrl( 529836, $amount, 'letmein' )
+			$urlGenerator->generateUrl( 44, 'wx529836', $amount, 'letmein' )
 		);
 	}
 
@@ -65,6 +65,6 @@ class SofortUrlGeneratorTest extends TestCase {
 		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( 'Could not generate Sofort URL: boo boo' );
 
-		$urlGenerator->generateUrl( 529837, Euro::newFromCents( 300 ), 'letmein' );
+		$urlGenerator->generateUrl( 23, 'dq529837', Euro::newFromCents( 300 ), 'letmein' );
 	}
 }

--- a/tests/Unit/Presentation/SofortUrlGeneratorTest.php
+++ b/tests/Unit/Presentation/SofortUrlGeneratorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Presentation;
+
+use PHPUnit\Framework\TestCase;
+use Sofort\SofortLib\Sofortueberweisung;
+use WMDE\Euro\Euro;
+use WMDE\Fundraising\Frontend\Presentation\SofortUrlConfig;
+use WMDE\Fundraising\Frontend\Presentation\SofortUrlGenerator;
+
+class SofortUrlGeneratorTest extends TestCase {
+
+	public function testGenerateUrlSuccess(): void {
+		$config = new SofortUrlConfig( 'fff', 'Donation', 'https://us.org/yes', 'https://us.org/no' );
+
+		$api = $this->createMock( Sofortueberweisung::class );
+		$api
+			->expects( $this->once() )
+			->method( 'setAmount' )
+			->with( '5.00' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setCurrencyCode' )
+			->with( 'EUR' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setReason' )
+			->with( 'Donation', 'idofdonation' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setSuccessUrl' )
+			->with( 'https://us.org/yes?id=idofdonation&accessToken=letmein', true )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'setAbortUrl' )
+			->with( 'https://us.org/no' )
+			->willReturnSelf();
+		$api
+			->expects( $this->once() )
+			->method( 'sendRequest' )
+			->willReturn( null );
+		$api
+			->expects( $this->once() )
+			->method( 'isError' )
+			->willReturn( false );
+		$api
+			->expects( $this->never() )
+			->method( 'getError' );
+		$api
+			->expects( $this->once() )
+			->method( 'getTransactionId' )
+			->willReturn( 'tr4ns4ct10n' );
+		$api
+			->expects( $this->once() )
+			->method( 'getPaymentUrl' )
+			->willReturn( 'https://awsomepaymentprovider.tld/784trhhrf4' );
+
+		$sut = new SofortUrlGenerator( $config, $api );
+		$this->assertSame(
+			'https://awsomepaymentprovider.tld/784trhhrf4',
+			$sut->generateUrl( 'idofdonation', Euro::newFromCents( 500 ), 'letmein' )
+		);
+	}
+
+	public function testGenerateUrlApiError(): void {
+		$config = new SofortUrlConfig( 'ggg', 'Buy', 'https://irreleva.nt', 'http://irreleva.nt' );
+
+		$api = $this->createMock( Sofortueberweisung::class );
+
+		$api
+			->expects( $this->once() )
+			->method( 'isError' )
+			->willReturn( true );
+		$api
+			->expects( $this->once() )
+			->method( 'getError' )
+			->willReturn( 'boo boo' );
+
+		$sut = new SofortUrlGenerator( $config, $api );
+
+		$this->expectException( \RuntimeException::class );
+		$this->expectExceptionMessage( 'Could not generate Sofort URL: boo boo' );
+
+		$sut->generateUrl( 'idofdonation', Euro::newFromCents( 300 ), 'letmein' );
+	}
+}

--- a/tests/Unit/Validation/PaymentDataValidatorTest.php
+++ b/tests/Unit/Validation/PaymentDataValidatorTest.php
@@ -9,7 +9,7 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PaymentType;
 use WMDE\Fundraising\Frontend\Validation\PaymentDataValidator;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Validation\PaymentDataValidator
+ * @covers \WMDE\Fundraising\Frontend\Validation\PaymentDataValidator
  *
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
@@ -22,69 +22,69 @@ class PaymentDataValidatorTest extends \PHPUnit\Framework\TestCase {
 
 	public function testGivenAmountWithinLimits_validationSucceeds() {
 		$validator = $this->newPaymentValidator();
-		$this->assertTrue( $validator->validate( 50, PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertTrue( $validator->validate( 50, 'UEB' )->isSuccessful() );
 	}
 
 	public function testGivenAmountTooLow_validationFails() {
 		$validator = $this->newPaymentValidator();
-		$this->assertFalse( $validator->validate( 0.2, PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertFalse( $validator->validate( 0.2, 'UEB' )->isSuccessful() );
 	}
 
 	public function testGivenAmountTooHigh_validationFails() {
 		$validator = $this->newPaymentValidator();
-		$this->assertFalse( $validator->validate( 100000, PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertFalse( $validator->validate( 100000, 'UEB' )->isSuccessful() );
 	}
 
 	public function testGivenAmountIsNotANumber_validationFails() {
 		$validator = $this->newPaymentValidator();
-		$this->assertFalse( $validator->validate( 'much money', PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertFalse( $validator->validate( 'much money', 'UEB' )->isSuccessful() );
 	}
 
 	public function testGivenPaymentTypeSpecificLimits_differentPaymentTypeUsesMainLimit() {
-		$validator = new PaymentDataValidator( 1, 100000, [ PaymentType::DIRECT_DEBIT => 100, PaymentType::PAYPAL => 200 ] );
-		$this->assertTrue( $validator->validate( 50, PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$validator = new PaymentDataValidator( 1, 100000, [ 'UEB', 'BEZ', 'PPL' ], [ 'BEZ' => 100, 'PPL' => 200 ] );
+		$this->assertTrue( $validator->validate( 50, 'UEB' )->isSuccessful() );
 	}
 
 	public function testGivenPaymentWithTypeSpecificLimits_specificLimitIsUsed() {
-		$validator = new PaymentDataValidator( 10, 100000, [ PaymentType::DIRECT_DEBIT => 50, PaymentType::BANK_TRANSFER => 100 ] );
+		$validator = new PaymentDataValidator( 10, 100000, [ 'UEB', 'BEZ', 'PPL' ], [ 'BEZ' => 50, 'UEB' => 100 ] );
 
-		$this->assertTrue( $validator->validate( 60, PaymentType::DIRECT_DEBIT )->isSuccessful() );
-		$this->assertFalse( $validator->validate( 40, PaymentType::DIRECT_DEBIT )->isSuccessful() );
+		$this->assertTrue( $validator->validate( 60, 'BEZ' )->isSuccessful() );
+		$this->assertFalse( $validator->validate( 40, 'BEZ' )->isSuccessful() );
 	}
 
 	public function testNumberEqualToBoundIsAllowed() {
 		$validator = $this->newPaymentValidator();
-		$this->assertTrue( $validator->validate( 1, PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertTrue( $validator->validate( 1, 'UEB' )->isSuccessful() );
 	}
 
 	public function testStringNotationBelowLowerBoundIsNotAllowed() {
 		$validator = $this->newPaymentValidator();
-		$this->assertFalse( $validator->validate( '0.1', PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertFalse( $validator->validate( '0.1', 'UEB' )->isSuccessful() );
 	}
 
 	public function testStringNotationAboveLowerBoundIsAllowed() {
 		$validator = $this->newPaymentValidator();
-		$this->assertTrue( $validator->validate( '1.1', PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertTrue( $validator->validate( '1.1', 'UEB' )->isSuccessful() );
 	}
 
 	public function testNumberEqualToUpperBoundIsNotAllowed() {
 		$validator = $this->newPaymentValidator();
-		$this->assertFalse( $validator->validate( 100000, PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertFalse( $validator->validate( 100000, 'UEB' )->isSuccessful() );
 	}
 
 	public function testStringNotationAboveUpperBoundIsNotAllowed() {
 		$validator = $this->newPaymentValidator();
-		$this->assertFalse( $validator->validate( '123456.78', PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertFalse( $validator->validate( '123456.78', 'UEB' )->isSuccessful() );
 	}
 
 	public function testStringNotationBelowUpperBoundIsAllowed() {
 		$validator = $this->newPaymentValidator();
-		$this->assertTrue( $validator->validate( '99999.99', PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertTrue( $validator->validate( '99999.99', 'UEB' )->isSuccessful() );
 	}
 
 	public function testBinaryNotationIsNotAllowed() {
 		$validator = $this->newPaymentValidator();
-		$this->assertFalse( $validator->validate( '0b10100111001', PaymentType::BANK_TRANSFER )->isSuccessful() );
+		$this->assertFalse( $validator->validate( '0b10100111001', 'UEB' )->isSuccessful() );
 	}
 
 	public function testUnknownPaymentMethodsAreNotAllowed() {
@@ -93,14 +93,18 @@ class PaymentDataValidatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	private function newPaymentValidator(): PaymentDataValidator {
-		return new PaymentDataValidator( self::MIN_DONATION_AMOUNT, self::MAX_DONATION_AMOUNT );
+		return new PaymentDataValidator(
+			self::MIN_DONATION_AMOUNT,
+			self::MAX_DONATION_AMOUNT,
+			[ 'UEB', 'BEZ', 'PPL' ]
+		);
 	}
 
 	public function testGivenEuroAmountWithinLimits_validationSucceeds() {
 		$this->assertTrue(
 			$this->newPaymentValidator()->validate(
 				Euro::newFromInt( 50 ),
-				PaymentType::BANK_TRANSFER
+				'UEB'
 			)->isSuccessful()
 		);
 	}


### PR DESCRIPTION
* sofort client facade
* refactored payment type validator to be not coupled to existing payment types (injection rather)
* (ajax) validate payment type only successfully when feature toggle says true
* support SUB

Contains all of the view/js implementation PR #909 (T167875), always rebased.
Depends on https://github.com/wmde/fundraising-frontend-content/pull/22