### PR TITLE
Phpdoc -> Type hint

### DIFF
--- a/cli/ConfigValidation/SchemaLoader.php
+++ b/cli/ConfigValidation/SchemaLoader.php
@@ -19,7 +19,7 @@ class SchemaLoader {
 		$this->fileFetcher = $fileFetcher;
 	}
 
-	public function loadSchema( $schema ): \stdClass {
+	public function loadSchema( string $schema ): \stdClass {
 		try {
 			$schemaString = $this->fileFetcher->fetchFile( $schema );
 		} catch ( FileFetchingException $e ) {

--- a/cli/ConfigValidation/ValidateConfigCommand.php
+++ b/cli/ConfigValidation/ValidateConfigCommand.php
@@ -90,7 +90,7 @@ class ValidateConfigCommand extends Command {
 		return $configReader->getConfigObject();
 	}
 
-	private function writeError( OutputInterface $output, string $message ) {
+	private function writeError( OutputInterface $output, string $message ): void {
 		$errOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
 		$errOutput->writeln( $message );
 	}

--- a/cli/ConfigValidation/ValidationErrorRenderer.php
+++ b/cli/ConfigValidation/ValidationErrorRenderer.php
@@ -18,7 +18,7 @@ class ValidationErrorRenderer {
 		$this->schema = $schema;
 	}
 
-	public function render( ValidationError $error ) {
+	public function render( ValidationError $error ): string {
 		switch ( $error->getCode() ) {
 			case \League\JsonGuard\ErrorCode::MISSING_REQUIRED:
 				$keys = array_keys( get_object_vars( $error->getValue() ) );

--- a/cli/FundraisingCli.php
+++ b/cli/FundraisingCli.php
@@ -24,15 +24,15 @@ class FundraisingCli {
 		$this->registerCommands();
 		return $this->app;
 	}
-	private function setApplicationInfo() {
+	private function setApplicationInfo(): void {
 		$this->app->setName( 'Fundraising Console' );
 		$this->app->setVersion( '2.0' );
 	}
-	private function registerCommands() {
+	private function registerCommands(): void {
 		$this->app->add( new ValidateConfigCommand() );
 		$this->app->add( new RenderMailTemplatesCommand() );
 	}
-	public function run() {
+	public function run(): void {
 		$this->newApplication()->run();
 	}
 

--- a/cli/RenderMailTemplatesCommand.php
+++ b/cli/RenderMailTemplatesCommand.php
@@ -30,7 +30,7 @@ class RenderMailTemplatesCommand extends Command {
 
 	private const NAME = 'dump-mail-tpl';
 
-	protected function configure() {
+	protected function configure(): void {
 		$this->setName( self::NAME )
 			->setDescription( 'Dump rendered Mail_* Twig templates' )
 			->setDefinition(
@@ -45,7 +45,7 @@ class RenderMailTemplatesCommand extends Command {
 			);
 	}
 
-	protected function execute( InputInterface $input, OutputInterface $output ) {
+	protected function execute( InputInterface $input, OutputInterface $output ): void {
 		$config = $this->getDefaultConfig();
 		$config['twig']['strict-variables'] = true;
 

--- a/contexts/DonationContext/src/DataAccess/DoctrineDonationEventLogger.php
+++ b/contexts/DonationContext/src/DataAccess/DoctrineDonationEventLogger.php
@@ -30,7 +30,7 @@ class DoctrineDonationEventLogger implements DonationEventLogger {
 		}
 	}
 
-	public function log( int $donationId, string $message ) {
+	public function log( int $donationId, string $message ): void {
 		try {
 			/** @var DoctrineDonation $donation */
 			$donation = $this->entityManager->find( DoctrineDonation::class, $donationId );

--- a/contexts/DonationContext/src/DataAccess/DoctrineDonationPrePersistSubscriber.php
+++ b/contexts/DonationContext/src/DataAccess/DoctrineDonationPrePersistSubscriber.php
@@ -33,7 +33,7 @@ class DoctrineDonationPrePersistSubscriber implements EventSubscriber {
 		return [ Events::prePersist ];
 	}
 
-	public function prePersist( LifecycleEventArgs $args ) {
+	public function prePersist( LifecycleEventArgs $args ): void {
 		$entity = $args->getObject();
 
 		if ( $entity instanceof Donation ) {

--- a/contexts/DonationContext/src/DataAccess/DoctrineDonationPrePersistSubscriber.php
+++ b/contexts/DonationContext/src/DataAccess/DoctrineDonationPrePersistSubscriber.php
@@ -54,7 +54,7 @@ class DoctrineDonationPrePersistSubscriber implements EventSubscriber {
 		}
 	}
 
-	private function isEmpty( $stringOrNull ): bool {
+	private function isEmpty( ?string $stringOrNull ): bool {
 		return $stringOrNull === null || $stringOrNull === '';
 	}
 

--- a/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
+++ b/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
@@ -44,7 +44,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		$this->entityManager = $entityManager;
 	}
 
-	public function storeDonation( Donation $donation ) {
+	public function storeDonation( Donation $donation ): void {
 		if ( $donation->getId() === null ) {
 			$this->insertDonation( $donation );
 		}
@@ -53,7 +53,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		}
 	}
 
-	private function insertDonation( Donation $donation ) {
+	private function insertDonation( Donation $donation ): void {
 		$doctrineDonation = new DoctrineDonation();
 		$this->updateDonationEntity( $doctrineDonation, $donation );
 
@@ -68,7 +68,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		$donation->assignId( $doctrineDonation->getId() );
 	}
 
-	private function updateDonation( Donation $donation ) {
+	private function updateDonation( Donation $donation ): void {
 		$doctrineDonation = $this->getDoctrineDonationById( $donation->getId() );
 
 		if ( $doctrineDonation === null ) {
@@ -86,7 +86,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		}
 	}
 
-	private function updateDonationEntity( DoctrineDonation $doctrineDonation, Donation $donation ) {
+	private function updateDonationEntity( DoctrineDonation $doctrineDonation, Donation $donation ): void {
 		$doctrineDonation->setId( $donation->getId() );
 		$this->updatePaymentInformation( $doctrineDonation, $donation );
 		$this->updateDonorInformation( $doctrineDonation, $donation->getDonor() );
@@ -99,7 +99,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		) );
 	}
 
-	private function updatePaymentInformation( DoctrineDonation $doctrineDonation, Donation $donation ) {
+	private function updatePaymentInformation( DoctrineDonation $doctrineDonation, Donation $donation ): void {
 		$doctrineDonation->setStatus( $donation->getStatus() );
 		$doctrineDonation->setAmount( $donation->getAmount()->getEuroString() );
 		$doctrineDonation->setPaymentIntervalInMonths( $donation->getPaymentIntervalInMonths() );
@@ -108,7 +108,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		$doctrineDonation->setBankTransferCode( $this->getBankTransferCode( $donation->getPaymentMethod() ) );
 	}
 
-	private function updateDonorInformation( DoctrineDonation $doctrineDonation, Donor $donor = null ) {
+	private function updateDonorInformation( DoctrineDonation $doctrineDonation, Donor $donor = null ): void {
 		if ( $donor === null ) {
 			if ( $doctrineDonation->getId() === null ) {
 				$doctrineDonation->setDonorFullName( 'Anonym' );
@@ -120,7 +120,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		}
 	}
 
-	private function updateComment( DoctrineDonation $doctrineDonation, DonationComment $comment = null ) {
+	private function updateComment( DoctrineDonation $doctrineDonation, DonationComment $comment = null ): void {
 		if ( $comment === null ) {
 			$doctrineDonation->setIsPublic( false );
 			$doctrineDonation->setComment( '' );

--- a/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
+++ b/contexts/DonationContext/src/DataAccess/DoctrineDonationRepository.php
@@ -198,7 +198,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		);
 	}
 
-	private function getDataFieldsFromPersonName( DonorName $name ) {
+	private function getDataFieldsFromPersonName( DonorName $name ): array {
 		return [
 			'adresstyp' => $name->getPersonType(),
 			'anrede' => $name->getSalutation(),
@@ -209,7 +209,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		];
 	}
 
-	private function getDataFieldsFromAddress( DonorAddress $address ) {
+	private function getDataFieldsFromAddress( DonorAddress $address ): array {
 		return [
 			'strasse' => $address->getStreetAddress(),
 			'plz' => $address->getPostalCode(),
@@ -218,7 +218,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		];
 	}
 
-	private function getDataFieldsFromPayPalData( PayPalData $payPalData ) {
+	private function getDataFieldsFromPayPalData( PayPalData $payPalData ): array {
 		return [
 			'paypal_payer_id' => $payPalData->getPayerId(),
 			'paypal_subscr_id' => $payPalData->getSubscriberId(),
@@ -240,7 +240,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		];
 	}
 
-	private function getDataFieldsFromCreditCardData( CreditCardTransactionData $ccData ) {
+	private function getDataFieldsFromCreditCardData( CreditCardTransactionData $ccData ): array {
 		return [
 			'ext_payment_id' => $ccData->getTransactionId(),
 			'ext_payment_status' => $ccData->getTransactionStatus(),
@@ -371,7 +371,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		return $address->freeze()->assertNoNullFields();
 	}
 
-	private function getBankDataFromEntity( DoctrineDonation $dd ) {
+	private function getBankDataFromEntity( DoctrineDonation $dd ): BankData {
 		$data = $dd->getDecodedData();
 
 		$bankData = new BankData();
@@ -426,7 +426,7 @@ class DoctrineDonationRepository implements DonationRepository {
 		return null;
 	}
 
-	private function getCreditCardDataFromEntity( DoctrineDonation $dd ) {
+	private function getCreditCardDataFromEntity( DoctrineDonation $dd ): CreditCardTransactionData {
 		$data = $dd->getDecodedData();
 
 		return ( new CreditCardTransactionData() )
@@ -442,7 +442,6 @@ class DoctrineDonationRepository implements DonationRepository {
 			->setCountryCode( $data['mcp_country'] ?? '' )
 			->setCurrencyCode( $data['mcp_currency'] ?? '' )
 			->freeze();
-
 	}
 
 	private function getCommentFromEntity( DoctrineDonation $dd ): ?DonationComment {

--- a/contexts/DonationContext/src/Domain/Model/Donation.php
+++ b/contexts/DonationContext/src/Domain/Model/Donation.php
@@ -67,7 +67,7 @@ class Donation {
 		$this->comment = $comment;
 	}
 
-	private function setStatus( string $status ) {
+	private function setStatus( string $status ): void {
 		if ( !$this->isValidStatus( $status ) ) {
 			throw new \InvalidArgumentException( 'Invalid donation status' );
 		}
@@ -97,7 +97,7 @@ class Donation {
 	 * @param int $id
 	 * @throws \RuntimeException
 	 */
-	public function assignId( int $id ) {
+	public function assignId( int $id ): void {
 		if ( $this->id !== null && $this->id !== $id ) {
 			throw new \RuntimeException( 'Id cannot be changed after initial assignment' );
 		}
@@ -140,7 +140,7 @@ class Donation {
 		return $this->comment;
 	}
 
-	public function addComment( DonationComment $comment ) {
+	public function addComment( DonationComment $comment ): void {
 		if ( $this->hasComment() ) {
 			throw new RuntimeException( 'Can only add a single comment to a donation' );
 		}
@@ -163,7 +163,7 @@ class Donation {
 	/**
 	 * @throws RuntimeException
 	 */
-	public function cancel() {
+	public function cancel(): void {
 		if ( $this->getPaymentType() !== PaymentType::DIRECT_DEBIT ) {
 			throw new RuntimeException( 'Can only cancel direct debit' );
 		}
@@ -178,7 +178,7 @@ class Donation {
 	/**
 	 * @throws RuntimeException
 	 */
-	public function confirmBooked() {
+	public function confirmBooked(): void {
 		if ( !$this->hasExternalPayment() ) {
 			throw new RuntimeException( 'Only external payments can be confirmed as booked' );
 		}
@@ -194,7 +194,7 @@ class Donation {
 		$this->status = self::STATUS_EXTERNAL_BOOKED;
 	}
 
-	private function makeCommentPrivate() {
+	private function makeCommentPrivate(): void {
 		$this->comment = new DonationComment(
 			$this->comment->getCommentText(),
 			false,
@@ -210,17 +210,17 @@ class Donation {
 		return $this->isIncomplete() || $this->needsModeration() || $this->isCancelled();
 	}
 
-	public function markForModeration() {
+	public function markForModeration(): void {
 		$this->status = self::STATUS_MODERATION;
 	}
 
-	public function notifyOfPolicyValidationFailure() {
+	public function notifyOfPolicyValidationFailure(): void {
 		if ( !$this->hasExternalPayment() ) {
 			$this->markForModeration();
 		}
 	}
 
-	public function notifyOfCommentValidationFailure() {
+	public function notifyOfCommentValidationFailure(): void {
 		$this->markForModeration();
 	}
 
@@ -233,7 +233,7 @@ class Donation {
 	 *
 	 * @throws RuntimeException
 	 */
-	public function addCreditCardData( CreditCardTransactionData $creditCardData ) {
+	public function addCreditCardData( CreditCardTransactionData $creditCardData ): void {
 		$paymentMethod = $this->payment->getPaymentMethod();
 
 		if ( !( $paymentMethod instanceof CreditCardPayment ) ) {
@@ -267,7 +267,7 @@ class Donation {
 		return $this->status === self::STATUS_CANCELLED;
 	}
 
-	public function markAsDeleted() {
+	public function markAsDeleted(): void {
 		$this->status = self::STATUS_CANCELLED;
 	}
 

--- a/contexts/DonationContext/src/Domain/Model/DonationTrackingInfo.php
+++ b/contexts/DonationContext/src/Domain/Model/DonationTrackingInfo.php
@@ -28,7 +28,7 @@ class DonationTrackingInfo {
 		return $this->tracking;
 	}
 
-	public function setTracking( string $tracking ) {
+	public function setTracking( string $tracking ): void {
 		$this->assertIsWritable();
 		$this->tracking = $tracking;
 	}
@@ -37,7 +37,7 @@ class DonationTrackingInfo {
 		return $this->source;
 	}
 
-	public function setSource( string $source ) {
+	public function setSource( string $source ): void {
 		$this->assertIsWritable();
 		$this->source = $source;
 	}
@@ -46,7 +46,7 @@ class DonationTrackingInfo {
 		return $this->totalImpressionCount;
 	}
 
-	public function setTotalImpressionCount( int $totalImpressionCount ) {
+	public function setTotalImpressionCount( int $totalImpressionCount ): void {
 		$this->assertIsWritable();
 		$this->totalImpressionCount = $totalImpressionCount;
 	}
@@ -55,7 +55,7 @@ class DonationTrackingInfo {
 		return $this->singleBannerImpressionCount;
 	}
 
-	public function setSingleBannerImpressionCount( int $singleBannerImpressionCount ) {
+	public function setSingleBannerImpressionCount( int $singleBannerImpressionCount ): void {
 		$this->assertIsWritable();
 		$this->singleBannerImpressionCount = $singleBannerImpressionCount;
 	}
@@ -64,7 +64,7 @@ class DonationTrackingInfo {
 		return $this->color;
 	}
 
-	public function setColor( string $color ) {
+	public function setColor( string $color ): void {
 		$this->assertIsWritable();
 		$this->color = $color;
 	}
@@ -73,7 +73,7 @@ class DonationTrackingInfo {
 		return $this->skin;
 	}
 
-	public function setSkin( string $skin ) {
+	public function setSkin( string $skin ): void {
 		$this->assertIsWritable();
 		$this->skin = $skin;
 	}
@@ -82,7 +82,7 @@ class DonationTrackingInfo {
 		return $this->layout;
 	}
 
-	public function setLayout( string $layout ) {
+	public function setLayout( string $layout ): void {
 		$this->assertIsWritable();
 		$this->layout = $layout;
 	}

--- a/contexts/DonationContext/src/Domain/Model/DonorAddress.php
+++ b/contexts/DonationContext/src/Domain/Model/DonorAddress.php
@@ -23,7 +23,7 @@ class DonorAddress {
 		return $this->streetAddress;
 	}
 
-	public function setStreetAddress( string $streetAddress ) {
+	public function setStreetAddress( string $streetAddress ): void {
 		$this->assertIsWritable();
 		$this->streetAddress = $streetAddress;
 	}
@@ -32,7 +32,7 @@ class DonorAddress {
 		return $this->postalCode;
 	}
 
-	public function setPostalCode( string $postalCode ) {
+	public function setPostalCode( string $postalCode ): void {
 		$this->assertIsWritable();
 		$this->postalCode = $postalCode;
 	}
@@ -41,7 +41,7 @@ class DonorAddress {
 		return $this->city;
 	}
 
-	public function setCity( string $city ) {
+	public function setCity( string $city ): void {
 		$this->assertIsWritable();
 		$this->city = $city;
 	}
@@ -50,7 +50,7 @@ class DonorAddress {
 		return $this->countryCode;
 	}
 
-	public function setCountryCode( string $countryCode ) {
+	public function setCountryCode( string $countryCode ): void {
 		$this->assertIsWritable();
 		$this->countryCode = $countryCode;
 	}

--- a/contexts/DonationContext/src/Domain/Model/DonorName.php
+++ b/contexts/DonationContext/src/Domain/Model/DonorName.php
@@ -49,7 +49,7 @@ class DonorName {
 		return $this->companyName;
 	}
 
-	public function setCompanyName( string $companyName ) {
+	public function setCompanyName( string $companyName ): void {
 		$this->assertIsWritable();
 		$this->companyName = $companyName;
 	}
@@ -58,7 +58,7 @@ class DonorName {
 		return $this->personType === self::PERSON_COMPANY ? self::COMPANY_SALUTATION : $this->salutation;
 	}
 
-	public function setSalutation( string $salutation ) {
+	public function setSalutation( string $salutation ): void {
 		$this->assertIsWritable();
 		$this->salutation = $salutation;
 	}
@@ -67,7 +67,7 @@ class DonorName {
 		return $this->title;
 	}
 
-	public function setTitle( string $title ) {
+	public function setTitle( string $title ): void {
 		$this->assertIsWritable();
 		$this->title = $title;
 	}
@@ -76,7 +76,7 @@ class DonorName {
 		return $this->firstName;
 	}
 
-	public function setFirstName( string $firstName ) {
+	public function setFirstName( string $firstName ): void {
 		$this->assertIsWritable();
 		$this->firstName = $firstName;
 	}
@@ -85,7 +85,7 @@ class DonorName {
 		return $this->lastName;
 	}
 
-	public function setLastName( string $lastName ) {
+	public function setLastName( string $lastName ): void {
 		$this->assertIsWritable();
 		$this->lastName = $lastName;
 	}

--- a/contexts/DonationContext/src/Domain/Repositories/CommentWithAmount.php
+++ b/contexts/DonationContext/src/Domain/Repositories/CommentWithAmount.php
@@ -20,7 +20,7 @@ class CommentWithAmount {
 	private $donationTime;
 	private $donationId;
 
-	public static function newInstance() {
+	public static function newInstance(): self {
 		return new self();
 	}
 

--- a/contexts/DonationContext/src/Domain/Repositories/DonationRepository.php
+++ b/contexts/DonationContext/src/Domain/Repositories/DonationRepository.php
@@ -22,7 +22,7 @@ interface DonationRepository {
 	 *
 	 * @throws StoreDonationException
 	 */
-	public function storeDonation( Donation $donation );
+	public function storeDonation( Donation $donation ): void;
 
 	/**
 	 * @param int $id

--- a/contexts/DonationContext/src/Domain/Repositories/GetDonationException.php
+++ b/contexts/DonationContext/src/Domain/Repositories/GetDonationException.php
@@ -10,7 +10,7 @@ namespace WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories;
  */
 class GetDonationException extends \RuntimeException {
 
-	public function __construct( \Exception $previous = null, $message = 'Could not get donation' ) {
+	public function __construct( \Exception $previous = null, string $message = 'Could not get donation' ) {
 		parent::__construct( $message, 0, $previous );
 	}
 

--- a/contexts/DonationContext/src/Domain/Repositories/StoreDonationException.php
+++ b/contexts/DonationContext/src/Domain/Repositories/StoreDonationException.php
@@ -10,7 +10,7 @@ namespace WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories;
  */
 class StoreDonationException extends \RuntimeException {
 
-	public function __construct( \Exception $previous = null, $message = 'Could not store donation' ) {
+	public function __construct( \Exception $previous = null, string $message = 'Could not store donation' ) {
 		parent::__construct( $message, 0, $previous );
 	}
 

--- a/contexts/DonationContext/src/Infrastructure/BestEffortDonationEventLogger.php
+++ b/contexts/DonationContext/src/Infrastructure/BestEffortDonationEventLogger.php
@@ -20,7 +20,7 @@ class BestEffortDonationEventLogger implements DonationEventLogger {
 		$this->logger = $logger;
 	}
 
-	public function log( int $donationId, string $message ) {
+	public function log( int $donationId, string $message ): void {
 		try {
 			$this->donationEventLogger->log( $donationId, $message );
 		} catch ( DonationEventLogException $e ) {

--- a/contexts/DonationContext/src/Infrastructure/DonationConfirmationMailer.php
+++ b/contexts/DonationContext/src/Infrastructure/DonationConfirmationMailer.php
@@ -22,7 +22,7 @@ class DonationConfirmationMailer {
 		$this->mailer = $mailer;
 	}
 
-	public function sendConfirmationMailFor( Donation $donation ) {
+	public function sendConfirmationMailFor( Donation $donation ): void {
 		$this->mailer->sendMail(
 			new EmailAddress( $donation->getDonor()->getEmailAddress() ),
 			$this->getConfirmationMailTemplateArguments( $donation )

--- a/contexts/DonationContext/src/Infrastructure/DonationEventLogger.php
+++ b/contexts/DonationContext/src/Infrastructure/DonationEventLogger.php
@@ -18,6 +18,6 @@ interface DonationEventLogger {
 	 *
 	 * @throws DonationEventLogException
 	 */
-	public function log( int $donationId, string $message );
+	public function log( int $donationId, string $message ): void;
 
 }

--- a/contexts/DonationContext/src/Infrastructure/LoggingDonationRepository.php
+++ b/contexts/DonationContext/src/Infrastructure/LoggingDonationRepository.php
@@ -36,7 +36,7 @@ class LoggingDonationRepository implements DonationRepository {
 	 *
 	 * @throws StoreDonationException
 	 */
-	public function storeDonation( Donation $donation ) {
+	public function storeDonation( Donation $donation ): void {
 		try {
 			$this->repository->storeDonation( $donation );
 		}

--- a/contexts/DonationContext/src/UseCases/AddDonation/AddDonationRequest.php
+++ b/contexts/DonationContext/src/UseCases/AddDonation/AddDonationRequest.php
@@ -51,7 +51,7 @@ class AddDonationRequest {
 		return $this->optIn;
 	}
 
-	public function setOptIn( string $optIn ) {
+	public function setOptIn( string $optIn ): void {
 		$this->optIn = $optIn;
 	}
 
@@ -59,7 +59,7 @@ class AddDonationRequest {
 		return $this->amount;
 	}
 
-	public function setAmount( Euro $amount ) {
+	public function setAmount( Euro $amount ): void {
 		$this->amount = $amount;
 	}
 
@@ -67,7 +67,7 @@ class AddDonationRequest {
 		return $this->paymentType;
 	}
 
-	public function setPaymentType( string $paymentType ) {
+	public function setPaymentType( string $paymentType ): void {
 		$this->paymentType = $paymentType;
 	}
 
@@ -75,7 +75,7 @@ class AddDonationRequest {
 		return $this->interval;
 	}
 
-	public function setInterval( int $interval ) {
+	public function setInterval( int $interval ): void {
 		$this->interval = $interval;
 	}
 
@@ -83,7 +83,7 @@ class AddDonationRequest {
 		return $this->bankData;
 	}
 
-	public function setBankData( BankData $bankData ) {
+	public function setBankData( BankData $bankData ): void {
 		$this->bankData = $bankData;
 	}
 
@@ -91,7 +91,7 @@ class AddDonationRequest {
 		return $this->tracking;
 	}
 
-	public function setTracking( string $tracking ) {
+	public function setTracking( string $tracking ): void {
 		$this->tracking = $tracking;
 	}
 
@@ -99,7 +99,7 @@ class AddDonationRequest {
 		return $this->source;
 	}
 
-	public function setSource( string $source ) {
+	public function setSource( string $source ): void {
 		$this->source = $source;
 	}
 
@@ -107,7 +107,7 @@ class AddDonationRequest {
 		return $this->totalImpressionCount;
 	}
 
-	public function setTotalImpressionCount( int $totalImpressionCount ) {
+	public function setTotalImpressionCount( int $totalImpressionCount ): void {
 		$this->totalImpressionCount = $totalImpressionCount;
 	}
 
@@ -115,7 +115,7 @@ class AddDonationRequest {
 		return $this->singleBannerImpressionCount;
 	}
 
-	public function setSingleBannerImpressionCount( int $singleBannerImpressionCount ) {
+	public function setSingleBannerImpressionCount( int $singleBannerImpressionCount ): void {
 		$this->singleBannerImpressionCount = $singleBannerImpressionCount;
 	}
 
@@ -144,7 +144,7 @@ class AddDonationRequest {
 		return $this->donorType;
 	}
 
-	public function setDonorType( string $donorType ) {
+	public function setDonorType( string $donorType ): void {
 		$this->donorType = $donorType;
 	}
 
@@ -152,7 +152,7 @@ class AddDonationRequest {
 		return $this->donorFirstName;
 	}
 
-	public function setDonorFirstName( string $donorFirstName ) {
+	public function setDonorFirstName( string $donorFirstName ): void {
 		$this->donorFirstName = $donorFirstName;
 	}
 
@@ -160,7 +160,7 @@ class AddDonationRequest {
 		return $this->donorLastName;
 	}
 
-	public function setDonorLastName( string $donorLastName ) {
+	public function setDonorLastName( string $donorLastName ): void {
 		$this->donorLastName = $donorLastName;
 	}
 
@@ -168,7 +168,7 @@ class AddDonationRequest {
 		return $this->donorSalutation;
 	}
 
-	public function setDonorSalutation( string $donorSalutation ) {
+	public function setDonorSalutation( string $donorSalutation ): void {
 		$this->donorSalutation = $donorSalutation;
 	}
 
@@ -176,7 +176,7 @@ class AddDonationRequest {
 		return $this->donorTitle;
 	}
 
-	public function setDonorTitle( string $donorTitle ) {
+	public function setDonorTitle( string $donorTitle ): void {
 		$this->donorTitle = $donorTitle;
 	}
 
@@ -184,7 +184,7 @@ class AddDonationRequest {
 		return $this->donorCompany;
 	}
 
-	public function setDonorCompany( string $donorCompany ) {
+	public function setDonorCompany( string $donorCompany ): void {
 		$this->donorCompany = $donorCompany;
 	}
 
@@ -192,7 +192,7 @@ class AddDonationRequest {
 		return $this->donorStreetAddress;
 	}
 
-	public function setDonorStreetAddress( string $donorStreetAddress ) {
+	public function setDonorStreetAddress( string $donorStreetAddress ): void {
 		$this->donorStreetAddress = $donorStreetAddress;
 	}
 
@@ -200,7 +200,7 @@ class AddDonationRequest {
 		return $this->donorPostalCode;
 	}
 
-	public function setDonorPostalCode( string $donorPostalCode ) {
+	public function setDonorPostalCode( string $donorPostalCode ): void {
 		$this->donorPostalCode = $donorPostalCode;
 	}
 
@@ -208,7 +208,7 @@ class AddDonationRequest {
 		return $this->donorCity;
 	}
 
-	public function setDonorCity( string $donorCity ) {
+	public function setDonorCity( string $donorCity ): void {
 		$this->donorCity = $donorCity;
 	}
 
@@ -216,7 +216,7 @@ class AddDonationRequest {
 		return $this->donorCountryCode;
 	}
 
-	public function setDonorCountryCode( string $donorCountryCode ) {
+	public function setDonorCountryCode( string $donorCountryCode ): void {
 		$this->donorCountryCode = $donorCountryCode;
 	}
 
@@ -224,7 +224,7 @@ class AddDonationRequest {
 		return $this->donorEmailAddress;
 	}
 
-	public function setDonorEmailAddress( string $donorEmailAddress ) {
+	public function setDonorEmailAddress( string $donorEmailAddress ): void {
 		$this->donorEmailAddress = $donorEmailAddress;
 	}
 

--- a/contexts/DonationContext/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -186,7 +186,7 @@ class AddDonationUseCase {
 	 *
 	 * @throws \RuntimeException
 	 */
-	private function sendDonationConfirmationEmail( Donation $donation ) {
+	private function sendDonationConfirmationEmail( Donation $donation ): void {
 		if ( $donation->getDonor() !== null && !$donation->hasExternalPayment() ) {
 			$this->mailer->sendConfirmationMailFor( $donation );
 		}

--- a/contexts/DonationContext/src/UseCases/AddDonation/AddDonationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/AddDonation/AddDonationUseCase.php
@@ -96,7 +96,7 @@ class AddDonationUseCase {
 		);
 	}
 
-	private function getPersonalInfoFromRequest( AddDonationRequest $request ) {
+	private function getPersonalInfoFromRequest( AddDonationRequest $request ): ?Donor {
 		if ( $request->donorIsAnonymous() ) {
 			return null;
 		}

--- a/contexts/DonationContext/src/UseCases/AddDonation/AddDonationValidator.php
+++ b/contexts/DonationContext/src/UseCases/AddDonation/AddDonationValidator.php
@@ -69,7 +69,7 @@ class AddDonationValidator {
 		return new Result( ...$this->violations );
 	}
 
-	private function validateAmount() {
+	private function validateAmount(): void {
 		// TODO validate without euro class, put conversion in PaymentDataValidator
 		$result = $this->paymentDataValidator->validate(
 			$this->request->getAmount()->getEuroFloat(),
@@ -83,11 +83,11 @@ class AddDonationValidator {
 		$this->addViolations( $violations );
 	}
 
-	private function addViolations( array $violations ) {
+	private function addViolations( array $violations ): void {
 		$this->violations = array_merge( $this->violations, $violations );
 	}
 
-	private function validateBankData() {
+	private function validateBankData(): void {
 		if ( $this->request->getPaymentType() !== PaymentType::DIRECT_DEBIT ) {
 			return;
 		}
@@ -100,7 +100,7 @@ class AddDonationValidator {
 		$this->validateFieldLength( $bankData->getBic(), Result::SOURCE_BIC );
 	}
 
-	private function validateDonorEmail() {
+	private function validateDonorEmail(): void {
 		if ( $this->request->donorIsAnonymous() ) {
 			return;
 		}
@@ -115,7 +115,7 @@ class AddDonationValidator {
 		}
 	}
 
-	private function validateDonorName() {
+	private function validateDonorName(): void {
 		if ( $this->request->donorIsAnonymous() ) {
 			return;
 		}
@@ -127,7 +127,7 @@ class AddDonationValidator {
 		}
 	}
 
-	private function validateCompanyName() {
+	private function validateCompanyName(): void {
 		if ( $this->request->getDonorCompany() === '' ) {
 			$this->violations[] = new ConstraintViolation(
 				$this->request->getDonorCompany(),
@@ -139,7 +139,7 @@ class AddDonationValidator {
 		}
 	}
 
-	private function validatePersonName() {
+	private function validatePersonName(): void {
 		$violations = [];
 
 		if ( $this->request->getDonorFirstName() === '' ) {
@@ -178,7 +178,7 @@ class AddDonationValidator {
 		$this->addViolations( $violations );
 	}
 
-	private function validateDonorAddress() {
+	private function validateDonorAddress(): void {
 		if ( $this->request->donorIsAnonymous() ) {
 			return;
 		}
@@ -236,7 +236,7 @@ class AddDonationValidator {
 		$this->addViolations( $violations );
 	}
 
-	private function validatePayment() {
+	private function validatePayment(): void {
 		if ( ! in_array( $this->request->getPaymentType(), PaymentType::getPaymentTypes() ) ) {
 			$this->violations[] = new ConstraintViolation(
 				$this->request->getPaymentType(),
@@ -246,13 +246,13 @@ class AddDonationValidator {
 		}
 	}
 
-	private function validateFieldLength( string $value, string $fieldName ) {
+	private function validateFieldLength( string $value, string $fieldName ): void {
 		if ( strlen( $value ) > $this->maximumFieldLengths[$fieldName] )  {
 			$this->violations[] = new ConstraintViolation( $value, Result::VIOLATION_WRONG_LENGTH, $fieldName );
 		}
 	}
 
-	private function validateTrackingData() {
+	private function validateTrackingData(): void {
 		$this->validateFieldLength( $this->request->getSource(), Result::SOURCE_TRACKING_SOURCE );
 		// validation of impression counts is not needed because input is converted to int
 		// validation of skin, color and layout is not needed because they are static legacy values and empty.

--- a/contexts/DonationContext/src/UseCases/AddDonation/ReferrerGeneralizer.php
+++ b/contexts/DonationContext/src/UseCases/AddDonation/ReferrerGeneralizer.php
@@ -22,7 +22,7 @@ class ReferrerGeneralizer {
 		$this->domainMap = $domainMap;
 	}
 
-	public function generalize( string $referrer ) {
+	public function generalize( string $referrer ): string {
 		$parsedUrl = parse_url( $referrer );
 		if ( array_key_exists( 'host', $parsedUrl ) && array_key_exists( $parsedUrl['host'], $this->domainMap ) ) {
 			return $this->domainMap[$parsedUrl['host']];

--- a/contexts/DonationContext/src/UseCases/CancelDonation/CancelDonationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/CancelDonation/CancelDonationUseCase.php
@@ -94,7 +94,7 @@ class CancelDonationUseCase {
 		);
 	}
 
-	private function sendConfirmationEmail( Donation $donation ) {
+	private function sendConfirmationEmail( Donation $donation ): void {
 		if ( $donation->getDonor() !== null ) {
 			$this->mailer->sendMail(
 				new EmailAddress( $donation->getDonor()->getEmailAddress() ),

--- a/contexts/DonationContext/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationResponse.php
+++ b/contexts/DonationContext/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationResponse.php
@@ -25,11 +25,11 @@ class CreditCardNotificationResponse {
 		$this->isSuccess = $isSuccess;
 	}
 
-	public static function newFailureResponse( string $errorMessage ) {
+	public static function newFailureResponse( string $errorMessage ): self {
 		return new self( 0, '', $errorMessage, false );
 	}
 
-	public static function newSuccessResponse( int $donationId, string $accessToken ) {
+	public static function newSuccessResponse( int $donationId, string $accessToken ): self {
 		return new self( $donationId, $accessToken, '', true );
 	}
 

--- a/contexts/DonationContext/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCase.php
@@ -44,7 +44,7 @@ class CreditCardNotificationUseCase {
 	 * @param CreditCardPaymentNotificationRequest $request
 	 * @throws CreditCardPaymentHandlerException
 	 */
-	public function handleNotification( CreditCardPaymentNotificationRequest $request ) {
+	public function handleNotification( CreditCardPaymentNotificationRequest $request ): void {
 		try {
 			$donation = $this->repository->getDonationById( $request->getDonationId() );
 		} catch ( GetDonationException $ex ) {
@@ -70,11 +70,7 @@ class CreditCardNotificationUseCase {
 		$this->handleRequest( $request, $donation );
 	}
 
-	/**
-	 * @param CreditCardPaymentNotificationRequest $request
-	 * @param \WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation $donation
-	 */
-	private function handleRequest( CreditCardPaymentNotificationRequest $request, Donation $donation ) {
+	private function handleRequest( CreditCardPaymentNotificationRequest $request, Donation $donation ): void {
 		try {
 			$donation->addCreditCardData( $this->newCreditCardDataFromRequest( $request ) );
 			$donation->confirmBooked();
@@ -93,7 +89,7 @@ class CreditCardNotificationUseCase {
 		$this->donationEventLogger->log( $donation->getId(), 'mcp_handler: booked' );
 	}
 
-	private function sendConfirmationEmail( Donation $donation ) {
+	private function sendConfirmationEmail( Donation $donation ): void {
 		if ( $donation->getDonor() !== null ) {
 			try {
 				$this->mailer->sendConfirmationMailFor( $donation );

--- a/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
@@ -120,7 +120,7 @@ class HandlePayPalPaymentNotificationUseCase {
 		] );
 	}
 
-	private function sendConfirmationEmailFor( Donation $donation ) {
+	private function sendConfirmationEmailFor( Donation $donation ): void {
 		if ( $donation->getDonor() !== null ) {
 			try {
 				$this->mailer->sendConfirmationMailFor( $donation );
@@ -202,7 +202,7 @@ class HandlePayPalPaymentNotificationUseCase {
 		return PaypalNotificationResponse::newSuccessResponse();
 	}
 
-	private function logChildDonationCreatedEvent( $parentId, $childId ) {
+	private function logChildDonationCreatedEvent( $parentId, $childId ): void {
 		$this->donationEventLogger->log(
 			$parentId,
 			"paypal_handler: new transaction id to corresponding child donation: $childId"

--- a/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCase.php
@@ -202,7 +202,7 @@ class HandlePayPalPaymentNotificationUseCase {
 		return PaypalNotificationResponse::newSuccessResponse();
 	}
 
-	private function logChildDonationCreatedEvent( $parentId, $childId ): void {
+	private function logChildDonationCreatedEvent( $parentId, $childId ): void {	// @codingStandardsIgnoreLine
 		$this->donationEventLogger->log(
 			$parentId,
 			"paypal_handler: new transaction id to corresponding child donation: $childId"

--- a/contexts/DonationContext/src/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCase.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\Frontend\DonationContext\UseCases\ShowDonationConfirm
 
 use WMDE\Fundraising\Frontend\DonationContext\Authorization\DonationAuthorizer;
 use WMDE\Fundraising\Frontend\DonationContext\Authorization\DonationTokenFetcher;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\DonationRepository;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\GetDonationException;
 
@@ -41,7 +42,7 @@ class ShowDonationConfirmationUseCase {
 		return ShowDonationConfirmationResponse::newNotAllowedResponse();
 	}
 
-	private function getDonationById( int $donationId ) {
+	private function getDonationById( int $donationId ): ?Donation {
 		try {
 			return $this->donationRepository->getDonationById( $donationId );
 		}

--- a/contexts/DonationContext/tests/Data/IncompleteDoctrineDonation.php
+++ b/contexts/DonationContext/tests/Data/IncompleteDoctrineDonation.php
@@ -29,7 +29,7 @@ class IncompleteDoctrineDonation {
 		return ( new self() )->createCreditcardDonationWithMissingFields();
 	}
 
-	private function createPaypalDonationWithMissingFields() {
+	private function createPaypalDonationWithMissingFields(): Donation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );
@@ -45,7 +45,7 @@ class IncompleteDoctrineDonation {
 		return $donation;
 	}
 
-	private function createPaypalDonationWithMissingTrackingData() {
+	private function createPaypalDonationWithMissingTrackingData(): Donation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );
@@ -60,7 +60,7 @@ class IncompleteDoctrineDonation {
 		return $donation;
 	}
 
-	private function createDirectDebitDonationWithMissingFields() {
+	private function createDirectDebitDonationWithMissingFields(): Donation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );
@@ -75,7 +75,7 @@ class IncompleteDoctrineDonation {
 		return $donation;
 	}
 
-	private function createCreditcardDonationWithMissingFields() {
+	private function createCreditcardDonationWithMissingFields(): Donation {
 		$donation = new Donation();
 		$this->setPaymentData( $donation );
 		$this->setDonorData( $donation );

--- a/contexts/DonationContext/tests/Data/IncompleteDoctrineDonation.php
+++ b/contexts/DonationContext/tests/Data/IncompleteDoctrineDonation.php
@@ -90,12 +90,12 @@ class IncompleteDoctrineDonation {
 		return $donation;
 	}
 
-	private function setPaymentData( Donation $donation ) {
+	private function setPaymentData( Donation $donation ): void {
 		$donation->setAmount( (string)ValidDonation::DONATION_AMOUNT );
 		$donation->setPaymentIntervalInMonths( ValidDonation::PAYMENT_INTERVAL_IN_MONTHS );
 	}
 
-	private function setDonorData( Donation $donation ) {
+	private function setDonorData( Donation $donation ): void {
 		$donation->setDonorCity( ValidDonation::DONOR_CITY );
 		$donation->setDonorEmail( ValidDonation::DONOR_EMAIL_ADDRESS );
 		$donation->setDonorFullName( ValidDonation::DONOR_FULL_NAME );

--- a/contexts/DonationContext/tests/Data/ValidAddDonationRequest.php
+++ b/contexts/DonationContext/tests/Data/ValidAddDonationRequest.php
@@ -40,7 +40,7 @@ class ValidAddDonationRequest {
 		return $request;
 	}
 
-	private static function newValidBankData() {
+	private static function newValidBankData(): BankData {
 		$bankData = new BankData();
 
 		$bankData->setAccount( ValidDonation::PAYMENT_BANK_ACCOUNT );

--- a/contexts/DonationContext/tests/Data/ValidDonation.php
+++ b/contexts/DonationContext/tests/Data/ValidDonation.php
@@ -129,7 +129,7 @@ class ValidDonation {
 		);
 	}
 
-	public static function newBookedCreditCardDonation() {
+	public static function newBookedCreditCardDonation(): Donation {
 		$creditCardData = new CreditCardTransactionData();
 		$creditCardData->setTransactionId( self::CREDIT_CARD_TRANSACTION_ID );
 
@@ -182,7 +182,7 @@ class ValidDonation {
 		);
 	}
 
-	private function createAnonymousDonationWithId( int $donationId, PaymentMethod $paymentMethod, string $status ) {
+	private function createAnonymousDonationWithId( int $donationId, PaymentMethod $paymentMethod, string $status ): Donation {
 		return new Donation(
 			$donationId,
 			$status,

--- a/contexts/DonationContext/tests/Fixtures/DonationEventLoggerSpy.php
+++ b/contexts/DonationContext/tests/Fixtures/DonationEventLoggerSpy.php
@@ -14,7 +14,7 @@ class DonationEventLoggerSpy implements DonationEventLogger {
 
 	private $logCalls = [];
 
-	public function log( int $donationId, string $message ) {
+	public function log( int $donationId, string $message ): void {
 		$this->logCalls[] = [ $donationId, $message ];
 	}
 

--- a/contexts/DonationContext/tests/Fixtures/DonationEventLoggerSpy.php
+++ b/contexts/DonationContext/tests/Fixtures/DonationEventLoggerSpy.php
@@ -18,7 +18,7 @@ class DonationEventLoggerSpy implements DonationEventLogger {
 		$this->logCalls[] = [ $donationId, $message ];
 	}
 
-	public function getLogCalls() {
+	public function getLogCalls(): array {
 		return $this->logCalls;
 	}
 

--- a/contexts/DonationContext/tests/Fixtures/DonationRepositorySpy.php
+++ b/contexts/DonationContext/tests/Fixtures/DonationRepositorySpy.php
@@ -21,7 +21,7 @@ class DonationRepositorySpy extends FakeDonationRepository {
 		$this->storeDonationCalls = []; // remove calls coming from initialization
 	}
 
-	public function storeDonation( Donation $donation ) {
+	public function storeDonation( Donation $donation ): void {
 		$this->storeDonationCalls[] = clone( $donation ); // protect against the donation being changed later
 		parent::storeDonation( $donation );
 	}

--- a/contexts/DonationContext/tests/Fixtures/FakeDonationRepository.php
+++ b/contexts/DonationContext/tests/Fixtures/FakeDonationRepository.php
@@ -26,15 +26,15 @@ class FakeDonationRepository implements DonationRepository {
 		}
 	}
 
-	public function throwOnRead() {
+	public function throwOnRead(): void {
 		$this->throwOnRead = true;
 	}
 
-	public function throwOnWrite() {
+	public function throwOnWrite(): void {
 		$this->throwOnWrite = true;
 	}
 
-	public function storeDonation( Donation $donation ) {
+	public function storeDonation( Donation $donation ): void {
 		if ( $this->throwOnWrite ) {
 			throw new StoreDonationException();
 		}

--- a/contexts/DonationContext/tests/Fixtures/ThrowingDonationRepository.php
+++ b/contexts/DonationContext/tests/Fixtures/ThrowingDonationRepository.php
@@ -18,11 +18,11 @@ class ThrowingDonationRepository implements DonationRepository {
 	private $throwOnStoreDonation;
 	private $onGetDonationById;
 
-	public function throwOnStoreDonation() {
+	public function throwOnStoreDonation(): void {
 		$this->throwOnStoreDonation = true;
 	}
 
-	public function throwOnGetDonationById() {
+	public function throwOnGetDonationById(): void {
 		$this->onGetDonationById = true;
 	}
 
@@ -35,7 +35,7 @@ class ThrowingDonationRepository implements DonationRepository {
 	 *
 	 * @throws StoreDonationException
 	 */
-	public function storeDonation( Donation $donation ) {
+	public function storeDonation( Donation $donation ): void {
 		if ( $this->throwOnStoreDonation ) {
 			throw new StoreDonationException();
 		}

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineCommentFinderTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineCommentFinderTest.php
@@ -26,7 +26,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $entityManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 		parent::setUp();
 	}
@@ -35,13 +35,13 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		return new DoctrineCommentFinder( $this->entityManager );
 	}
 
-	public function testWhenThereAreNoComments_anEmptyListIsReturned() {
+	public function testWhenThereAreNoComments_anEmptyListIsReturned(): void {
 		$repository = $this->newDbalCommentRepository();
 
 		$this->assertEmpty( $repository->getPublicComments( 10 ) );
 	}
 
-	public function testWhenThereAreLessCommentsThanTheLimit_theyAreAllReturned() {
+	public function testWhenThereAreLessCommentsThanTheLimit_theyAreAllReturned(): void {
 		$this->persistFirstDonationWithComment();
 		$this->persistSecondDonationWithComment();
 		$this->persistThirdDonationWithComment();
@@ -59,7 +59,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenThereAreMoreCommentsThanTheLimit_aLimitedNumberAreReturned() {
+	public function testWhenThereAreMoreCommentsThanTheLimit_aLimitedNumberAreReturned(): void {
 		$this->persistFirstDonationWithComment();
 		$this->persistSecondDonationWithComment();
 		$this->persistThirdDonationWithComment();
@@ -76,7 +76,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testOnlyPublicCommentsGetReturned() {
+	public function testOnlyPublicCommentsGetReturned(): void {
 		$this->persistFirstDonationWithComment();
 		$this->persistSecondDonationWithComment();
 		$this->persistDonationWithPrivateComment();
@@ -95,7 +95,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testOnlyNonDeletedCommentsGetReturned() {
+	public function testOnlyNonDeletedCommentsGetReturned(): void {
 		$this->persistFirstDonationWithComment();
 		$this->persistSecondDonationWithComment();
 		$this->persistDeletedDonationWithComment();
@@ -115,7 +115,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function persistFirstDonationWithComment() {
+	private function persistFirstDonationWithComment(): void {
 		$firstDonation = new Donation();
 		$firstDonation->setPublicRecord( 'First name' );
 		$firstDonation->setComment( 'First comment' );
@@ -125,7 +125,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		$this->entityManager->persist( $firstDonation );
 	}
 
-	private function persistSecondDonationWithComment() {
+	private function persistSecondDonationWithComment(): void {
 		$secondDonation = new Donation();
 		$secondDonation->setPublicRecord( 'Second name' );
 		$secondDonation->setComment( 'Second comment' );
@@ -135,7 +135,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		$this->entityManager->persist( $secondDonation );
 	}
 
-	private function persistThirdDonationWithComment() {
+	private function persistThirdDonationWithComment(): void {
 		$thirdDonation = new Donation();
 		$thirdDonation->setPublicRecord( 'Third name' );
 		$thirdDonation->setComment( 'Third comment' );
@@ -145,7 +145,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		$this->entityManager->persist( $thirdDonation );
 	}
 
-	private function persistDonationWithPrivateComment() {
+	private function persistDonationWithPrivateComment(): void {
 		$privateDonation = new Donation();
 		$privateDonation->setPublicRecord( 'Private name' );
 		$privateDonation->setComment( 'Private comment' );
@@ -155,7 +155,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		$this->entityManager->persist( $privateDonation );
 	}
 
-	private function persistDeletedDonationWithComment() {
+	private function persistDeletedDonationWithComment(): void {
 		$deletedDonation = new Donation();
 		$deletedDonation->setPublicRecord( 'Deleted name' );
 		$deletedDonation->setComment( 'Deleted comment' );
@@ -166,7 +166,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		$this->entityManager->persist( $deletedDonation );
 	}
 
-	private function persistDeletedDonationWithoutDeletedTimestamp() {
+	private function persistDeletedDonationWithoutDeletedTimestamp(): void {
 		$deletedDonation = new Donation();
 		$deletedDonation->setPublicRecord( 'Deleted name' );
 		$deletedDonation->setComment( 'Deleted comment' );
@@ -207,7 +207,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 			->freeze()->assertNoNullFields();
 	}
 
-	public function testDoctrineThrowsException_getPublicCommentsRethrowsAsDomainException() {
+	public function testDoctrineThrowsException_getPublicCommentsRethrowsAsDomainException(): void {
 		$repository = new DoctrineCommentFinder( $this->newThrowingEntityManager() );
 
 		$this->expectException( CommentListingException::class );
@@ -224,7 +224,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		return $entityManager;
 	}
 
-	public function testGivenOffsetOfOneCausesOneCommentToBeSkipped() {
+	public function testGivenOffsetOfOneCausesOneCommentToBeSkipped(): void {
 		$this->persistFirstDonationWithComment();
 		$this->persistSecondDonationWithComment();
 		$this->persistThirdDonationWithComment();
@@ -239,7 +239,7 @@ class DoctrineCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenOffsetBeyondResultSetCausesEmptyResult() {
+	public function testGivenOffsetBeyondResultSetCausesEmptyResult(): void {
 		$this->persistFirstDonationWithComment();
 		$this->persistSecondDonationWithComment();
 		$this->persistThirdDonationWithComment();

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationAuthorizerTest.php
@@ -46,7 +46,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @slowThreshold 400
 	 */
-	public function testWhenNoDonations() {
+	public function testWhenNoDonations(): void {
 		$this->specify( 'update authorization fails', function() {
 			$authorizer = $this->newAuthorizationServiceWithDonations( self::CORRECT_UPDATE_TOKEN );
 			$this->assertFalse( $authorizer->userCanModifyDonation( self::MEANINGLESS_DONATION_ID ) );
@@ -61,7 +61,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @slowThreshold 1200
 	 */
-	public function testWhenDonationWithTokenExists() {
+	public function testWhenDonationWithTokenExists(): void {
 		$donation = new Donation();
 		$donationData = $donation->getDataObject();
 		$donationData->setUpdateToken( self::CORRECT_UPDATE_TOKEN );
@@ -125,7 +125,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @slowThreshold 400
 	 */
-	public function testWhenDonationWithoutTokenExists() {
+	public function testWhenDonationWithoutTokenExists(): void {
 		$donation = new Donation();
 
 		$this->specify(
@@ -148,7 +148,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @slowThreshold 400
 	 */
-	public function testWhenUpdateTokenIsExpired() {
+	public function testWhenUpdateTokenIsExpired(): void {
 		$donation = new Donation();
 		$donationData = $donation->getDataObject();
 		$donationData->setUpdateToken( self::CORRECT_UPDATE_TOKEN );
@@ -179,7 +179,7 @@ class DoctrineDonationAuthorizerTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @slowThreshold 400
 	 */
-	public function testWhenDoctrineThrowsException() {
+	public function testWhenDoctrineThrowsException(): void {
 		$authorizer = new DoctrineDonationAuthorizer(
 			$this->getThrowingEntityManager(),
 			self::CORRECT_UPDATE_TOKEN,

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationEventLoggerTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationEventLoggerTest.php
@@ -24,18 +24,18 @@ class DoctrineDonationEventLoggerTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $entityManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 	}
 
-	public function testIfDonationDoesNotExistLoggingFails() {
+	public function testIfDonationDoesNotExistLoggingFails(): void {
 		$logger = new DoctrineDonationEventLogger( $this->entityManager, $this->getDefaultTimeFunction() );
 
 		$this->expectException( DonationEventLogException::class );
 		$logger->log( 1234, self::DEFAULT_MESSAGE );
 	}
 
-	public function testWhenPersistenceFails_domainExceptionIsThrown() {
+	public function testWhenPersistenceFails_domainExceptionIsThrown(): void {
 		$logger = new DoctrineDonationEventLogger(
 			ThrowingEntityManager::newInstance( $this ),
 			$this->getDefaultTimeFunction()
@@ -45,7 +45,7 @@ class DoctrineDonationEventLoggerTest extends \PHPUnit\Framework\TestCase {
 		$logger->log( 1234, self::DEFAULT_MESSAGE );
 	}
 
-	public function testWhenNoLogExists_logGetsAdded() {
+	public function testWhenNoLogExists_logGetsAdded(): void {
 		$donation = new Donation();
 		$this->entityManager->persist( $donation );
 		$this->entityManager->flush();
@@ -65,7 +65,7 @@ class DoctrineDonationEventLoggerTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $expectedLog, $data['log'] );
 	}
 
-	public function testWhenLogExists_logGetsAppended() {
+	public function testWhenLogExists_logGetsAppended(): void {
 		$donation = new Donation();
 		$donation->encodeAndSetData( [ 'log' => [ '2014-01-01 0:00:00' => 'New year!' ] ] );
 		$this->entityManager->persist( $donation );

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationEventLoggerTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationEventLoggerTest.php
@@ -92,7 +92,7 @@ class DoctrineDonationEventLoggerTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// always return fixed date
-	private function getDefaultTimeFunction() {
+	private function getDefaultTimeFunction(): callable {
 		return function() {
 			return self::LOG_TIMESTAMP;
 		};

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -294,7 +294,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( '', $paymentMethod->getBankData()->getIban()->toString() );
 	}
 
-	private function createDonationWithIncompleteBankData() {
+	private function createDonationWithIncompleteBankData(): ?int {
 		$doctrineDonation = IncompleteDoctrineDonation::newDirectDebitDonationWithMissingFields();
 		$this->entityManager->persist( $doctrineDonation );
 		$this->entityManager->flush();
@@ -311,7 +311,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( '', $paymentMethod->getCreditCardData()->getTitle() );
 	}
 
-	private function createDonationWithIncompleteCreditcardData() {
+	private function createDonationWithIncompleteCreditcardData(): ?int {
 		$doctrineDonation = IncompleteDoctrineDonation::newCreditcardDonationWithMissingFields();
 		$this->entityManager->persist( $doctrineDonation );
 		$this->entityManager->flush();

--- a/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/DoctrineDonationRepositoryTest.php
@@ -34,14 +34,14 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $entityManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		$factory = TestEnvironment::newInstance()->getFactory();
 		$factory->disableDoctrineSubscribers();
 		$this->entityManager = $factory->getEntityManager();
 		parent::setUp();
 	}
 
-	public function testValidDonationGetPersisted() {
+	public function testValidDonationGetPersisted(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$this->newRepository()->storeDonation( $donation );
@@ -56,7 +56,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return new DoctrineDonationRepository( $this->entityManager );
 	}
 
-	private function assertDoctrineEntityIsInDatabase( DoctrineDonation $expected ) {
+	private function assertDoctrineEntityIsInDatabase( DoctrineDonation $expected ): void {
 		$actual = $this->getDoctrineDonationById( $expected->getId() );
 
 		$this->assertNotNull( $actual->getCreationTime() );
@@ -74,7 +74,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $donation;
 	}
 
-	public function testWhenPersistenceFails_domainExceptionIsThrown() {
+	public function testWhenPersistenceFails_domainExceptionIsThrown(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$repository = new DoctrineDonationRepository( ThrowingEntityManager::newInstance( $this ) );
@@ -83,7 +83,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$repository->storeDonation( $donation );
 	}
 
-	public function testNewDonationPersistenceRoundTrip() {
+	public function testNewDonationPersistenceRoundTrip(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$repository = $this->newRepository();
@@ -96,7 +96,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenDonationAlreadyExists_persistingCausesUpdate() {
+	public function testWhenDonationAlreadyExists_persistingCausesUpdate(): void {
 		$repository = $this->newRepository();
 
 		$donation = ValidDonation::newDirectDebitDonation();
@@ -111,20 +111,20 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $newDonation, $repository->getDonationById( $newDonation->getId() ) );
 	}
 
-	public function testWhenDonationDoesNotExist_getDonationReturnsNull() {
+	public function testWhenDonationDoesNotExist_getDonationReturnsNull(): void {
 		$repository = $this->newRepository();
 
 		$this->assertNull( $repository->getDonationById( self::ID_OF_DONATION_NOT_IN_DB ) );
 	}
 
-	public function testWhenDoctrineThrowsException_domainExceptionIsThrown() {
+	public function testWhenDoctrineThrowsException_domainExceptionIsThrown(): void {
 		$repository = new DoctrineDonationRepository( ThrowingEntityManager::newInstance( $this ) );
 
 		$this->expectException( GetDonationException::class );
 		$repository->getDonationById( self::ID_OF_DONATION_NOT_IN_DB );
 	}
 
-	public function testWhenDonationDoesNotExist_persistingCausesException() {
+	public function testWhenDonationDoesNotExist_persistingCausesException(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 		$donation->assignId( self::ID_OF_DONATION_NOT_IN_DB );
 
@@ -134,7 +134,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$repository->storeDonation( $donation );
 	}
 
-	public function testWhenDeletionDateGetsSet_repositoryNoLongerReturnsEntity() {
+	public function testWhenDeletionDateGetsSet_repositoryNoLongerReturnsEntity(): void {
 		$donation = $this->createDeletedDonation();
 		$repository = $this->newRepository();
 
@@ -151,7 +151,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $donation;
 	}
 
-	public function testWhenDeletionDateGetsSet_repositoryNoLongerPersistsEntity() {
+	public function testWhenDeletionDateGetsSet_repositoryNoLongerPersistsEntity(): void {
 		$donation = $this->createDeletedDonation();
 		$repository = $this->newRepository();
 
@@ -159,7 +159,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$repository->storeDonation( $donation );
 	}
 
-	public function testDataFieldsAreRetainedOrUpdatedOnUpdate() {
+	public function testDataFieldsAreRetainedOrUpdatedOnUpdate(): void {
 		$doctrineDonation = $this->getNewlyCreatedDoctrineDonation();
 
 		$doctrineDonation->encodeAndSetData( array_merge(
@@ -188,7 +188,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * The backend application data purge script sets the personal information to empty strings
 	 */
-	public function testGivenPurgedDonationNoDonorIsCreated() {
+	public function testGivenPurgedDonationNoDonorIsCreated(): void {
 		$doctrineDonation = $this->getNewlyCreatedDoctrineDonation();
 		$doctrineDonation->setDtBackup( new \DateTime() );
 		$this->entityManager->persist( $doctrineDonation );
@@ -199,7 +199,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertNull( $donation->getDonor() );
 	}
 
-	public function testGivenDonationUpdateWithoutDonorInformation_DonorNameStaysTheSame() {
+	public function testGivenDonationUpdateWithoutDonorInformation_DonorNameStaysTheSame(): void {
 		$donation = ValidDonation::newBookedPayPalDonation();
 		$this->newRepository()->storeDonation( $donation );
 
@@ -217,7 +217,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $this->getDoctrineDonationById( $donation->getId() );
 	}
 
-	public function testCommentGetPersistedAndRetrieved() {
+	public function testCommentGetPersistedAndRetrieved(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 		$donation->addComment( ValidDonation::newPublicComment() );
 
@@ -229,7 +229,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $donation, $retrievedDonation );
 	}
 
-	public function testPersistingDonationWithoutCommentCausesCommentToBeCleared() {
+	public function testPersistingDonationWithoutCommentCausesCommentToBeCleared(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 		$donation->addComment( ValidDonation::newPublicComment() );
 
@@ -250,7 +250,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertDoctrineEntityIsInDatabase( $expectedDoctrineEntity );
 	}
 
-	public function testDonationWithIncompletePaypalDataCanBeLoaded() {
+	public function testDonationWithIncompletePaypalDataCanBeLoaded(): void {
 		$donationId = $this->createPaypalDonationWithMissingFields();
 		$repository = $this->newRepository();
 		$donation = $repository->getDonationById( $donationId );
@@ -267,7 +267,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $doctrineDonation->getId();
 	}
 
-	public function testDonationWithMissingTrackingInformationDataCanBeLoaded() {
+	public function testDonationWithMissingTrackingInformationDataCanBeLoaded(): void {
 		$donationId = $this->createPaypalDonationWithMissingTracking();
 		$repository = $this->newRepository();
 		$donation = $repository->getDonationById( $donationId );
@@ -284,7 +284,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $doctrineDonation->getId();
 	}
 
-	public function testDonationWithIncompleteBankDataCanBeLoaded() {
+	public function testDonationWithIncompleteBankDataCanBeLoaded(): void {
 		$donationId = $this->createDonationWithIncompleteBankData();
 		$repository = $this->newRepository();
 		$donation = $repository->getDonationById( $donationId );
@@ -301,7 +301,7 @@ class DoctrineDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $doctrineDonation->getId();
 	}
 
-	public function testDonationWithIncompleteCreditcardDataCanBeLoaded() {
+	public function testDonationWithIncompleteCreditcardDataCanBeLoaded(): void {
 		$donationId = $this->createDonationWithIncompleteCreditcardData();
 		$repository = $this->newRepository();
 		$donation = $repository->getDonationById( $donationId );

--- a/contexts/DonationContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -27,7 +27,7 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/** @dataProvider donationDataProvider */
-	public function testDataFieldOfDonationIsInteractedWithCorrectly( $paymentType, $data ): void {
+	public function testDataFieldOfDonationIsInteractedWithCorrectly( string $paymentType, array $data ): void {
 		$this->repository = new DoctrineDonationRepository( $this->entityManager );
 		$this->storeDonation( $paymentType, $data );
 
@@ -39,7 +39,7 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $data, $dd->getDecodedData() );
 	}
 
-	public function donationDataProvider() {
+	public function donationDataProvider(): array {
 		return [
 			[
 				'UEB',

--- a/contexts/DonationContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/contexts/DonationContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -22,12 +22,12 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 	/** @var DonationRepository */
 	private $repository;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 	}
 
 	/** @dataProvider donationDataProvider */
-	public function testDataFieldOfDonationIsInteractedWithCorrectly( $paymentType, $data ) {
+	public function testDataFieldOfDonationIsInteractedWithCorrectly( $paymentType, $data ): void {
 		$this->repository = new DoctrineDonationRepository( $this->entityManager );
 		$this->storeDonation( $paymentType, $data );
 
@@ -311,7 +311,7 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	private function storeDonation( string $paymentType, array $data ) {
+	private function storeDonation( string $paymentType, array $data ): void {
 		$dd = new Donation();
 		$dd->setDonorEmail( 'max.muster@mydomain.com' );
 		$dd->setAmount( '1.00' );

--- a/contexts/DonationContext/tests/Integration/DonationAcceptedEventHandlerTest.php
+++ b/contexts/DonationContext/tests/Integration/DonationAcceptedEventHandlerTest.php
@@ -40,7 +40,7 @@ class DonationAcceptedEventHandlerTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $mailer;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->authorizer = new SucceedingDonationAuthorizer();
 		$this->repository = new FakeDonationRepository( $this->newDonation() );
 		$this->mailer = $this->createMock( DonationConfirmationMailer::class );
@@ -52,7 +52,7 @@ class DonationAcceptedEventHandlerTest extends \PHPUnit\Framework\TestCase {
 		return $donation;
 	}
 
-	public function testWhenAuthorizationFails_errorIsReturned() {
+	public function testWhenAuthorizationFails_errorIsReturned(): void {
 		$this->authorizer = new FailingDonationAuthorizer();
 		$eventHandler = $this->newDonationAcceptedEventHandler();
 
@@ -69,7 +69,7 @@ class DonationAcceptedEventHandlerTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenIdOfUnknownDonation_errorIsReturned() {
+	public function testGivenIdOfUnknownDonation_errorIsReturned(): void {
 		$eventHandler = $this->newDonationAcceptedEventHandler();
 
 		$result = $eventHandler->onDonationAccepted( self::UNKNOWN_ID );
@@ -77,7 +77,7 @@ class DonationAcceptedEventHandlerTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( DonationAcceptedEventHandler::UNKNOWN_ID_PROVIDED, $result );
 	}
 
-	public function testGivenKnownIdAndValidAuth_successIsReturned() {
+	public function testGivenKnownIdAndValidAuth_successIsReturned(): void {
 		$eventHandler = $this->newDonationAcceptedEventHandler();
 
 		$result = $eventHandler->onDonationAccepted( self::KNOWN_ID );
@@ -85,7 +85,7 @@ class DonationAcceptedEventHandlerTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( DonationAcceptedEventHandler::SUCCESS, $result );
 	}
 
-	public function testGivenKnownIdAndValidAuth_mailerIsInvoked() {
+	public function testGivenKnownIdAndValidAuth_mailerIsInvoked(): void {
 		$this->mailer->expects( $this->once() )
 			->method( 'sendConfirmationMailFor' )
 			->with( $this->equalTo( $this->newDonation() ) );
@@ -93,12 +93,12 @@ class DonationAcceptedEventHandlerTest extends \PHPUnit\Framework\TestCase {
 		$this->newDonationAcceptedEventHandler()->onDonationAccepted( self::KNOWN_ID );
 	}
 
-	public function testGivenIdOfUnknownDonation_mailerIsNotInvoked() {
+	public function testGivenIdOfUnknownDonation_mailerIsNotInvoked(): void {
 		$this->mailer->expects( $this->never() )->method( $this->anything() );
 		$this->newDonationAcceptedEventHandler()->onDonationAccepted( self::UNKNOWN_ID );
 	}
 
-	public function testWhenAuthorizationFails_mailerIsNotInvoked() {
+	public function testWhenAuthorizationFails_mailerIsNotInvoked(): void {
 		$this->authorizer = new FailingDonationAuthorizer();
 		$this->mailer->expects( $this->never() )->method( $this->anything() );
 		$this->newDonationAcceptedEventHandler()->onDonationAccepted( self::KNOWN_ID );

--- a/contexts/DonationContext/tests/Integration/UseCases/AddComment/AddCommentUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddComment/AddCommentUseCaseTest.php
@@ -190,7 +190,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $response->isSuccessful() );
 	}
 
-	private function newSucceedingAddCommentValidator() {
+	private function newSucceedingAddCommentValidator(): AddCommentValidator {
 		$validator = $this->createMock( AddCommentValidator::class );
 		$validator->method( 'validate' )->willReturn( new AddCommentValidationResult( [] ) );
 		return $validator;

--- a/contexts/DonationContext/tests/Integration/UseCases/AddComment/AddCommentUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddComment/AddCommentUseCaseTest.php
@@ -34,7 +34,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 	private $textPolicyValidator;
 	private $commentValidator;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->donationRepository = new FakeDonationRepository();
 		$this->authorizer = new SucceedingDonationAuthorizer();
 		$this->textPolicyValidator = $this->newSucceedingTextPolicyValidator();
@@ -53,7 +53,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $validator;
 	}
 
-	public function testGivenValidRequest_commentGetsAdded() {
+	public function testGivenValidRequest_commentGetsAdded(): void {
 		$this->donationRepository = $this->newFakeRepositoryWithDonation();
 
 		$response = $this->newUseCase()->addComment( $this->newValidRequest() );
@@ -97,7 +97,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $addCommentRequest->freeze()->assertNoNullFields();
 	}
 
-	public function testWhenRepositoryThrowsExceptionOnGet_failureResponseIsReturned() {
+	public function testWhenRepositoryThrowsExceptionOnGet_failureResponseIsReturned(): void {
 		$this->donationRepository = new ThrowingDonationRepository();
 		$this->donationRepository->throwOnGetDonationById();
 
@@ -106,7 +106,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $response->isSuccessful() );
 	}
 
-	public function testWhenRepositoryThrowsExceptionOnStore_failureResponseIsReturned() {
+	public function testWhenRepositoryThrowsExceptionOnStore_failureResponseIsReturned(): void {
 		$this->donationRepository = new ThrowingDonationRepository();
 		$this->donationRepository->throwOnStoreDonation();
 
@@ -115,7 +115,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $response->isSuccessful() );
 	}
 
-	public function testAuthorizationFails_failureResponseIsReturned() {
+	public function testAuthorizationFails_failureResponseIsReturned(): void {
 		$this->authorizer = new FailingDonationAuthorizer();
 
 		$response = $this->newUseCase()->addComment( $this->newValidRequest() );
@@ -123,11 +123,11 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $response->isSuccessful() );
 	}
 
-	public function testWhenDonationDoesNotExist_failureResponseIsReturned() {
+	public function testWhenDonationDoesNotExist_failureResponseIsReturned(): void {
 		$this->assertFalse( $this->newUseCase()->addComment( $this->newValidRequest() )->isSuccessful() );
 	}
 
-	public function testWhenTextValidationFails_commentIsMadePrivate() {
+	public function testWhenTextValidationFails_commentIsMadePrivate(): void {
 		$this->donationRepository = $this->newFakeRepositoryWithDonation();
 		$this->textPolicyValidator = $this->newFailingTextPolicyValidator();
 
@@ -143,7 +143,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $this->newStubTextPolicyValidator( false );
 	}
 
-	public function testWhenTextValidationFails_donationIsMarkedForModeration() {
+	public function testWhenTextValidationFails_donationIsMarkedForModeration(): void {
 		$this->donationRepository = $this->newFakeRepositoryWithDonation();
 		$this->textPolicyValidator = $this->newFailingTextPolicyValidator();
 
@@ -155,7 +155,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenTextValidationFails_responseMessageDoesNotContainOK() {
+	public function testWhenTextValidationFails_responseMessageDoesNotContainOK(): void {
 		$this->donationRepository = $this->newFakeRepositoryWithDonation();
 		$this->textPolicyValidator = $this->newFailingTextPolicyValidator();
 
@@ -165,7 +165,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertNotContains( 'ok', $response->getSuccessMessage() );
 	}
 
-	public function testWhenDonationIsMarkedForModeration_responseMessageDoesNotContainOK() {
+	public function testWhenDonationIsMarkedForModeration_responseMessageDoesNotContainOK(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 		$donation->assignId( self::DONATION_ID );
 		$donation->markForModeration();
@@ -179,7 +179,7 @@ class AddCommentUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertNotContains( 'ok', $response->getSuccessMessage() );
 	}
 
-	public function testWhenValidationFails_failureResponseIsReturned() {
+	public function testWhenValidationFails_failureResponseIsReturned(): void {
 		$this->donationRepository = $this->newFakeRepositoryWithDonation();
 		$this->commentValidator = $this->createMock( AddCommentValidator::class );
 		$this->commentValidator->method( 'validate' )->willReturn( new AddCommentValidationResult( [

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationPolicyValidatorTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationPolicyValidatorTest.php
@@ -20,7 +20,7 @@ use WMDE\Fundraising\Frontend\Validation\ValidationResult;
  */
 class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 
-	public function testTooHighAmountGiven_needsModerationReturnsTrue() {
+	public function testTooHighAmountGiven_needsModerationReturnsTrue(): void {
 		$policyValidator = new AddDonationPolicyValidator(
 			$this->newFailingAmountValidator(),
 			$this->newSucceedingTextPolicyValidator()
@@ -28,7 +28,7 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $policyValidator->needsModeration( ValidAddDonationRequest::getRequest() ) );
 	}
 
-	public function testGivenBadWords_needsModerationReturnsTrue() {
+	public function testGivenBadWords_needsModerationReturnsTrue(): void {
 		$policyValidator = new AddDonationPolicyValidator(
 			$this->newSucceedingAmountValidator(),
 			$this->newFailingTextPolicyValidator()
@@ -70,7 +70,7 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 	}
 
 	/** @dataProvider allowedEmailAddressProvider */
-	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( $emailAddress ) {
+	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setDonorEmailAddress( $emailAddress );
@@ -87,7 +87,7 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 	}
 
 	/** @dataProvider blacklistedEmailAddressProvider */
-	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( $emailAddress ) {
+	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setDonorEmailAddress( $emailAddress );

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationPolicyValidatorTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationPolicyValidatorTest.php
@@ -56,13 +56,13 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 		return $amountPolicyValidator;
 	}
 
-	private function newSucceedingTextPolicyValidator() {
+	private function newSucceedingTextPolicyValidator(): TextPolicyValidator {
 		$succeedingTextPolicyValidator = $this->createMock( TextPolicyValidator::class );
 		$succeedingTextPolicyValidator->method( 'textIsHarmless' )->willReturn( true );
 		return $succeedingTextPolicyValidator;
 	}
 
-	private function newFailingTextPolicyValidator() {
+	private function newFailingTextPolicyValidator(): TextPolicyValidator {
 		$failingTextPolicyValidator = $this->createMock( TextPolicyValidator::class );
 		$failingTextPolicyValidator->method( 'hasHarmlessContent' )
 			->willReturn( false );
@@ -70,7 +70,7 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 	}
 
 	/** @dataProvider allowedEmailAddressProvider */
-	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( $emailAddress ): void {
+	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( string $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setDonorEmailAddress( $emailAddress );
@@ -78,7 +78,7 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 		$this->assertFalse( $policyValidator->isAutoDeleted( ValidAddDonationRequest::getRequest() ) );
 	}
 
-	public function allowedEmailAddressProvider() {
+	public function allowedEmailAddressProvider(): array {
 		return [
 			[ 'other.person@bar.baz' ],
 			[ 'test@example.computer.says.no' ],
@@ -87,7 +87,7 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 	}
 
 	/** @dataProvider blacklistedEmailAddressProvider */
-	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( $emailAddress ): void {
+	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( string $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setDonorEmailAddress( $emailAddress );
@@ -95,7 +95,7 @@ class AddDonationPolicyValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $policyValidator->isAutoDeleted( $request ) );
 	}
 
-	public function blacklistedEmailAddressProvider() {
+	public function blacklistedEmailAddressProvider(): array {
 		return [
 			[ 'blocked.person@bar.baz' ],
 			[ 'test@example.com' ],

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
@@ -42,11 +42,11 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $oneHourInTheFuture;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->oneHourInTheFuture = ( new \DateTime() )->add( $this->newOneHourInterval() );
 	}
 
-	public function testWhenValidationSucceeds_successResponseIsCreated() {
+	public function testWhenValidationSucceeds_successResponseIsCreated(): void {
 		$useCase = $this->newValidationSucceedingUseCase();
 
 		$this->assertTrue( $useCase->addDonation( $this->newMinimumDonationRequest() )->isSuccessful() );
@@ -88,7 +88,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return new FakeDonationRepository();
 	}
 
-	public function testValidationFails_responseObjectContainsViolations() {
+	public function testValidationFails_responseObjectContainsViolations(): void {
 		$useCase = new AddDonationUseCase(
 			$this->newRepository(),
 			$this->getFailingValidatorMock( new ConstraintViolation( 'foo', 'bar' ) ),
@@ -103,7 +103,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( [ new ConstraintViolation( 'foo', 'bar' ) ], $result->getValidationErrors() );
 	}
 
-	public function testValidationFails_responseObjectContainsRequestObject() {
+	public function testValidationFails_responseObjectContainsRequestObject(): void {
 		$useCase = new AddDonationUseCase(
 			$this->newRepository(),
 			$this->getFailingValidatorMock( new ConstraintViolation( 'foo', 'bar' ) ),
@@ -185,7 +185,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $donationRequest;
 	}
 
-	public function testGivenInvalidRequest_noConfirmationEmailIsSend() {
+	public function testGivenInvalidRequest_noConfirmationEmailIsSend(): void {
 		$mailer = $this->newMailer();
 
 		$mailer->expects( $this->never() )->method( $this->anything() );
@@ -207,7 +207,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $this->createMock( TransferCodeGenerator::class );
 	}
 
-	public function testGivenValidRequest_confirmationEmailIsSent() {
+	public function testGivenValidRequest_confirmationEmailIsSent(): void {
 		$mailer = $this->newMailer();
 		$donation = $this->newValidAddDonationRequestWithEmail( 'foo@bar.baz' );
 
@@ -220,7 +220,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->addDonation( $donation );
 	}
 
-	public function testGivenValidRequestWithExternalPaymentType_confirmationEmailIsNotSent() {
+	public function testGivenValidRequestWithExternalPaymentType_confirmationEmailIsNotSent(): void {
 		$mailer = $this->newMailer();
 
 		$mailer->expects( $this->never() )->method( $this->anything() );
@@ -232,7 +232,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->addDonation( $request );
 	}
 
-	public function testGivenValidRequestWithPolicyViolation_donationIsModerated() {
+	public function testGivenValidRequestWithPolicyViolation_donationIsModerated(): void {
 		$useCase = new AddDonationUseCase(
 			$this->newRepository(),
 			$this->getSucceedingValidatorMock(),
@@ -247,7 +247,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $response->getDonation()->needsModeration() );
 	}
 
-	public function testGivenPolicyViolationForExternalPaymentDonation_donationIsNotModerated() {
+	public function testGivenPolicyViolationForExternalPaymentDonation_donationIsNotModerated(): void {
 		$useCase = new AddDonationUseCase(
 			$this->newRepository(),
 			$this->getSucceedingValidatorMock(),
@@ -312,7 +312,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $request;
 	}
 
-	public function testWhenAdditionWorks_successResponseContainsTokens() {
+	public function testWhenAdditionWorks_successResponseContainsTokens(): void {
 		$useCase = $this->newValidationSucceedingUseCase();
 
 		$response = $useCase->addDonation( $this->newMinimumDonationRequest() );
@@ -321,7 +321,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( self::ACCESS_TOKEN, $response->getAccessToken() );
 	}
 
-	public function testWhenAddingCompanyDonation_salutationFieldIsSet() {
+	public function testWhenAddingCompanyDonation_salutationFieldIsSet(): void {
 		$useCase = $this->newValidationSucceedingUseCase();
 
 		$response = $useCase->addDonation( $this->newValidCompanyDonationRequest() );
@@ -329,7 +329,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( DonorName::COMPANY_SALUTATION, $response->getDonation()->getDonor()->getName()->getSalutation() );
 	}
 
-	public function testWhenEmailAddressIsBlacklisted_donationIsMarkedAsDeleted() {
+	public function testWhenEmailAddressIsBlacklisted_donationIsMarkedAsDeleted(): void {
 		$repository = $this->newRepository();
 		$useCase = new AddDonationUseCase(
 			$repository,

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationUseCaseTest.php
@@ -264,7 +264,7 @@ class AddDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $response->getDonation()->needsModeration() );
 	}
 
-	private function newUseCaseWithMailer( DonationConfirmationMailer $mailer ) {
+	private function newUseCaseWithMailer( DonationConfirmationMailer $mailer ): AddDonationUseCase {
 		return new AddDonationUseCase(
 			$this->newRepository(),
 			$this->getSucceedingValidatorMock(),

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
@@ -212,7 +212,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		return new BankDataValidator( $ibanValidatorMock );
 	}
 
-	private function newMockEmailValidator() {
+	private function newMockEmailValidator(): EmailValidator {
 		$validator = $this->getMockBuilder( EmailValidator::class )->disableOriginalConstructor()->getMock();
 		$validator->method( 'validate' )->willReturn( new ValidationResult() );
 		return $validator;

--- a/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/AddDonation/AddDonationValidatorTest.php
@@ -33,16 +33,16 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 	/** @var AddDonationValidator */
 	private $donationValidator;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->donationValidator = $this->newDonationValidator();
 	}
 
-	public function testGivenValidDonation_validationIsSuccessful() {
+	public function testGivenValidDonation_validationIsSuccessful(): void {
 		$request = ValidAddDonationRequest::getRequest();
 		$this->assertEmpty( $this->donationValidator->validate( $request )->getViolations() );
 	}
 
-	public function testGivenAnonymousDonorAndEmptyAddressFields_validatorReturnsNoViolations() {
+	public function testGivenAnonymousDonorAndEmptyAddressFields_validatorReturnsNoViolations(): void {
 		$request = ValidAddDonationRequest::getRequest();
 
 		$request->setDonorType( DonorName::PERSON_ANONYMOUS );
@@ -60,7 +60,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		$this->assertEmpty( $this->donationValidator->validate( $request )->getViolations() );
 	}
 
-	public function testGivenNoPaymentType_validatorReturnsFalse() {
+	public function testGivenNoPaymentType_validatorReturnsFalse(): void {
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setPaymentType( '' );
 
@@ -72,7 +72,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		);
 	}
 
-	public function testGivenUnsupportedPaymentType_validatorReturnsFalse() {
+	public function testGivenUnsupportedPaymentType_validatorReturnsFalse(): void {
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setPaymentType( 'KaiCoin' );
 
@@ -84,7 +84,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		);
 	}
 
-	public function testPersonalInfoValidationFails_validatorReturnsFalse() {
+	public function testPersonalInfoValidationFails_validatorReturnsFalse(): void {
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setDonorType( DonorName::PERSON_COMPANY );
 		$request->setDonorCompany( '' );
@@ -97,7 +97,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		);
 	}
 
-	public function testDirectDebitMissingBankData_validatorReturnsFalse() {
+	public function testDirectDebitMissingBankData_validatorReturnsFalse(): void {
 		$bankData = new BankData();
 		$bankData->setIban( new Iban( '' ) );
 		$bankData->setBic( '' );
@@ -112,7 +112,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $result, AddDonationValidationResult::SOURCE_BIC );
 	}
 
-	public function testForeignDirectDebitMissingBankData_validationSucceeds() {
+	public function testForeignDirectDebitMissingBankData_validationSucceeds(): void {
 		$bankData = new BankData();
 		$bankData->setIban( new Iban( self::FOREIGN_IBAN ) );
 		$bankData->setBic( self::FOREIGN_BIC );
@@ -128,7 +128,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		$this->assertFalse( $result->hasViolations() );
 	}
 
-	public function testAmountTooLow_validatorReturnsFalse() {
+	public function testAmountTooLow_validatorReturnsFalse(): void {
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setAmount( Euro::newFromCents( 50 ) );
 
@@ -138,7 +138,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $result, AddDonationValidationResult::SOURCE_PAYMENT_AMOUNT );
 	}
 
-	public function testPersonalInfoWithLongFields_validationFails() {
+	public function testPersonalInfoWithLongFields_validationFails(): void {
 		$longText = str_repeat( 'Cats ', 500 );
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setDonorFirstName( $longText );
@@ -165,7 +165,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $result, AddDonationValidationResult::SOURCE_DONOR_EMAIL );
 	}
 
-	public function testBankDataWithLongFields_validationFails() {
+	public function testBankDataWithLongFields_validationFails(): void {
 		$longText = str_repeat( 'Cats ', 500 );
 		$request = ValidAddDonationRequest::getRequest();
 		$validBankData = $request->getBankData();
@@ -186,7 +186,7 @@ class AddDonationValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $result, AddDonationValidationResult::SOURCE_BIC );
 	}
 
-	public function testLongSource_validationFails() {
+	public function testLongSource_validationFails(): void {
 		$request = ValidAddDonationRequest::getRequest();
 		$request->setSource( 'http://catlady.com/#' . str_repeat( 'Cats ', 500 ) );
 

--- a/contexts/DonationContext/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/CancelDonation/CancelDonationUseCaseTest.php
@@ -45,7 +45,7 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $logger;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->repository = new FakeDonationRepository();
 		$this->mailer = new TemplateBasedMailerSpy( $this );
 		$this->authorizer = new SucceedingDonationAuthorizer();
@@ -61,19 +61,19 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenIdOfUnknownDonation_cancellationIsNotSuccessful() {
+	public function testGivenIdOfUnknownDonation_cancellationIsNotSuccessful(): void {
 		$response = $this->newCancelDonationUseCase()->cancelDonation( new CancelDonationRequest( 1 ) );
 
 		$this->assertFalse( $response->cancellationSucceeded() );
 	}
 
-	public function testResponseContainsDonationId() {
+	public function testResponseContainsDonationId(): void {
 		$response = $this->newCancelDonationUseCase()->cancelDonation( new CancelDonationRequest( 1337 ) );
 
 		$this->assertSame( 1337, $response->getDonationId() );
 	}
 
-	public function testGivenIdOfCancellableDonation_cancellationIsSuccessful() {
+	public function testGivenIdOfCancellableDonation_cancellationIsSuccessful(): void {
 		$donation = $this->newCancelableDonation();
 		$this->repository->storeDonation( $donation );
 
@@ -86,7 +86,7 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $this->repository->getDonationById( $donation->getId() )->isCancelled() );
 	}
 
-	public function testGivenIdOfNonCancellableDonation_cancellationIsNotSuccessful() {
+	public function testGivenIdOfNonCancellableDonation_cancellationIsNotSuccessful(): void {
 		$donation = $this->newCancelableDonation();
 		$donation->cancel();
 		$this->repository->storeDonation( $donation );
@@ -101,7 +101,7 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return ValidDonation::newDirectDebitDonation();
 	}
 
-	public function testWhenDonationGetsCancelled_cancellationConfirmationEmailIsSend() {
+	public function testWhenDonationGetsCancelled_cancellationConfirmationEmailIsSend(): void {
 		$donation = $this->newCancelableDonation();
 		$this->repository->storeDonation( $donation );
 
@@ -123,7 +123,7 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenDonationGetsCancelled_logEntryNeededByBackendIsWritten() {
+	public function testWhenDonationGetsCancelled_logEntryNeededByBackendIsWritten(): void {
 		$donation = $this->newCancelableDonation();
 		$this->repository->storeDonation( $donation );
 
@@ -135,13 +135,13 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenIdOfNonCancellableDonation_nothingIsWrittenToTheLog() {
+	public function testGivenIdOfNonCancellableDonation_nothingIsWrittenToTheLog(): void {
 		$this->newCancelDonationUseCase()->cancelDonation( new CancelDonationRequest( 1 ) );
 
 		$this->assertSame( [], $this->logger->getLogCalls() );
 	}
 
-	public function testWhenConfirmationMailFails_mailDeliveryFailureResponseIsReturned() {
+	public function testWhenConfirmationMailFails_mailDeliveryFailureResponseIsReturned(): void {
 		$this->mailer = $this->newThrowingMailer();
 
 		$response = $this->getResponseForCancellableDonation();
@@ -158,7 +158,7 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $mailer;
 	}
 
-	public function testWhenGetDonationFails_cancellationIsNotSuccessful() {
+	public function testWhenGetDonationFails_cancellationIsNotSuccessful(): void {
 		$this->repository->throwOnRead();
 
 		$response = $this->getResponseForCancellableDonation();
@@ -174,7 +174,7 @@ class CancelDonationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $this->newCancelDonationUseCase()->cancelDonation( $request );
 	}
 
-	public function testWhenDonationSavingFails_cancellationIsNotSuccessful() {
+	public function testWhenDonationSavingFails_cancellationIsNotSuccessful(): void {
 		$donation = $this->newCancelableDonation();
 		$this->repository->storeDonation( $donation );
 

--- a/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
@@ -37,7 +37,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 	private $eventLogger;
 	private $creditCardService;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->repository = new FakeDonationRepository();
 		$this->authorizer = new SucceedingDonationAuthorizer();
 		$this->mailer = $this->newMailer();
@@ -45,7 +45,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->creditCardService = new FakeCreditCardService();
 	}
 
-	public function testWhenRepositoryThrowsException_handlerThrowsException() {
+	public function testWhenRepositoryThrowsException_handlerThrowsException(): void {
 		$this->repository = new DoctrineDonationRepository( ThrowingEntityManager::newInstance( $this ) );
 		$this->authorizer = new FailingDonationAuthorizer();
 		$useCase = $this->newCreditCardNotificationUseCase();
@@ -55,7 +55,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->handleNotification( $request );
 	}
 
-	public function testWhenAuthorizationFails_handlerThrowsException() {
+	public function testWhenAuthorizationFails_handlerThrowsException(): void {
 		$this->authorizer = new FailingDonationAuthorizer();
 		$this->repository->storeDonation( ValidDonation::newIncompleteCreditCardDonation() );
 
@@ -67,7 +67,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->handleNotification( $request );
 	}
 
-	public function testWhenAuthorizationSucceeds_handlerDoesNotThrowException() {
+	public function testWhenAuthorizationSucceeds_handlerDoesNotThrowException(): void {
 		$this->repository->storeDonation( ValidDonation::newIncompleteCreditCardDonation() );
 
 		$useCase = $this->newCreditCardNotificationUseCase();
@@ -82,7 +82,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
-	public function testWhenPaymentTypeIsIncorrect_handlerThrowsException() {
+	public function testWhenPaymentTypeIsIncorrect_handlerThrowsException(): void {
 		$this->repository->storeDonation( ValidDonation::newDirectDebitDonation() );
 
 		$useCase = $this->newCreditCardNotificationUseCase();
@@ -93,7 +93,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->handleNotification( $request );
 	}
 
-	public function testWhenAuthorizationSucceeds_confirmationMailIsSent() {
+	public function testWhenAuthorizationSucceeds_confirmationMailIsSent(): void {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$this->repository->storeDonation( $donation );
 
@@ -107,7 +107,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->handleNotification( $request );
 	}
 
-	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent() {
+	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent(): void {
 		$donation = ValidDonation::newIncompleteAnonymousCreditCardDonation();
 		$this->repository->storeDonation( $donation );
 
@@ -120,7 +120,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->handleNotification( $request );
 	}
 
-	public function testWhenAuthorizationSucceeds_donationIsStored() {
+	public function testWhenAuthorizationSucceeds_donationIsStored(): void {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$this->repository = new DonationRepositorySpy( $donation );
 
@@ -131,7 +131,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 1, $this->repository->getStoreDonationCalls() );
 	}
 
-	public function testWhenAuthorizationSucceeds_donationIsBooked() {
+	public function testWhenAuthorizationSucceeds_donationIsBooked(): void {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$this->repository = new DonationRepositorySpy( $donation );
 
@@ -142,7 +142,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $this->repository->getDonationById( $donation->getId() )->isBooked() );
 	}
 
-	public function testWhenAuthorizationSucceeds_bookingEventIsLogged() {
+	public function testWhenAuthorizationSucceeds_bookingEventIsLogged(): void {
 		$donation = ValidDonation::newIncompleteCreditCardDonation();
 		$this->repository = new DonationRepositorySpy( $donation );
 		$this->eventLogger = new DonationEventLoggerSpy();
@@ -155,7 +155,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEventLogContainsExpression( $this->eventLogger, $donation->getId(), '/booked/' );
 	}
 
-	public function testWhenSendingConfirmationMailFails_handlerDoesNotThrowException() {
+	public function testWhenSendingConfirmationMailFails_handlerDoesNotThrowException(): void {
 		$this->repository->storeDonation( ValidDonation::newIncompleteCreditCardDonation() );
 
 		$this->mailer->expects( $this->once() )
@@ -172,7 +172,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
-	private function assertEventLogContainsExpression( DonationEventLoggerSpy $eventLoggerSpy, int $donationId, string $expr ) {
+	private function assertEventLogContainsExpression( DonationEventLoggerSpy $eventLoggerSpy, int $donationId, string $expr ): void {
 		$foundCalls = array_filter( $eventLoggerSpy->getLogCalls(), function( $call ) use ( $donationId, $expr ) {
 			return $call[0] == $donationId && preg_match( $expr, $call[1] );
 		} );
@@ -205,7 +205,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenPaymentAmountMismatches_handlerThreepwoodsException() {
+	public function testWhenPaymentAmountMismatches_handlerThreepwoodsException(): void {
 		$this->repository->storeDonation( ValidDonation::newIncompleteCreditCardDonation() );
 
 		$useCase = $this->newCreditCardNotificationUseCase();

--- a/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
@@ -194,7 +194,7 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $this->createMock( DonationEventLogger::class );
 	}
 
-	private function newCreditCardNotificationUseCase() {
+	private function newCreditCardNotificationUseCase(): CreditCardNotificationUseCase {
 		return new CreditCardNotificationUseCase(
 			$this->repository,
 			$this->authorizer,

--- a/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
@@ -29,7 +29,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\ThrowingEntityManager;
  */
 class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenRepositoryThrowsException_errorResponseIsReturned() {
+	public function testWhenRepositoryThrowsException_errorResponseIsReturned(): void {
 		$useCase = new HandlePayPalPaymentNotificationUseCase(
 			new DoctrineDonationRepository( ThrowingEntityManager::newInstance( $this ) ),
 			new FailingDonationAuthorizer(),
@@ -42,7 +42,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $reponse->hasErrors() );
 	}
 
-	public function testWhenAuthorizationFails_unhandledResponseIsReturned() {
+	public function testWhenAuthorizationFails_unhandledResponseIsReturned(): void {
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( ValidDonation::newIncompletePayPalDonation() );
 
@@ -57,7 +57,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenAuthorizationSucceeds_successResponseIsReturned() {
+	public function testWhenAuthorizationSucceeds_successResponseIsReturned(): void {
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( ValidDonation::newIncompletePayPalDonation() );
 
@@ -72,7 +72,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenPaymentTypeIsNonPayPal_unhandledResponseIsReturned() {
+	public function testWhenPaymentTypeIsNonPayPal_unhandledResponseIsReturned(): void {
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( ValidDonation::newDirectDebitDonation() );
 
@@ -87,7 +87,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenPaymentStatusIsPending_unhandledResponseIsReturned() {
+	public function testWhenPaymentStatusIsPending_unhandledResponseIsReturned(): void {
 		$request = ValidPayPalNotificationRequest::newPendingPayment();
 
 		$useCase = new HandlePayPalPaymentNotificationUseCase(
@@ -100,7 +100,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenTransactionTypeIsForSubscriptionChanges_unhandledResponseIsReturned() {
+	public function testWhenTransactionTypeIsForSubscriptionChanges_unhandledResponseIsReturned(): void {
 		$request = ValidPayPalNotificationRequest::newSubscriptionModification();
 
 		$useCase = new HandlePayPalPaymentNotificationUseCase(
@@ -112,7 +112,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenAuthorizationSucceeds_confirmationMailIsSent() {
+	public function testWhenAuthorizationSucceeds_confirmationMailIsSent(): void {
 		$donation = ValidDonation::newIncompletePayPalDonation();
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( $donation );
@@ -133,7 +133,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent() {
+	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent(): void {
 		$donation = ValidDonation::newIncompleteAnonymousPayPalDonation();
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( $donation );
@@ -153,7 +153,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenAuthorizationSucceeds_donationIsStored() {
+	public function testWhenAuthorizationSucceeds_donationIsStored(): void {
 		$donation = ValidDonation::newIncompletePayPalDonation();
 		$repositorySpy = new DonationRepositorySpy( $donation );
 
@@ -169,7 +169,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertCount( 1, $repositorySpy->getStoreDonationCalls() );
 	}
 
-	public function testWhenAuthorizationSucceeds_donationIsBooked() {
+	public function testWhenAuthorizationSucceeds_donationIsBooked(): void {
 		$donation = ValidDonation::newIncompletePayPalDonation();
 		$repository = new FakeDonationRepository( $donation );
 
@@ -185,7 +185,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $repository->getDonationById( $donation->getId() )->isBooked() );
 	}
 
-	public function testWhenAuthorizationSucceeds_bookingEventIsLogged() {
+	public function testWhenAuthorizationSucceeds_bookingEventIsLogged(): void {
 		$donation = ValidDonation::newIncompletePayPalDonation();
 		$repositorySpy = new DonationRepositorySpy( $donation );
 
@@ -204,7 +204,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertEventLogContainsExpression( $eventLogger, $donation->getId(), '/booked/' );
 	}
 
-	public function testWhenSendingConfirmationMailFails_handlerReturnsTrue() {
+	public function testWhenSendingConfirmationMailFails_handlerReturnsTrue(): void {
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( ValidDonation::newIncompletePayPalDonation() );
 
@@ -224,7 +224,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testGivenNewTransactionIdForBookedDonation_transactionIdShowsUpInChildPayments() {
+	public function testGivenNewTransactionIdForBookedDonation_transactionIdShowsUpInChildPayments(): void {
 		$donation = ValidDonation::newBookedPayPalDonation();
 		$transactionId = '16R12136PU8783961';
 
@@ -251,7 +251,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		);
 	}
 
-	public function testGivenNewTransactionIdForBookedDonation_childTransactionWithSameDataIsCreated() {
+	public function testGivenNewTransactionIdForBookedDonation_childTransactionWithSameDataIsCreated(): void {
 		$donation = ValidDonation::newBookedPayPalDonation();
 		$transactionId = '16R12136PU8783961';
 
@@ -283,7 +283,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $childDonation->isBooked() );
 	}
 
-	public function testGivenNewTransactionIdForBookedDonation_childCreationeventIsLogged() {
+	public function testGivenNewTransactionIdForBookedDonation_childCreationeventIsLogged(): void {
 		$donation = ValidDonation::newBookedPayPalDonation();
 		$transactionId = '16R12136PU8783961';
 
@@ -312,7 +312,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertEventLogContainsExpression( $eventLogger, $childDonationId, '/parent donation.*' . $donation->getId() .'/' );
 	}
 
-	public function testGivenExistingTransactionIdForBookedDonation_handlerReturnsFalse() {
+	public function testGivenExistingTransactionIdForBookedDonation_handlerReturnsFalse(): void {
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( ValidDonation::newBookedPayPalDonation() );
 
@@ -328,7 +328,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testGivenTransactionIdInBookedChildDonation_noNewDonationIsCreated() {
+	public function testGivenTransactionIdInBookedChildDonation_noNewDonationIsCreated(): void {
 		$transactionId = '16R12136PU8783961';
 		$fakeChildEntityId = 2;
 		$donation = ValidDonation::newBookedPayPalDonation();
@@ -349,7 +349,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
-	public function testWhenNotificationIsForNonExistingDonation_newDonationIsCreated() {
+	public function testWhenNotificationIsForNonExistingDonation_newDonationIsCreated(): void {
 		$repositorySpy = new DonationRepositorySpy();
 
 		$request = ValidPayPalNotificationRequest::newInstantPayment( 12345 );
@@ -368,7 +368,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertDonationIsCreatedWithNotficationRequestData( $storeDonationCalls[0] );
 	}
 
-	public function testGivenRecurringPaymentForIncompleteDonation_donationIsBooked() {
+	public function testGivenRecurringPaymentForIncompleteDonation_donationIsBooked(): void {
 		$donation = ValidDonation::newIncompletePayPalDonation();
 		$repositorySpy = new DonationRepositorySpy( $donation );
 
@@ -389,7 +389,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertTrue( $donation->isBooked() );
 	}
 
-	public function testWhenNotificationIsForNonExistingDonation_confirmationMailIsSent() {
+	public function testWhenNotificationIsForNonExistingDonation_confirmationMailIsSent(): void {
 		$request = ValidPayPalNotificationRequest::newInstantPayment( 12345 );
 		$mailer = $this->getMailer();
 		$mailer->expects( $this->once() )
@@ -405,7 +405,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$useCase->handleNotification( $request );
 	}
 
-	public function testWhenNotificationIsForNonExistingDonation_bookingEventIsLogged() {
+	public function testWhenNotificationIsForNonExistingDonation_bookingEventIsLogged(): void {
 		$request = ValidPayPalNotificationRequest::newInstantPayment( 12345 );
 		$eventLogger = new DonationEventLoggerSpy();
 
@@ -421,7 +421,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertEventLogContainsExpression( $eventLogger, 1, '/booked/' ); // 1 is the generated donation id
 	}
 
-	private function assertDonationIsCreatedWithNotficationRequestData( Donation $donation ) {
+	private function assertDonationIsCreatedWithNotficationRequestData( Donation $donation ): void {
 		$this->assertSame( 0, $donation->getPaymentIntervalInMonths(), 'Payment interval is always empty' );
 		$this->assertTrue( $donation->isBooked() );
 
@@ -445,7 +445,7 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		$this->assertSame( ValidPayPalNotificationRequest::PAYER_ADDRESS_NAME, $paypalData->getAddressName() );
 	}
 
-	private function assertEventLogContainsExpression( DonationEventLoggerSpy $eventLoggerSpy, int $donationId, string $expr ) {
+	private function assertEventLogContainsExpression( DonationEventLoggerSpy $eventLoggerSpy, int $donationId, string $expr ): void {
 		$foundCalls = array_filter( $eventLoggerSpy->getLogCalls(), function( $call ) use ( $donationId, $expr ) {
 			return $call[0] == $donationId && preg_match( $expr, $call[1] );
 		} );

--- a/contexts/DonationContext/tests/Integration/UseCases/ListComments/ListCommentsUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/ListComments/ListCommentsUseCaseTest.php
@@ -18,7 +18,7 @@ use WMDE\Fundraising\Frontend\DonationContext\UseCases\ListComments\ListComments
  */
 class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenThereAreNoComments_anEmptyListIsPresented() {
+	public function testWhenThereAreNoComments_anEmptyListIsPresented(): void {
 		$useCase = new ListCommentsUseCase( new InMemoryCommentFinder() );
 
 		$this->assertEquals(
@@ -27,7 +27,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenThereAreLessCommentsThanTheLimit_theyAreAllPresented() {
+	public function testWhenThereAreLessCommentsThanTheLimit_theyAreAllPresented(): void {
 		$useCase = new ListCommentsUseCase( new InMemoryCommentFinder(
 			$this->newCommentWithAuthorName( 'name0' ),
 			$this->newCommentWithAuthorName( 'name1' ),
@@ -52,7 +52,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 			->setDonationTime( new \DateTime( '1984-01-01' ) );
 	}
 
-	public function testWhenThereAreMoreCommentsThanTheLimit_onlyTheFirstFewArePresented() {
+	public function testWhenThereAreMoreCommentsThanTheLimit_onlyTheFirstFewArePresented(): void {
 		$useCase = new ListCommentsUseCase( new InMemoryCommentFinder(
 			$this->newCommentWithAuthorName( 'name0' ),
 			$this->newCommentWithAuthorName( 'name1' ),
@@ -69,7 +69,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenPageParameterIsTwo_correctOffsetIsUsed() {
+	public function testWhenPageParameterIsTwo_correctOffsetIsUsed(): void {
 		$useCase = new ListCommentsUseCase( new InMemoryCommentFinder(
 			$this->newCommentWithAuthorName( 'name0' ),
 			$this->newCommentWithAuthorName( 'name1' ),
@@ -88,7 +88,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider invalidPageNumberProvider
 	 */
-	public function testGivenInvalidPageNumber_firstPageIsReturned( int $invalidPageNumber ) {
+	public function testGivenInvalidPageNumber_firstPageIsReturned( int $invalidPageNumber ): void {
 		$useCase = new ListCommentsUseCase( new InMemoryCommentFinder(
 			$this->newCommentWithAuthorName( 'name0' ),
 			$this->newCommentWithAuthorName( 'name1' ),
@@ -117,7 +117,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider invalidLimitProvider
 	 */
-	public function testGivenInvalidLimit_10resultsAreReturned( int $invalidLimit ) {
+	public function testGivenInvalidLimit_10resultsAreReturned( int $invalidLimit ): void {
 		$useCase = new ListCommentsUseCase( $this->newInMemoryCommentFinderWithComments( 20 ) );
 
 		$commentList = $useCase->listComments( new CommentListingRequest(

--- a/contexts/DonationContext/tests/Integration/UseCases/ListComments/ListCommentsUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/ListComments/ListCommentsUseCaseTest.php
@@ -105,7 +105,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function invalidPageNumberProvider() {
+	public function invalidPageNumberProvider(): array {
 		return [
 			'too big' => [ 31337 ],
 			'upper limit boundary' => [ 101 ],
@@ -128,7 +128,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 10, $commentList->toArray() );
 	}
 
-	private function newInMemoryCommentFinderWithComments( int $commentCount ) {
+	private function newInMemoryCommentFinderWithComments( int $commentCount ): InMemoryCommentFinder {
 		return new InMemoryCommentFinder(
 			...new \LimitIterator(
 				$this->newInfiniteCommentIterator(),
@@ -146,7 +146,7 @@ class ListCommentsUseCaseTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
-	public function invalidLimitProvider() {
+	public function invalidLimitProvider(): array {
 		return [
 			'too big' => [ 31337 ],
 			'upper limit boundary' => [ 101 ],

--- a/contexts/DonationContext/tests/Integration/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCaseTest.php
@@ -25,7 +25,7 @@ class ShowDonationConfirmationUseCaseTest extends \PHPUnit\Framework\TestCase {
 	private const ACCESS_TOKEN = 'some token';
 	private const UPDATE_TOKEN = 'some other token';
 
-	public function testWhenAuthorizerSaysNoCanHaz_accessIsNotPermitted() {
+	public function testWhenAuthorizerSaysNoCanHaz_accessIsNotPermitted(): void {
 		$useCase = new ShowDonationConfirmationUseCase(
 			new FailingDonationAuthorizer(),
 			$this->newFixedTokenFetcher(),
@@ -40,7 +40,7 @@ class ShowDonationConfirmationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertNull( $response->getDonation() );
 	}
 
-	public function testWhenAuthorizerSaysSureThingBro_accessIsPermitted() {
+	public function testWhenAuthorizerSaysSureThingBro_accessIsPermitted(): void {
 		$useCase = new ShowDonationConfirmationUseCase(
 			new SucceedingDonationAuthorizer(),
 			$this->newFixedTokenFetcher(),
@@ -54,7 +54,7 @@ class ShowDonationConfirmationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $response->accessIsPermitted() );
 	}
 
-	public function testWhenDonationDoesNotExist_accessIsNotPermitted() {
+	public function testWhenDonationDoesNotExist_accessIsNotPermitted(): void {
 		$useCase = new ShowDonationConfirmationUseCase(
 			new SucceedingDonationAuthorizer(),
 			$this->newFixedTokenFetcher(),
@@ -69,7 +69,7 @@ class ShowDonationConfirmationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertNull( $response->getDonation() );
 	}
 
-	public function testWhenDonationExistsAndAccessIsAllowed_donationIsReturned() {
+	public function testWhenDonationExistsAndAccessIsAllowed_donationIsReturned(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$useCase = new ShowDonationConfirmationUseCase(

--- a/contexts/DonationContext/tests/Integration/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/ShowDonationConfirmation/ShowDonationConfirmationUseCaseTest.php
@@ -85,7 +85,7 @@ class ShowDonationConfirmationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $donation, $response->getDonation() );
 	}
 
-	private function newFixedTokenFetcher() {
+	private function newFixedTokenFetcher(): FixedDonationTokenFetcher {
 		return new FixedDonationTokenFetcher( new DonationTokens( self::ACCESS_TOKEN, self::UPDATE_TOKEN ) );
 	}
 }

--- a/contexts/DonationContext/tests/Unit/Domain/InMemoryCommentFinderTest.php
+++ b/contexts/DonationContext/tests/Unit/Domain/InMemoryCommentFinderTest.php
@@ -15,11 +15,11 @@ use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\InMemoryCommentFind
  */
 class InMemoryCommentFinderTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenThereAreNoComments_getCommentsReturnsEmptyArray() {
+	public function testWhenThereAreNoComments_getCommentsReturnsEmptyArray(): void {
 		$this->assertSame( [], ( new InMemoryCommentFinder() )->getPublicComments( 10 ) );
 	}
 
-	public function testWhenThereAreComments_getCommentsReturnsThem() {
+	public function testWhenThereAreComments_getCommentsReturnsThem(): void {
 		$this->assertEquals(
 			[
 				CommentWithAmount::newInstance()->setAuthorName( 'name0' )->setCommentText( 'comment' )
@@ -40,7 +40,7 @@ class InMemoryCommentFinderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenLimitSmallerThanCommentCount_getCommentsLimitsItsResult() {
+	public function testGivenLimitSmallerThanCommentCount_getCommentsLimitsItsResult(): void {
 		$this->assertEquals(
 			[
 				CommentWithAmount::newInstance()->setAuthorName( 'name0' )->setCommentText( 'comment' )

--- a/contexts/DonationContext/tests/Unit/Domain/Model/DonationTest.php
+++ b/contexts/DonationContext/tests/Unit/Domain/Model/DonationTest.php
@@ -17,14 +17,14 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalData;
  */
 class DonationTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenNonDirectDebitDonation_cancellationFails() {
+	public function testGivenNonDirectDebitDonation_cancellationFails(): void {
 		$donation = ValidDonation::newBankTransferDonation();
 
 		$this->expectException( RuntimeException::class );
 		$donation->cancel();
 	}
 
-	public function testGivenDirectDebitDonation_cancellationSucceeds() {
+	public function testGivenDirectDebitDonation_cancellationSucceeds(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$donation->cancel();
@@ -34,7 +34,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider nonCancellableStatusProvider
 	 */
-	public function testGivenNonNewStatus_cancellationFails( $nonCancellableStatus ) {
+	public function testGivenNonNewStatus_cancellationFails( $nonCancellableStatus ): void {
 		$donation = $this->newDirectDebitDonationWithStatus( $nonCancellableStatus );
 
 		$this->expectException( RuntimeException::class );
@@ -61,21 +61,21 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	public function testGivenNewStatus_cancellationSucceeds() {
+	public function testGivenNewStatus_cancellationSucceeds(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$donation->cancel();
 		$this->assertSame( Donation::STATUS_CANCELLED, $donation->getStatus() );
 	}
 
-	public function testModerationStatusCanBeQueried() {
+	public function testModerationStatusCanBeQueried(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$donation->markForModeration();
 		$this->assertTrue( $donation->needsModeration() );
 	}
 
-	public function testGivenModerationStatus_cancellationSucceeds() {
+	public function testGivenModerationStatus_cancellationSucceeds(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$donation->markForModeration();
@@ -83,18 +83,18 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( Donation::STATUS_CANCELLED, $donation->getStatus() );
 	}
 
-	public function testIdIsNullWhenNotAssigned() {
+	public function testIdIsNullWhenNotAssigned(): void {
 		$this->assertNull( ValidDonation::newDirectDebitDonation()->getId() );
 	}
 
-	public function testCanAssignIdToNewDonation() {
+	public function testCanAssignIdToNewDonation(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$donation->assignId( 42 );
 		$this->assertSame( 42, $donation->getId() );
 	}
 
-	public function testCannotAssignIdToDonationWithIdentity() {
+	public function testCannotAssignIdToDonationWithIdentity(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 		$donation->assignId( 42 );
 
@@ -102,7 +102,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$donation->assignId( 43 );
 	}
 
-	public function testGivenNonExternalPaymentType_confirmBookedThrowsException() {
+	public function testGivenNonExternalPaymentType_confirmBookedThrowsException(): void {
 		$donation = ValidDonation::newDirectDebitDonation();
 
 		$this->expectException( RuntimeException::class );
@@ -113,7 +113,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider statusesThatDoNotAllowForBookingProvider
 	 */
-	public function testGivenStatusThatDoesNotAllowForBooking_confirmBookedThrowsException( Donation $donation ) {
+	public function testGivenStatusThatDoesNotAllowForBooking_confirmBookedThrowsException( Donation $donation ): void {
 		$this->expectException( RuntimeException::class );
 		$donation->confirmBooked();
 	}
@@ -128,7 +128,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider statusesThatAllowsForBookingProvider
 	 */
-	public function testGivenStatusThatAllowsForBooking_confirmBookedSetsBookedStatus( Donation $donation ) {
+	public function testGivenStatusThatAllowsForBooking_confirmBookedSetsBookedStatus( Donation $donation ): void {
 		$donation->confirmBooked();
 		$this->assertSame( Donation::STATUS_EXTERNAL_BOOKED, $donation->getStatus() );
 	}
@@ -148,7 +148,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		return $donation;
 	}
 
-	public function testAddCommentThrowsExceptionWhenCommentAlreadySet() {
+	public function testAddCommentThrowsExceptionWhenCommentAlreadySet(): void {
 		$donation = new Donation(
 			null,
 			Donation::STATUS_NEW,
@@ -163,7 +163,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$donation->addComment( ValidDonation::newPublicComment() );
 	}
 
-	public function testAddCommentSetsWhenCommentNotSetYet() {
+	public function testAddCommentSetsWhenCommentNotSetYet(): void {
 		$donation = new Donation(
 			null,
 			Donation::STATUS_NEW,
@@ -178,11 +178,11 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( ValidDonation::newPublicComment(), $donation->getComment() );
 	}
 
-	public function testWhenNoCommentHasBeenSet_getCommentReturnsNull() {
+	public function testWhenNoCommentHasBeenSet_getCommentReturnsNull(): void {
 		$this->assertNull( ValidDonation::newDirectDebitDonation()->getComment() );
 	}
 
-	public function testWhenCompletingBookingOfExternalPaymentInModeration_commentIsMadePrivate() {
+	public function testWhenCompletingBookingOfExternalPaymentInModeration_commentIsMadePrivate(): void {
 		$donation = $this->newInModerationPayPalDonation();
 		$donation->addComment( ValidDonation::newPublicComment() );
 
@@ -191,7 +191,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $donation->getComment()->isPublic() );
 	}
 
-	public function testWhenCompletingBookingOfCancelledExternalPayment_commentIsMadePrivate() {
+	public function testWhenCompletingBookingOfCancelledExternalPayment_commentIsMadePrivate(): void {
 		$donation = ValidDonation::newCancelledPayPalDonation();
 		$donation->addComment( ValidDonation::newPublicComment() );
 
@@ -200,7 +200,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $donation->getComment()->isPublic() );
 	}
 
-	public function testWhenCompletingBookingOfCancelledExternalPayment_lackOfCommentCausesNoError() {
+	public function testWhenCompletingBookingOfCancelledExternalPayment_lackOfCommentCausesNoError(): void {
 		$donation = ValidDonation::newCancelledPayPalDonation();
 
 		$donation->confirmBooked();
@@ -208,7 +208,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $donation->hasComment() );
 	}
 
-	public function testWhenConstructingWithInvalidStatus_exceptionIsThrown() {
+	public function testWhenConstructingWithInvalidStatus_exceptionIsThrown(): void {
 		$this->expectException( \InvalidArgumentException::class );
 
 		new Donation(
@@ -222,13 +222,13 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenNonExternalPaymentIsNotifiedOfPolicyValidationFailure_itIsPutInModeration() {
+	public function testWhenNonExternalPaymentIsNotifiedOfPolicyValidationFailure_itIsPutInModeration(): void {
 		$donation = ValidDonation::newBankTransferDonation();
 		$donation->notifyOfPolicyValidationFailure();
 		$this->assertTrue( $donation->needsModeration() );
 	}
 
-	public function testWhenExternalPaymentIsNotifiedOfPolicyValidationFailure_itIsNotPutInModeration() {
+	public function testWhenExternalPaymentIsNotifiedOfPolicyValidationFailure_itIsNotPutInModeration(): void {
 		$donation = ValidDonation::newIncompletePayPalDonation();
 		$donation->notifyOfPolicyValidationFailure();
 		$this->assertFalse( $donation->needsModeration() );

--- a/contexts/DonationContext/tests/Unit/Domain/Model/DonationTest.php
+++ b/contexts/DonationContext/tests/Unit/Domain/Model/DonationTest.php
@@ -34,14 +34,14 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider nonCancellableStatusProvider
 	 */
-	public function testGivenNonNewStatus_cancellationFails( $nonCancellableStatus ): void {
+	public function testGivenNonNewStatus_cancellationFails( string $nonCancellableStatus ): void {
 		$donation = $this->newDirectDebitDonationWithStatus( $nonCancellableStatus );
 
 		$this->expectException( RuntimeException::class );
 		$donation->cancel();
 	}
 
-	private function newDirectDebitDonationWithStatus( string $status ) {
+	private function newDirectDebitDonationWithStatus( string $status ): Donation {
 		return new Donation(
 			null,
 			$status,
@@ -52,7 +52,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function nonCancellableStatusProvider() {
+	public function nonCancellableStatusProvider(): array {
 		return [
 			[ Donation::STATUS_CANCELLED ],
 			[ Donation::STATUS_EXTERNAL_BOOKED ],
@@ -118,7 +118,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$donation->confirmBooked();
 	}
 
-	public function statusesThatDoNotAllowForBookingProvider() {
+	public function statusesThatDoNotAllowForBookingProvider(): array {
 		return [
 			[ ValidDonation::newBookedPayPalDonation() ],
 			[ ValidDonation::newBookedCreditCardDonation() ],
@@ -133,7 +133,7 @@ class DonationTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( Donation::STATUS_EXTERNAL_BOOKED, $donation->getStatus() );
 	}
 
-	public function statusesThatAllowsForBookingProvider() {
+	public function statusesThatAllowsForBookingProvider(): array {
 		return [
 			[ ValidDonation::newIncompletePayPalDonation() ],
 			[ ValidDonation::newIncompleteCreditCardDonation() ],

--- a/contexts/DonationContext/tests/Unit/Domain/Model/DonorNameTest.php
+++ b/contexts/DonationContext/tests/Unit/Domain/Model/DonorNameTest.php
@@ -17,7 +17,7 @@ class DonorNameTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider privatePersonProvider
 	 */
-	public function testGivenPersonName_determineFullNameReturnsFullName( $expectedValue, $data ) {
+	public function testGivenPersonName_determineFullNameReturnsFullName( $expectedValue, $data ): void {
 		$personName = DonorName::newPrivatePersonName();
 
 		$personName->setCompanyName( $data['company'] );

--- a/contexts/DonationContext/tests/Unit/Domain/Model/DonorNameTest.php
+++ b/contexts/DonationContext/tests/Unit/Domain/Model/DonorNameTest.php
@@ -17,7 +17,7 @@ class DonorNameTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider privatePersonProvider
 	 */
-	public function testGivenPersonName_determineFullNameReturnsFullName( $expectedValue, $data ): void {
+	public function testGivenPersonName_determineFullNameReturnsFullName( string $expectedValue, array $data ): void {
 		$personName = DonorName::newPrivatePersonName();
 
 		$personName->setCompanyName( $data['company'] );
@@ -28,7 +28,7 @@ class DonorNameTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( $expectedValue, $personName->getFullName() );
 	}
 
-	public function privatePersonProvider() {
+	public function privatePersonProvider(): array {
 		return [
 			[
 				'Ebenezer Scrooge',

--- a/contexts/DonationContext/tests/Unit/Infrastructure/LoggingDonationRepositoryTest.php
+++ b/contexts/DonationContext/tests/Unit/Infrastructure/LoggingDonationRepositoryTest.php
@@ -21,7 +21,7 @@ use WMDE\PsrLogTestDoubles\LoggerSpy;
  */
 class LoggingDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenGetDonationByIdThrowException_itIsLogged() {
+	public function testWhenGetDonationByIdThrowException_itIsLogged(): void {
 		$loggingRepo = new LoggingDonationRepository(
 			$this->newThrowingRepository(),
 			new LoggerSpy()
@@ -45,7 +45,7 @@ class LoggingDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $repository;
 	}
 
-	public function testWhenGetDonationByIdThrowException_itIsNotFullyCaught() {
+	public function testWhenGetDonationByIdThrowException_itIsNotFullyCaught(): void {
 		$logger = new LoggerSpy();
 
 		$loggingRepo = new LoggingDonationRepository(
@@ -62,7 +62,7 @@ class LoggingDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertExceptionLoggedAsCritical( GetDonationException::class, $logger );
 	}
 
-	private function assertExceptionLoggedAsCritical( string $expectedExceptionType, LoggerSpy $logger ) {
+	private function assertExceptionLoggedAsCritical( string $expectedExceptionType, LoggerSpy $logger ): void {
 		$this->assertCount( 1, $logger->getLogCalls(), 'There should be exactly one log call' );
 
 		$logCall = $logger->getLogCalls()->getFirstCall();
@@ -72,7 +72,7 @@ class LoggingDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertInstanceOf( $expectedExceptionType, $logCall->getContext()['exception'] );
 	}
 
-	public function testWhenGetDonationByIdDoesNotThrow_returnValueIsReturnedWithoutLogging() {
+	public function testWhenGetDonationByIdDoesNotThrow_returnValueIsReturnedWithoutLogging(): void {
 		$logger = new LoggerSpy();
 		$donation = ValidDonation::newDirectDebitDonation();
 		$donation->assignId( 1337 );
@@ -86,7 +86,7 @@ class LoggingDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$logger->assertNoLoggingCallsWhereMade();
 	}
 
-	public function testWhenStoreDonationThrowException_itIsLogged() {
+	public function testWhenStoreDonationThrowException_itIsLogged(): void {
 		$loggingRepo = new LoggingDonationRepository(
 			$this->newThrowingRepository(),
 			new LoggerSpy()
@@ -96,7 +96,7 @@ class LoggingDonationRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$loggingRepo->storeDonation( ValidDonation::newDirectDebitDonation() );
 	}
 
-	public function testWhenStoreDonationThrowException_itIsNotFullyCaught() {
+	public function testWhenStoreDonationThrowException_itIsNotFullyCaught(): void {
 		$logger = new LoggerSpy();
 
 		$loggingRepo = new LoggingDonationRepository(

--- a/contexts/DonationContext/tests/Unit/UseCases/AddComment/AddCommentValidatorTest.php
+++ b/contexts/DonationContext/tests/Unit/UseCases/AddComment/AddCommentValidatorTest.php
@@ -19,19 +19,19 @@ class AddCommentValidatorTest extends \PHPUnit\Framework\TestCase {
 		return $request;
 	}
 
-	public function testValidCommentRequest_isSuccessful() {
+	public function testValidCommentRequest_isSuccessful(): void {
 		$validator = new AddCommentValidator();
 		$this->assertTrue( $validator->validate( $this->newValidAddCommentRequest() )->isSuccessful() );
 	}
 
-	public function testLongComment_isNotSuccessful() {
+	public function testLongComment_isNotSuccessful(): void {
 		$validator = new AddCommentValidator();
 		$request = $this->newValidAddCommentRequest();
 		$request->setCommentText( str_repeat( 'All work and no play makes jack a dull boy.', 1000 ) );
 		$this->assertFalse( $validator->validate( $request )->isSuccessful() );
 	}
 
-	public function testLongName_isNotSuccessful() {
+	public function testLongName_isNotSuccessful(): void {
 		$validator = new AddCommentValidator();
 		$request = $this->newValidAddCommentRequest();
 		$request->setAuthorDisplayName( str_repeat( 'Dr. ', 50 ) . $request->getAuthorDisplayName() );

--- a/contexts/DonationContext/tests/Unit/UseCases/AddDonation/ReferrerGeneralizerTest.php
+++ b/contexts/DonationContext/tests/Unit/UseCases/AddDonation/ReferrerGeneralizerTest.php
@@ -35,7 +35,7 @@ class ReferrerGeneralizerTest extends ValidatorTestCase {
 		$this->assertSame( $expected, $generalizer->generalize( $url ) );
 	}
 
-	public function urlProvider() {
+	public function urlProvider(): array {
 		return [
 			[ 'http://de.wikipedia.org/wiki/Hauptseite', 'de.wikipedia.org' ],
 			[ 'https://en.wikipedia.org/wiki/Main_Page', 'en.wikipedia.org' ],

--- a/contexts/DonationContext/tests/Unit/UseCases/AddDonation/ReferrerGeneralizerTest.php
+++ b/contexts/DonationContext/tests/Unit/UseCases/AddDonation/ReferrerGeneralizerTest.php
@@ -30,7 +30,7 @@ class ReferrerGeneralizerTest extends ValidatorTestCase {
 	 * @param string $expected
 	 * @param string $url
 	 */
-	public function testGeneralization( string $url, string $expected ) {
+	public function testGeneralization( string $url, string $expected ): void {
 		$generalizer = new ReferrerGeneralizer( 'web', $this->domainMap );
 		$this->assertSame( $expected, $generalizer->generalize( $url ) );
 	}

--- a/contexts/DonationContext/tests/Unit/UseCases/ListComments/CommentListTest.php
+++ b/contexts/DonationContext/tests/Unit/UseCases/ListComments/CommentListTest.php
@@ -15,11 +15,11 @@ use WMDE\Fundraising\Frontend\DonationContext\UseCases\ListComments\CommentList;
  */
 class CommentListTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenNoArguments_constructorCreatesEmptyList() {
+	public function testGivenNoArguments_constructorCreatesEmptyList(): void {
 		$this->assertSame( [], ( new CommentList() )->toArray() );
 	}
 
-	public function testGivenOneComment_constructorCreatesListWithComment() {
+	public function testGivenOneComment_constructorCreatesListWithComment(): void {
 		$comment = CommentWithAmount::newInstance()
 			->setAuthorName( 'name0' )
 			->setCommentText( 'comment' )
@@ -29,7 +29,7 @@ class CommentListTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( [ $comment ], ( new CommentList( $comment ) )->toArray() );
 	}
 
-	public function testGivenMultipleComments_constructorCreatesListWithAllComments() {
+	public function testGivenMultipleComments_constructorCreatesListWithAllComments(): void {
 		$comment0 = CommentWithAmount::newInstance()
 			->setAuthorName( 'name0' )
 			->setCommentText( 'comment' )

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationAuthorizer.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationAuthorizer.php
@@ -38,12 +38,7 @@ class DoctrineApplicationAuthorizer implements ApplicationAuthorizer {
 			&& $this->updateTokenMatches( $application );
 	}
 
-	/**
-	 * @param int $applicationId
-	 *
-	 * @return MembershipApplication|null
-	 */
-	private function getApplicationById( int $applicationId ) {
+	private function getApplicationById( int $applicationId ): ?MembershipApplication {
 		return $this->entityManager->find( MembershipApplication::class, $applicationId );
 	}
 

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationPiwikTracker.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationPiwikTracker.php
@@ -22,7 +22,7 @@ class DoctrineApplicationPiwikTracker implements ApplicationPiwikTracker {
 		$this->entityManager = $entityManager;
 	}
 
-	public function trackApplication( int $applicationId, string $trackingString ) {
+	public function trackApplication( int $applicationId, string $trackingString ): void {
 		$application = $this->getApplicationById( $applicationId );
 
 		$application->setTracking( $trackingString );
@@ -46,7 +46,7 @@ class DoctrineApplicationPiwikTracker implements ApplicationPiwikTracker {
 		return $application;
 	}
 
-	private function persistApplication( MembershipApplication $application ) {
+	private function persistApplication( MembershipApplication $application ): void {
 		try {
 			$this->entityManager->persist( $application );
 			$this->entityManager->flush();

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
@@ -39,7 +39,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		$this->entityManager = $entityManager;
 	}
 
-	public function storeApplication( Application $application ) {
+	public function storeApplication( Application $application ): void {
 		if ( $application->hasId() ) {
 			$this->updateApplication( $application );
 		}
@@ -48,7 +48,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		}
 	}
 
-	private function insertApplication( Application $application ) {
+	private function insertApplication( Application $application ): void {
 		$doctrineApplication = new DoctrineApplication();
 		$this->updateDoctrineApplication( $doctrineApplication, $application );
 
@@ -63,7 +63,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		$application->assignId( $doctrineApplication->getId() );
 	}
 
-	private function updateApplication( Application $application ) {
+	private function updateApplication( Application $application ): void {
 		$doctrineApplication = $this->getDoctrineApplicationById( $application->getId() );
 
 		if ( $doctrineApplication === null ) {
@@ -81,7 +81,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		}
 	}
 
-	private function updateDoctrineApplication( DoctrineApplication $doctrineApplication, Application $application ) {
+	private function updateDoctrineApplication( DoctrineApplication $doctrineApplication, Application $application ): void {
 		$doctrineApplication->setId( $application->getId() );
 		$doctrineApplication->setMembershipType( $application->getType() );
 
@@ -93,7 +93,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		$doctrineApplication->setStatus( $doctrineStatus );
 	}
 
-	private function setApplicantFields( DoctrineApplication $application, Applicant $applicant ) {
+	private function setApplicantFields( DoctrineApplication $application, Applicant $applicant ): void {
 		$application->setApplicantFirstName( $applicant->getName()->getFirstName() );
 		$application->setApplicantLastName( $applicant->getName()->getLastName() );
 		$application->setApplicantSalutation( $applicant->getName()->getSalutation() );
@@ -113,7 +113,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		$application->setAddress( $address->getStreetAddress() );
 	}
 
-	private function setPaymentFields( DoctrineApplication $application, Payment $payment ) {
+	private function setPaymentFields( DoctrineApplication $application, Payment $payment ): void {
 		$application->setPaymentIntervalInMonths( $payment->getIntervalInMonths() );
 		$application->setPaymentAmount( (int)$payment->getAmount()->getEuroFloat() );
 		$paymentMethod = $payment->getPaymentMethod();
@@ -126,7 +126,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		}
 	}
 
-	private function setBankDataFields( DoctrineApplication $application, BankData $bankData ) {
+	private function setBankDataFields( DoctrineApplication $application, BankData $bankData ): void {
 		$application->setPaymentBankAccount( $bankData->getAccount() );
 		$application->setPaymentBankCode( $bankData->getBankCode() );
 		$application->setPaymentBankName( $bankData->getBankName() );
@@ -134,7 +134,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		$application->setPaymentIban( $bankData->getIban()->toString() );
 	}
 
-	private function setPayPalDataFields( DoctrineApplication $application, PayPalData $payPalData ) {
+	private function setPayPalDataFields( DoctrineApplication $application, PayPalData $payPalData ): void {
 		$application->encodeAndSetData( array_merge(
 			$application->getDecodedData(),
 			[
@@ -190,7 +190,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		return $application->getPayment()->getPaymentMethod()->getType() === PaymentType::DIRECT_DEBIT;
 	}
 
-	private function preserveDoctrineStatus( DoctrineApplication $doctrineApplication, int $doctrineStatus ) {
+	private function preserveDoctrineStatus( DoctrineApplication $doctrineApplication, int $doctrineStatus ): void {
 		if ( $doctrineStatus < DoctrineApplication::STATUS_CONFIRMED ) {
 			$doctrineApplication->modifyDataObject( function ( MembershipApplicationData $data ) {
 				$data->setPreservedStatus( DoctrineApplication::STATUS_CONFIRMED );
@@ -224,7 +224,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 	 * @return DoctrineApplication|null
 	 * @throws ORMException
 	 */
-	public function getDoctrineApplicationById( int $id ) {
+	public function getDoctrineApplicationById( int $id ): ?DoctrineApplication {
 		return $this->entityManager->find( DoctrineApplication::class, $id );
 	}
 
@@ -302,11 +302,7 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		return $bankData->freeze()->assertNoNullFields();
 	}
 
-	/**
-	 * @param DoctrineApplication $application
-	 * @return PayPalData|null
-	 */
-	private function newPayPalData( DoctrineApplication $application ) {
+	private function newPayPalData( DoctrineApplication $application ): ?PayPalData {
 		$data = $application->getDecodedData();
 
 		return ( new PayPalData() )

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationRepository.php
@@ -182,11 +182,11 @@ class DoctrineApplicationRepository implements ApplicationRepository {
 		return $status;
 	}
 
-	private function isAutoConfirmed( int $status, Application $application ) {
+	private function isAutoConfirmed( int $status, Application $application ): bool {
 		return $status === DoctrineApplication::STATUS_NEUTRAL && $this->isDirectDebitPayment( $application );
 	}
 
-	private function isDirectDebitPayment( Application $application ) {
+	private function isDirectDebitPayment( Application $application ): bool {
 		return $application->getPayment()->getPaymentMethod()->getType() === PaymentType::DIRECT_DEBIT;
 	}
 

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationTokenFetcher.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationTokenFetcher.php
@@ -37,12 +37,7 @@ class DoctrineApplicationTokenFetcher implements ApplicationTokenFetcher {
 		);
 	}
 
-	/**
-	 * @param int $applicationId
-	 *
-	 * @return MembershipApplication|null
-	 */
-	private function getApplicationById( int $applicationId ) {
+	private function getApplicationById( int $applicationId ): ?MembershipApplication {
 		return $this->entityManager->find( MembershipApplication::class, $applicationId );
 	}
 

--- a/contexts/MembershipContext/src/DataAccess/DoctrineApplicationTracker.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineApplicationTracker.php
@@ -23,7 +23,7 @@ class DoctrineApplicationTracker implements ApplicationTracker {
 		$this->entityManager = $entityManager;
 	}
 
-	public function trackApplication( int $applicationId, MembershipApplicationTrackingInfo $trackingInfo ) {
+	public function trackApplication( int $applicationId, MembershipApplicationTrackingInfo $trackingInfo ): void {
 		$application = $this->getApplicationById( $applicationId );
 
 		$data = $application->getDecodedData();
@@ -50,7 +50,7 @@ class DoctrineApplicationTracker implements ApplicationTracker {
 		return $application;
 	}
 
-	private function persistApplication( MembershipApplication $application ) {
+	private function persistApplication( MembershipApplication $application ): void {
 		try {
 			$this->entityManager->persist( $application );
 			$this->entityManager->flush();

--- a/contexts/MembershipContext/src/DataAccess/DoctrineMembershipApplicationPrePersistSubscriber.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineMembershipApplicationPrePersistSubscriber.php
@@ -47,7 +47,7 @@ class DoctrineMembershipApplicationPrePersistSubscriber implements EventSubscrib
 		}
 	}
 
-	private function isEmpty( $stringOrNull ): bool {
+	private function isEmpty( ?string $stringOrNull ): bool {
 		return $stringOrNull === null || $stringOrNull === '';
 	}
 

--- a/contexts/MembershipContext/src/DataAccess/DoctrineMembershipApplicationPrePersistSubscriber.php
+++ b/contexts/MembershipContext/src/DataAccess/DoctrineMembershipApplicationPrePersistSubscriber.php
@@ -31,7 +31,7 @@ class DoctrineMembershipApplicationPrePersistSubscriber implements EventSubscrib
 		return [ Events::prePersist ];
 	}
 
-	public function prePersist( LifecycleEventArgs $args ) {
+	public function prePersist( LifecycleEventArgs $args ): void {
 		$entity = $args->getObject();
 
 		if ( $entity instanceof MembershipApplication ) {

--- a/contexts/MembershipContext/src/Domain/Model/Applicant.php
+++ b/contexts/MembershipContext/src/Domain/Model/Applicant.php
@@ -42,7 +42,7 @@ class Applicant {
 		return $this->dateOfBirth;
 	}
 
-	public function changeEmailAddress( EmailAddress $email ) {
+	public function changeEmailAddress( EmailAddress $email ): void {
 		$this->email = $email;
 	}
 

--- a/contexts/MembershipContext/src/Domain/Model/ApplicantAddress.php
+++ b/contexts/MembershipContext/src/Domain/Model/ApplicantAddress.php
@@ -23,7 +23,7 @@ class ApplicantAddress {
 		return $this->streetAddress;
 	}
 
-	public function setStreetAddress( string $streetAddress ) {
+	public function setStreetAddress( string $streetAddress ): void {
 		$this->assertIsWritable();
 		$this->streetAddress = $streetAddress;
 	}
@@ -32,7 +32,7 @@ class ApplicantAddress {
 		return $this->postalCode;
 	}
 
-	public function setPostalCode( string $postalCode ) {
+	public function setPostalCode( string $postalCode ): void {
 		$this->assertIsWritable();
 		$this->postalCode = $postalCode;
 	}
@@ -41,7 +41,7 @@ class ApplicantAddress {
 		return $this->city;
 	}
 
-	public function setCity( string $city ) {
+	public function setCity( string $city ): void {
 		$this->assertIsWritable();
 		$this->city = $city;
 	}
@@ -50,7 +50,7 @@ class ApplicantAddress {
 		return $this->countryCode;
 	}
 
-	public function setCountryCode( string $countryCode ) {
+	public function setCountryCode( string $countryCode ): void {
 		$this->assertIsWritable();
 		$this->countryCode = $countryCode;
 	}

--- a/contexts/MembershipContext/src/Domain/Model/ApplicantName.php
+++ b/contexts/MembershipContext/src/Domain/Model/ApplicantName.php
@@ -35,7 +35,7 @@ class ApplicantName {
 		return $companyName;
 	}
 
-	public function setCompanyName( string $companyName ) {
+	public function setCompanyName( string $companyName ): void {
 		$this->assertIsWritable();
 		$this->companyName = $companyName;
 	}
@@ -48,7 +48,7 @@ class ApplicantName {
 		return $this->salutation;
 	}
 
-	public function setSalutation( string $salutation ) {
+	public function setSalutation( string $salutation ): void {
 		$this->assertIsWritable();
 		$this->salutation = $salutation;
 	}
@@ -57,7 +57,7 @@ class ApplicantName {
 		return $this->title;
 	}
 
-	public function setTitle( string $title ) {
+	public function setTitle( string $title ): void {
 		$this->assertIsWritable();
 		$this->title = $title;
 	}
@@ -66,7 +66,7 @@ class ApplicantName {
 		return $this->firstName;
 	}
 
-	public function setFirstName( string $firstName ) {
+	public function setFirstName( string $firstName ): void {
 		$this->assertIsWritable();
 		$this->firstName = $firstName;
 	}
@@ -75,7 +75,7 @@ class ApplicantName {
 		return $this->lastName;
 	}
 
-	public function setLastName( string $lastName ) {
+	public function setLastName( string $lastName ): void {
 		$this->assertIsWritable();
 		$this->lastName = $lastName;
 	}

--- a/contexts/MembershipContext/src/Domain/Model/Application.php
+++ b/contexts/MembershipContext/src/Domain/Model/Application.php
@@ -92,7 +92,7 @@ class Application {
 	 * @param int $id
 	 * @throws \RuntimeException
 	 */
-	public function assignId( int $id ) {
+	public function assignId( int $id ): void {
 		if ( $this->id !== null && $this->id !== $id ) {
 			throw new \RuntimeException( 'Id cannot be changed after initial assignment' );
 		}
@@ -100,11 +100,11 @@ class Application {
 		$this->id = $id;
 	}
 
-	public function cancel() {
+	public function cancel(): void {
 		$this->isCancelled = self::IS_CANCELLED;
 	}
 
-	public function markForModeration() {
+	public function markForModeration(): void {
 		$this->needsModeration = self::NEEDS_MODERATION;
 	}
 
@@ -120,11 +120,11 @@ class Application {
 		return $this->isConfirmed === self::IS_CONFIRMED;
 	}
 
-	public function confirm() {
+	public function confirm(): void {
 		$this->isConfirmed = self::IS_CONFIRMED;
 	}
 
-	public function confirmSubscriptionCreated() {
+	public function confirmSubscriptionCreated(): void {
 		if ( !$this->hasExternalPayment() ) {
 			throw new RuntimeException( 'Only external payments can be confirmed as booked' );
 		}
@@ -144,7 +144,7 @@ class Application {
 		return !$this->isConfirmed() || $this->needsModeration() || $this->isCancelled();
 	}
 
-	public function markAsDeleted() {
+	public function markAsDeleted(): void {
 		$this->isDeleted = self::IS_DELETED;
 	}
 
@@ -152,7 +152,7 @@ class Application {
 		return $this->isDeleted;
 	}
 
-	public function notifyOfFirstPaymentDate( string $firstPaymentDate ) {
+	public function notifyOfFirstPaymentDate( string $firstPaymentDate ): void {
 		$paymentMethod = $this->getPayment()->getPaymentMethod();
 
 		if ( $paymentMethod instanceof PayPalPayment ) {

--- a/contexts/MembershipContext/src/Domain/Model/Payment.php
+++ b/contexts/MembershipContext/src/Domain/Model/Payment.php
@@ -33,7 +33,7 @@ class Payment {
 		$this->paymentMethod = $paymentMethod;
 	}
 
-	private function assertIsValidInterval( int $intervalInMonths ) {
+	private function assertIsValidInterval( int $intervalInMonths ): void {
 		if ( !in_array( $intervalInMonths, [ 1, 3, 6, 12 ] ) ) {
 			throw new \InvalidArgumentException( 'Interval needs to be 1, 3, 6 or 12' );
 		}

--- a/contexts/MembershipContext/src/Domain/Repositories/ApplicationRepository.php
+++ b/contexts/MembershipContext/src/Domain/Repositories/ApplicationRepository.php
@@ -21,7 +21,7 @@ interface ApplicationRepository {
 	 *
 	 * @throws StoreMembershipApplicationException
 	 */
-	public function storeApplication( Application $application );
+	public function storeApplication( Application $application ): void;
 
 	/**
 	 * @throws GetMembershipApplicationException

--- a/contexts/MembershipContext/src/Infrastructure/LoggingApplicationRepository.php
+++ b/contexts/MembershipContext/src/Infrastructure/LoggingApplicationRepository.php
@@ -36,7 +36,7 @@ class LoggingApplicationRepository implements ApplicationRepository {
 	 *
 	 * @throws StoreMembershipApplicationException
 	 */
-	public function storeApplication( Application $application ) {
+	public function storeApplication( Application $application ): void {
 		try {
 			$this->repository->storeApplication( $application );
 		}

--- a/contexts/MembershipContext/src/Tracking/ApplicationPiwikTracker.php
+++ b/contexts/MembershipContext/src/Tracking/ApplicationPiwikTracker.php
@@ -18,6 +18,6 @@ interface ApplicationPiwikTracker {
 	 *
 	 * @throws ApplicationPiwikTrackingException
 	 */
-	public function trackApplication( int $applicationId, string $trackingString );
+	public function trackApplication( int $applicationId, string $trackingString ): void;
 
 }

--- a/contexts/MembershipContext/src/Tracking/ApplicationTracker.php
+++ b/contexts/MembershipContext/src/Tracking/ApplicationTracker.php
@@ -14,6 +14,6 @@ interface ApplicationTracker {
 	/**
 	 * @throws ApplicationTrackingException
 	 */
-	public function trackApplication( int $applicationId, MembershipApplicationTrackingInfo $trackingInfo );
+	public function trackApplication( int $applicationId, MembershipApplicationTrackingInfo $trackingInfo ): void;
 
 }

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidator.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidator.php
@@ -28,7 +28,7 @@ class ApplyForMembershipPolicyValidator {
 			$this->addressContainsBadWords( $application );
 	}
 
-	public function isAutoDeleted( Application $application ) {
+	public function isAutoDeleted( Application $application ): bool {
 		foreach( $this->emailAddressBlacklist as $blacklistEntry ) {
 			if ( preg_match( $blacklistEntry, $application->getApplicant()->getEmailAddress()->getFullAddress() ) ) {
 				return true;
@@ -44,7 +44,7 @@ class ApplyForMembershipPolicyValidator {
 			> self::YEARLY_PAYMENT_MODERATION_THRESHOLD_IN_EURO;
 	}
 
-	private function addressContainsBadWords( Application $application ) {
+	private function addressContainsBadWords( Application $application ): bool {
 		$applicant = $application->getApplicant();
 		$harmless = $this->textPolicyValidator->textIsHarmless( $applicant->getName()->getFirstName() ) &&
 			$this->textPolicyValidator->textIsHarmless( $applicant->getName()->getLastName() ) &&

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipRequest.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipRequest.php
@@ -45,7 +45,7 @@ class ApplyForMembershipRequest {
 		return $this->membershipType;
 	}
 
-	public function setMembershipType( string $membershipType ) {
+	public function setMembershipType( string $membershipType ): void {
 		$this->assertIsWritable();
 		$this->membershipType = $membershipType;
 	}
@@ -57,7 +57,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantIsCompany;
 	}
 
-	public function markApplicantAsCompany() {
+	public function markApplicantAsCompany(): void {
 		$this->assertIsWritable();
 		$this->applicantIsCompany = true;
 	}
@@ -66,7 +66,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantCompanyName;
 	}
 
-	public function setApplicantCompanyName( string $applicantCompanyName ) {
+	public function setApplicantCompanyName( string $applicantCompanyName ): void {
 		$this->applicantCompanyName = $applicantCompanyName;
 	}
 
@@ -74,7 +74,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantSalutation;
 	}
 
-	public function setApplicantSalutation( string $applicantSalutation ) {
+	public function setApplicantSalutation( string $applicantSalutation ): void {
 		$this->assertIsWritable();
 		$this->applicantSalutation = $applicantSalutation;
 	}
@@ -83,7 +83,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantTitle;
 	}
 
-	public function setApplicantTitle( string $applicantTitle ) {
+	public function setApplicantTitle( string $applicantTitle ): void {
 		$this->assertIsWritable();
 		$this->applicantTitle = $applicantTitle;
 	}
@@ -92,7 +92,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantFirstName;
 	}
 
-	public function setApplicantFirstName( string $applicantFirstName ) {
+	public function setApplicantFirstName( string $applicantFirstName ): void {
 		$this->assertIsWritable();
 		$this->applicantFirstName = $applicantFirstName;
 	}
@@ -101,7 +101,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantLastName;
 	}
 
-	public function setApplicantLastName( string $applicantLastName ) {
+	public function setApplicantLastName( string $applicantLastName ): void {
 		$this->assertIsWritable();
 		$this->applicantLastName = $applicantLastName;
 	}
@@ -110,7 +110,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantStreetAddress;
 	}
 
-	public function setApplicantStreetAddress( string $applicantStreetAddress ) {
+	public function setApplicantStreetAddress( string $applicantStreetAddress ): void {
 		$this->assertIsWritable();
 		$this->applicantStreetAddress = $applicantStreetAddress;
 	}
@@ -119,7 +119,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantPostalCode;
 	}
 
-	public function setApplicantPostalCode( string $applicantPostalCode ) {
+	public function setApplicantPostalCode( string $applicantPostalCode ): void {
 		$this->assertIsWritable();
 		$this->applicantPostalCode = $applicantPostalCode;
 	}
@@ -128,7 +128,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantCity;
 	}
 
-	public function setApplicantCity( string $applicantCity ) {
+	public function setApplicantCity( string $applicantCity ): void {
 		$this->assertIsWritable();
 		$this->applicantCity = $applicantCity;
 	}
@@ -137,7 +137,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantCountryCode;
 	}
 
-	public function setApplicantCountryCode( string $applicantCountryCode ) {
+	public function setApplicantCountryCode( string $applicantCountryCode ): void {
 		$this->assertIsWritable();
 		$this->applicantCountryCode = $applicantCountryCode;
 	}
@@ -146,7 +146,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantEmailAddress;
 	}
 
-	public function setApplicantEmailAddress( string $applicantEmailAddress ) {
+	public function setApplicantEmailAddress( string $applicantEmailAddress ): void {
 		$this->assertIsWritable();
 		$this->applicantEmailAddress = $applicantEmailAddress;
 	}
@@ -155,7 +155,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantPhoneNumber;
 	}
 
-	public function setApplicantPhoneNumber( string $applicantPhoneNumber ) {
+	public function setApplicantPhoneNumber( string $applicantPhoneNumber ): void {
 		$this->assertIsWritable();
 		$this->applicantPhoneNumber = $applicantPhoneNumber;
 	}
@@ -164,7 +164,7 @@ class ApplyForMembershipRequest {
 		return $this->applicantDateOfBirth;
 	}
 
-	public function setApplicantDateOfBirth( string $applicantDateOfBirth ) {
+	public function setApplicantDateOfBirth( string $applicantDateOfBirth ): void {
 		$this->assertIsWritable();
 		$this->applicantDateOfBirth = $applicantDateOfBirth;
 	}
@@ -173,7 +173,7 @@ class ApplyForMembershipRequest {
 		return $this->paymentIntervalInMonths;
 	}
 
-	public function setPaymentIntervalInMonths( int $paymentIntervalInMonths ) {
+	public function setPaymentIntervalInMonths( int $paymentIntervalInMonths ): void {
 		$this->assertIsWritable();
 		$this->paymentIntervalInMonths = $paymentIntervalInMonths;
 	}
@@ -182,19 +182,16 @@ class ApplyForMembershipRequest {
 		return $this->paymentAmount;
 	}
 
-	public function setPaymentAmountInEuros( string $paymentAmount ) {
+	public function setPaymentAmountInEuros( string $paymentAmount ): void {
 		$this->assertIsWritable();
 		$this->paymentAmount = $paymentAmount;
 	}
 
-	/**
-	 * @return BankData|null
-	 */
-	public function getBankData() {
+	public function getBankData(): ?BankData {
 		return $this->bankData;
 	}
 
-	public function setBankData( BankData $bankData ) {
+	public function setBankData( BankData $bankData ): void {
 		$this->assertIsWritable();
 		$this->bankData = $bankData;
 	}
@@ -203,7 +200,7 @@ class ApplyForMembershipRequest {
 		return $this->trackingInfo;
 	}
 
-	public function setTrackingInfo( MembershipApplicationTrackingInfo $trackingInfo ) {
+	public function setTrackingInfo( MembershipApplicationTrackingInfo $trackingInfo ): void {
 		$this->assertIsWritable();
 		$this->trackingInfo = $trackingInfo;
 	}
@@ -212,7 +209,7 @@ class ApplyForMembershipRequest {
 		return $this->piwikTrackingString;
 	}
 
-	public function setPiwikTrackingString( string $piwikTrackingString ) {
+	public function setPiwikTrackingString( string $piwikTrackingString ): void {
 		$this->assertIsWritable();
 		$this->piwikTrackingString = $piwikTrackingString;
 	}
@@ -221,7 +218,7 @@ class ApplyForMembershipRequest {
 		return $this->paymentType;
 	}
 
-	public function setPaymentType( string $paymentType ) {
+	public function setPaymentType( string $paymentType ): void {
 		$this->assertIsWritable();
 		$this->paymentType = $paymentType;
 	}

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/ApplyForMembershipUseCase.php
@@ -91,7 +91,7 @@ class ApplyForMembershipUseCase {
 		return ( new MembershipApplicationBuilder() )->newApplicationFromRequest( $request );
 	}
 
-	private function sendConfirmationEmail( Application $application ) {
+	private function sendConfirmationEmail( Application $application ): void {
 		$this->mailer->sendMail(
 			$application->getApplicant()->getEmailAddress(),
 			[

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
@@ -70,7 +70,7 @@ class MembershipApplicationValidator {
 		return new Result( $this->violations );
 	}
 
-	private function validateFee() {
+	private function validateFee(): void {
 		$result = $this->feeValidator->validate(
 			$this->request->getPaymentAmountInEuros(),
 			$this->request->getPaymentIntervalInMonths(),
@@ -85,11 +85,11 @@ class MembershipApplicationValidator {
 			FeeValidator::APPLICANT_TYPE_COMPANY : FeeValidator::APPLICANT_TYPE_PERSON;
 	}
 
-	private function addViolations( array $violations ) {
+	private function addViolations( array $violations ): void {
 		$this->violations = array_merge( $this->violations, $violations );
 	}
 
-	private function validateBankData() {
+	private function validateBankData(): void {
 		$bankData = $this->request->getBankData();
 		$validationResult = $this->bankDataValidator->validate( $bankData );
 		$violations = [];
@@ -136,7 +136,7 @@ class MembershipApplicationValidator {
 		}
 	}
 
-	private function validateApplicantDateOfBirth() {
+	private function validateApplicantDateOfBirth(): void {
 		$dob = $this->request->getApplicantDateOfBirth();
 
 		if ( $dob !== '' && !strtotime( $dob ) ) {
@@ -144,7 +144,7 @@ class MembershipApplicationValidator {
 		}
 	}
 
-	private function validateApplicantContactInfo() {
+	private function validateApplicantContactInfo(): void {
 		$this->validatePhoneNumber();
 
 		$this->validateFieldLength( $this->request->getApplicantEmailAddress(), Result::SOURCE_APPLICANT_EMAIL );
@@ -153,7 +153,7 @@ class MembershipApplicationValidator {
 		}
 	}
 
-	private function validatePhoneNumber() {
+	private function validatePhoneNumber(): void {
 		$phoneNumber = $this->request->getApplicantPhoneNumber();
 
 		$this->validateFieldLength( $phoneNumber, Result::SOURCE_APPLICANT_PHONE_NUMBER );
@@ -162,7 +162,7 @@ class MembershipApplicationValidator {
 		}
 	}
 
-	private function validateApplicantName() {
+	private function validateApplicantName(): void {
 		if ( $this->request->isCompanyApplication() ) {
 			$this->validateCompanyName();
 		}
@@ -171,14 +171,14 @@ class MembershipApplicationValidator {
 		}
 	}
 
-	private function validateCompanyName() {
+	private function validateCompanyName(): void {
 		if ( $this->request->getApplicantCompanyName() === '' ) {
 			$this->violations[Result::SOURCE_APPLICANT_COMPANY] = Result::VIOLATION_MISSING;
 		}
 		$this->validateFieldLength( $this->request->getApplicantCompanyName(), Result::SOURCE_APPLICANT_COMPANY );
 	}
 
-	private function validatePersonName() {
+	private function validatePersonName(): void {
 		if ( $this->request->getApplicantFirstName() === '' ) {
 			$this->violations[Result::SOURCE_APPLICANT_FIRST_NAME] = Result::VIOLATION_MISSING;
 		}
@@ -195,7 +195,7 @@ class MembershipApplicationValidator {
 		$this->validateFieldLength( $this->request->getApplicantSalutation(), Result::SOURCE_APPLICANT_SALUTATION );
 	}
 
-	private function validateApplicantAddress() {
+	private function validateApplicantAddress(): void {
 		if ( $this->request->getApplicantStreetAddress() === '' ) {
 			$this->violations[Result::SOURCE_APPLICANT_STREET_ADDRESS] = Result::VIOLATION_MISSING;
 		}
@@ -220,7 +220,7 @@ class MembershipApplicationValidator {
 		$this->validateFieldLength( $this->request->getApplicantCountryCode(), Result::SOURCE_APPLICANT_COUNTRY );
 	}
 
-	private function validateFieldLength( string $value, string $fieldName ) {
+	private function validateFieldLength( string $value, string $fieldName ): void {
 		if ( strlen( $value ) > $this->maximumFieldLengths[$fieldName] )  {
 			$this->violations[$fieldName] = Result::VIOLATION_WRONG_LENGTH;
 		}

--- a/contexts/MembershipContext/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
+++ b/contexts/MembershipContext/src/UseCases/ApplyForMembership/MembershipApplicationValidator.php
@@ -80,7 +80,7 @@ class MembershipApplicationValidator {
 		$this->addViolations( $result->getViolations() );
 	}
 
-	private function getApplicantType() {
+	private function getApplicantType(): string {
 		return $this->request->isCompanyApplication() ?
 			FeeValidator::APPLICANT_TYPE_COMPANY : FeeValidator::APPLICANT_TYPE_PERSON;
 	}

--- a/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
@@ -55,7 +55,7 @@ class CancelMembershipApplicationUseCase {
 		return $this->newSuccessResponse( $request );
 	}
 
-	private function getApplicationById( int $id ) {
+	private function getApplicationById( int $id ): ?Application {
 		try {
 			return $this->repository->getApplicationById( $id );
 		}
@@ -65,11 +65,11 @@ class CancelMembershipApplicationUseCase {
 		}
 	}
 
-	private function newFailureResponse( CancellationRequest $request ) {
+	private function newFailureResponse( CancellationRequest $request ): CancellationResponse {
 		return new CancellationResponse( $request->getApplicationId(), CancellationResponse::IS_FAILURE );
 	}
 
-	private function newSuccessResponse( CancellationRequest $request ) {
+	private function newSuccessResponse( CancellationRequest $request ): CancellationResponse {
 		return new CancellationResponse( $request->getApplicationId(), CancellationResponse::IS_SUCCESS );
 	}
 

--- a/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCase.php
@@ -73,7 +73,7 @@ class CancelMembershipApplicationUseCase {
 		return new CancellationResponse( $request->getApplicationId(), CancellationResponse::IS_SUCCESS );
 	}
 
-	private function sendConfirmationEmail( Application $application ) {
+	private function sendConfirmationEmail( Application $application ): void {
 		$this->mailer->sendMail(
 			$application->getApplicant()->getEmailAddress(),
 			$this->getConfirmationMailTemplateArguments( $application )

--- a/contexts/MembershipContext/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCase.php
@@ -113,10 +113,7 @@ class HandleSubscriptionPaymentNotificationUseCase {
 			->setPaymentTimestamp( $request->getPaymentTimestamp() );
 	}
 
-	/**
-	 * @return null|Application
-	 */
-	private function createChildApplication( Application $application, PayPalPaymentNotificationRequest $request ) {
+	private function createChildApplication( Application $application, PayPalPaymentNotificationRequest $request ): ?Application {
 		$childApplication = Application::newApplication(
 			$application->getType(),
 			$application->getApplicant(),

--- a/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCase.php
@@ -94,7 +94,7 @@ class HandleSubscriptionSignupNotificationUseCase {
 		] );
 	}
 
-	private function sendConfirmationEmail( Application $application ) {
+	private function sendConfirmationEmail( Application $application ): void {
 		try {
 			$this->mailer->sendMail( $application->getApplicant()->getEmailAddress() );
 		} catch ( \RuntimeException $ex ) {

--- a/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipAppConfirmationResponse.php
+++ b/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipAppConfirmationResponse.php
@@ -33,7 +33,7 @@ class ShowMembershipAppConfirmationResponse {
 	 *
 	 * @return Application|null
 	 */
-	public function getApplication() {
+	public function getApplication(): ?Application {
 		return $this->membershipApplication;
 	}
 

--- a/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipAppConfirmationResponse.php
+++ b/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipAppConfirmationResponse.php
@@ -37,7 +37,7 @@ class ShowMembershipAppConfirmationResponse {
 		return $this->membershipApplication;
 	}
 
-	public function getUpdateToken() {
+	public function getUpdateToken(): ?string {
 		return $this->updateToken;
 	}
 

--- a/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipApplicationConfirmationUseCase.php
+++ b/contexts/MembershipContext/src/UseCases/ShowMembershipApplicationConfirmation/ShowMembershipApplicationConfirmationUseCase.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\Frontend\MembershipContext\UseCases\ShowMembershipApp
 
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationAuthorizer;
 use WMDE\Fundraising\Frontend\MembershipContext\Authorization\ApplicationTokenFetcher;
+use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\Application;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\ApplicationRepository;
 use WMDE\Fundraising\Frontend\MembershipContext\Domain\Repositories\GetMembershipApplicationException;
 
@@ -44,7 +45,7 @@ class ShowMembershipApplicationConfirmationUseCase {
 		return ShowMembershipAppConfirmationResponse::newNotAllowedResponse();
 	}
 
-	private function getMembershipApplicationById( int $applicationId ) {
+	private function getMembershipApplicationById( int $applicationId ): ?Application {
 		try {
 			return $this->repository->getApplicationById( $applicationId );
 		}

--- a/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
+++ b/contexts/MembershipContext/tests/Data/ValidMembershipApplication.php
@@ -154,7 +154,7 @@ class ValidMembershipApplication {
 		);
 	}
 
-	private function createApplicationUsingPayPal( $payPalData ): Application {
+	private function createApplicationUsingPayPal( PayPalData $payPalData = null ): Application {
 		$self = ( new self() );
 		return Application::newApplication(
 			self::MEMBERSHIP_TYPE,
@@ -208,11 +208,11 @@ class ValidMembershipApplication {
 		);
 	}
 
-	private function newDirectDebitPayment( BankData $bankData ) {
+	private function newDirectDebitPayment( BankData $bankData ): DirectDebitPayment {
 		return new DirectDebitPayment( $bankData );
 	}
 
-	private function newPayPalPayment( $payPalData = null ) {
+	private function newPayPalPayment( PayPalData $payPalData = null ): Payment {
 		return new Payment(
 			self::PAYMENT_PERIOD_IN_MONTHS,
 			Euro::newFromFloat( self::PAYMENT_AMOUNT_IN_EURO ),

--- a/contexts/MembershipContext/tests/Data/ValidMembershipApplicationRequest.php
+++ b/contexts/MembershipContext/tests/Data/ValidMembershipApplicationRequest.php
@@ -70,7 +70,7 @@ class ValidMembershipApplicationRequest {
 		return $bankData->assertNoNullFields();
 	}
 
-	private function newTrackingInfo() {
+	private function newTrackingInfo(): MembershipApplicationTrackingInfo {
 		return new MembershipApplicationTrackingInfo(
 			ValidMembershipApplication::TEMPLATE_CAMPAIGN,
 			ValidMembershipApplication::TEMPLATE_NAME

--- a/contexts/MembershipContext/tests/Fixtures/ApplicationRepositorySpy.php
+++ b/contexts/MembershipContext/tests/Fixtures/ApplicationRepositorySpy.php
@@ -21,7 +21,7 @@ class ApplicationRepositorySpy extends FakeApplicationRepository {
 		$this->storeApplicationCalls = []; // remove calls coming from initialization
 	}
 
-	public function storeApplication( Application $application ) {
+	public function storeApplication( Application $application ): void {
 		$this->storeApplicationCalls[] = clone( $application ); // protect against the application being changed later
 		parent::storeApplication( $application );
 	}

--- a/contexts/MembershipContext/tests/Fixtures/FakeApplicationRepository.php
+++ b/contexts/MembershipContext/tests/Fixtures/FakeApplicationRepository.php
@@ -26,15 +26,15 @@ class FakeApplicationRepository implements ApplicationRepository {
 		}
 	}
 
-	public function throwOnRead() {
+	public function throwOnRead(): void {
 		$this->throwOnRead = true;
 	}
 
-	public function throwOnWrite() {
+	public function throwOnWrite(): void {
 		$this->throwOnWrite = true;
 	}
 
-	public function storeApplication( Application $application ) {
+	public function storeApplication( Application $application ): void {
 		if ( $this->throwOnWrite ) {
 			throw new StoreMembershipApplicationException();
 		}

--- a/contexts/MembershipContext/tests/Fixtures/InMemoryApplicationRepository.php
+++ b/contexts/MembershipContext/tests/Fixtures/InMemoryApplicationRepository.php
@@ -27,7 +27,7 @@ class InMemoryApplicationRepository implements ApplicationRepository {
 	 *
 	 * @throws StoreMembershipApplicationException
 	 */
-	public function storeApplication( Application $application ) {
+	public function storeApplication( Application $application ): void {
 		if ( !$application->hasId() ) {
 			$application->assignId( $this->nextNewId++ );
 		}

--- a/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationAuthorizerTest.php
+++ b/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationAuthorizerTest.php
@@ -46,7 +46,7 @@ class DoctrineMembershipApplicationAuthorizerTest extends \PHPUnit\Framework\Tes
 	/**
 	 * @slowThreshold 400
 	 */
-	public function testWhenNoMembershipApplications() {
+	public function testWhenNoMembershipApplications(): void {
 		$this->specify( 'update authorization fails', function() {
 			$authorizer = $this->newAuthorizerWithApplications( self::CORRECT_UPDATE_TOKEN );
 			$this->assertFalse( $authorizer->canModifyApplication( self::MEANINGLESS_APPLICATION_ID ) );
@@ -61,7 +61,7 @@ class DoctrineMembershipApplicationAuthorizerTest extends \PHPUnit\Framework\Tes
 	/**
 	 * @slowThreshold 1200
 	 */
-	public function testWhenApplicationWithTokenExists() {
+	public function testWhenApplicationWithTokenExists(): void {
 		$application = new MembershipApplication();
 
 		$application->modifyDataObject( function( MembershipApplicationData $data ) {
@@ -121,7 +121,7 @@ class DoctrineMembershipApplicationAuthorizerTest extends \PHPUnit\Framework\Tes
 	/**
 	 * @slowThreshold 400
 	 */
-	public function testWhenApplicationWithoutTokenExists() {
+	public function testWhenApplicationWithoutTokenExists(): void {
 		$application = new MembershipApplication();
 
 		$this->specify(
@@ -144,7 +144,7 @@ class DoctrineMembershipApplicationAuthorizerTest extends \PHPUnit\Framework\Tes
 	/**
 	 * @slowThreshold 400
 	 */
-	public function testWhenDoctrineThrowsException() {
+	public function testWhenDoctrineThrowsException(): void {
 		$authorizer = new DoctrineApplicationAuthorizer(
 			$this->getThrowingEntityManager(),
 			self::CORRECT_UPDATE_TOKEN,

--- a/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
+++ b/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationRepositoryTest.php
@@ -31,14 +31,14 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 	 */
 	private $entityManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		$factory = TestEnvironment::newInstance()->getFactory();
 		$factory->disableDoctrineSubscribers();
 		$this->entityManager = $factory->getEntityManager();
 		parent::setUp();
 	}
 
-	public function testValidMembershipApplicationGetPersisted() {
+	public function testValidMembershipApplicationGetPersisted(): void {
 		$this->newRepository()->storeApplication( ValidMembershipApplication::newDomainEntity() );
 
 		$expectedDoctrineEntity = ValidMembershipApplication::newDoctrineEntity();
@@ -51,7 +51,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		return new DoctrineApplicationRepository( $this->entityManager );
 	}
 
-	private function assertDoctrineEntityIsInDatabase( DoctrineApplication $expected ) {
+	private function assertDoctrineEntityIsInDatabase( DoctrineApplication $expected ): void {
 		$actual = $this->getApplicationFromDatabase( $expected->getId() );
 
 		$this->assertNotNull( $actual->getCreationTime() );
@@ -69,7 +69,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		return $donation;
 	}
 
-	public function testIdGetsAssigned() {
+	public function testIdGetsAssigned(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 
 		$this->newRepository()->storeApplication( $application );
@@ -77,7 +77,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertSame( self::MEMBERSHIP_APPLICATION_ID, $application->getId() );
 	}
 
-	public function testWhenPersistenceFails_domainExceptionIsThrown() {
+	public function testWhenPersistenceFails_domainExceptionIsThrown(): void {
 		$donation = ValidMembershipApplication::newDomainEntity();
 
 		$repository = new DoctrineApplicationRepository( ThrowingEntityManager::newInstance( $this ) );
@@ -86,7 +86,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$repository->storeApplication( $donation );
 	}
 
-	public function testWhenMembershipApplicationInDatabase_itIsReturnedAsMatchingDomainEntity() {
+	public function testWhenMembershipApplicationInDatabase_itIsReturnedAsMatchingDomainEntity(): void {
 		$this->storeDoctrineApplication( ValidMembershipApplication::newDoctrineEntity() );
 
 		$expected = ValidMembershipApplication::newAutoConfirmedDomainEntity();
@@ -98,23 +98,23 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		);
 	}
 
-	private function storeDoctrineApplication( DoctrineApplication $application ) {
+	private function storeDoctrineApplication( DoctrineApplication $application ): void {
 		$this->entityManager->persist( $application );
 		$this->entityManager->flush();
 	}
 
-	public function testWhenEntityDoesNotExist_getEntityReturnsNull() {
+	public function testWhenEntityDoesNotExist_getEntityReturnsNull(): void {
 		$this->assertNull( $this->newRepository()->getApplicationById( self::ID_OF_APPLICATION_NOT_IN_DB ) );
 	}
 
-	public function testWhenReadFails_domainExceptionIsThrown() {
+	public function testWhenReadFails_domainExceptionIsThrown(): void {
 		$repository = new DoctrineApplicationRepository( ThrowingEntityManager::newInstance( $this ) );
 
 		$this->expectException( GetMembershipApplicationException::class );
 		$repository->getApplicationById( self::ID_OF_APPLICATION_NOT_IN_DB );
 	}
 
-	public function testWhenApplicationAlreadyExists_persistingCausesUpdate() {
+	public function testWhenApplicationAlreadyExists_persistingCausesUpdate(): void {
 		$repository = $this->newRepository();
 		$originalApplication = ValidMembershipApplication::newDomainEntity();
 
@@ -132,7 +132,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertSame( 'chuck.norris@always.win', $doctrineApplication->getApplicantEmailAddress() );
 	}
 
-	public function testWriteAndReadRoundtrip() {
+	public function testWriteAndReadRoundtrip(): void {
 		$repository = $this->newRepository();
 		$application = ValidMembershipApplication::newAutoConfirmedDomainEntity();
 
@@ -144,7 +144,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		);
 	}
 
-	public function testWhenPersistingDeletedApplication_exceptionIsThrown() {
+	public function testWhenPersistingDeletedApplication_exceptionIsThrown(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->assignId( self::ID_OF_APPLICATION_NOT_IN_DB );
 
@@ -154,7 +154,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$repository->storeApplication( $application );
 	}
 
-	public function testWhenPersistingApplicationWithModerationFlag_doctrineApplicationHasFlag() {
+	public function testWhenPersistingApplicationWithModerationFlag_doctrineApplicationHasFlag(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->markForModeration();
 
@@ -165,7 +165,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertFalse( $doctrineApplication->isCancelled() );
 	}
 
-	public function testWhenPersistingApplicationWithCancelledFlag_doctrineApplicationHasFlag() {
+	public function testWhenPersistingApplicationWithCancelledFlag_doctrineApplicationHasFlag(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->cancel();
 
@@ -176,7 +176,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertTrue( $doctrineApplication->isCancelled() );
 	}
 
-	public function testWhenPersistingCancelledModerationApplication_doctrineApplicationHasFlags() {
+	public function testWhenPersistingCancelledModerationApplication_doctrineApplicationHasFlags(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->markForModeration();
 		$application->cancel();
@@ -188,7 +188,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertTrue( $doctrineApplication->isCancelled() );
 	}
 
-	public function testGivenDoctrineApplicationWithModerationAndCancelled_domainEntityHasFlags() {
+	public function testGivenDoctrineApplicationWithModerationAndCancelled_domainEntityHasFlags(): void {
 		$doctrineApplication = ValidMembershipApplication::newDoctrineEntity();
 		$doctrineApplication->setStatus( DoctrineApplication::STATUS_CANCELED + DoctrineApplication::STATUS_MODERATION );
 
@@ -199,7 +199,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertTrue( $application->isCancelled() );
 	}
 
-	public function testGivenDoctrineApplicationWithModerationFlag_domainEntityHasFlag() {
+	public function testGivenDoctrineApplicationWithModerationFlag_domainEntityHasFlag(): void {
 		$doctrineApplication = ValidMembershipApplication::newDoctrineEntity();
 		$doctrineApplication->setStatus( DoctrineApplication::STATUS_MODERATION );
 
@@ -210,7 +210,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertFalse( $application->isCancelled() );
 	}
 
-	public function testGivenDoctrineApplicationWithCancelledFlag_domainEntityHasFlag() {
+	public function testGivenDoctrineApplicationWithCancelledFlag_domainEntityHasFlag(): void {
 		$doctrineApplication = ValidMembershipApplication::newDoctrineEntity();
 		$doctrineApplication->setStatus( DoctrineApplication::STATUS_CANCELED );
 
@@ -221,7 +221,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertTrue( $application->isCancelled() );
 	}
 
-	public function testGivenDoctrineApplicationWithCancelledFlag_initialStatusIsPreserved() {
+	public function testGivenDoctrineApplicationWithCancelledFlag_initialStatusIsPreserved(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->cancel();
 
@@ -231,7 +231,7 @@ class DoctrineMembershipApplicationRepositoryTest extends \PHPUnit\Framework\Tes
 		$this->assertSame( DoctrineApplication::STATUS_CONFIRMED, $doctrineApplication->getDataObject()->getPreservedStatus() );
 	}
 
-	public function testGivenCompanyApplication_companyNameIsPersisted() {
+	public function testGivenCompanyApplication_companyNameIsPersisted(): void {
 		$this->newRepository()->storeApplication( ValidMembershipApplication::newCompanyApplication() );
 
 		$expectedDoctrineEntity = ValidMembershipApplication::newDoctrineCompanyEntity();

--- a/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationTrackerTest.php
+++ b/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationTrackerTest.php
@@ -25,14 +25,14 @@ class DoctrineMembershipApplicationTrackerTest extends \PHPUnit\Framework\TestCa
 	 */
 	private $entityManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 	}
 
 	/**
 	 * @dataProvider validTrackingDataProvider
 	 */
-	public function testValidTrackingDataIsProperlyApplied( string $campaignCode, string $keyword ) {
+	public function testValidTrackingDataIsProperlyApplied( string $campaignCode, string $keyword ): void {
 		$application = ValidMembershipApplication::newDoctrineEntity();
 		$this->persistApplication( $application );
 
@@ -56,7 +56,7 @@ class DoctrineMembershipApplicationTrackerTest extends \PHPUnit\Framework\TestCa
 		];
 	}
 
-	private function persistApplication( MembershipApplication $application ) {
+	private function persistApplication( MembershipApplication $application ): void {
 		$this->entityManager->persist( $application );
 		$this->entityManager->flush();
 	}

--- a/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationTrackerTest.php
+++ b/contexts/MembershipContext/tests/Integration/DataAccess/DoctrineMembershipApplicationTrackerTest.php
@@ -47,7 +47,7 @@ class DoctrineMembershipApplicationTrackerTest extends \PHPUnit\Framework\TestCa
 		$this->assertSame( $campaignCode, $storedApplication->getDecodedData()['confirmationPageCampaign'] );
 	}
 
-	public function validTrackingDataProvider() {
+	public function validTrackingDataProvider(): array {
 		return [
 			[ 'campaignCode', 'keyword' ],
 			[ '', 'keyword', 'keyword' ],
@@ -69,7 +69,7 @@ class DoctrineMembershipApplicationTrackerTest extends \PHPUnit\Framework\TestCa
 		return new DoctrineApplicationTracker( $this->entityManager );
 	}
 
-	private function newMembershipApplicationTrackingInfo( $campaignCode, $keyword ) {
+	private function newMembershipApplicationTrackingInfo( string $campaignCode, string $keyword ): MembershipApplicationTrackingInfo {
 		return new MembershipApplicationTrackingInfo( $campaignCode, $keyword );
 	}
 

--- a/contexts/MembershipContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/contexts/MembershipContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 
 	/** @dataProvider encodedMembershipDataProvider */
-	public function testDataFieldOfMembershipApplicationIsInteractedWithCorrectly( $data ) {
+	public function testDataFieldOfMembershipApplicationIsInteractedWithCorrectly( $data ): void {
 		$entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 
 		$repository = new DoctrineApplicationRepository( $entityManager );
@@ -67,7 +67,7 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	private function storeMembershipApplication( EntityManager $entityManager, array $data ) {
+	private function storeMembershipApplication( EntityManager $entityManager, array $data ): void {
 		$membershipAppl = new MembershipApplication();
 
 		$membershipAppl->setApplicantSalutation( 'Frau' );

--- a/contexts/MembershipContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
+++ b/contexts/MembershipContext/tests/Integration/DataAccess/SerializedDataHandlingTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 
 	/** @dataProvider encodedMembershipDataProvider */
-	public function testDataFieldOfMembershipApplicationIsInteractedWithCorrectly( $data ): void {
+	public function testDataFieldOfMembershipApplicationIsInteractedWithCorrectly( array $data ): void {
 		$entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 
 		$repository = new DoctrineApplicationRepository( $entityManager );
@@ -30,7 +30,7 @@ class SerializedDataHandlingTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $data, $dma->getDecodedData() );
 	}
 
-	public function encodedMembershipDataProvider() {
+	public function encodedMembershipDataProvider(): array {
 		return [
 			[
 				[

--- a/contexts/MembershipContext/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/contexts/MembershipContext/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -167,7 +167,7 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $bankData->assertNoNullFields()->freeze();
 	}
 
-	private function newTrackingInfo() {
+	private function newTrackingInfo(): MembershipApplicationTrackingInfo {
 		return new MembershipApplicationTrackingInfo(
 			ValidMembershipApplication::TEMPLATE_CAMPAIGN,
 			ValidMembershipApplication::TEMPLATE_NAME

--- a/contexts/MembershipContext/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/contexts/MembershipContext/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -75,7 +75,7 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 	/** @var  ApplyForMembershipPolicyValidator */
 	private $policyValidator;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->repository = new InMemoryApplicationRepository();
 		$this->mailer = new TemplateBasedMailerSpy( $this );
 		$this->tokenGenerator = new FixedTokenGenerator( self::ACCESS_TOKEN );
@@ -96,7 +96,7 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $validator;
 	}
 
-	public function testGivenValidRequest_applicationSucceeds() {
+	public function testGivenValidRequest_applicationSucceeds(): void {
 		$response = $this->newUseCase()->applyForMembership( $this->newValidRequest() );
 
 		$this->assertTrue( $response->isSuccessful() );
@@ -174,7 +174,7 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenValidRequest_applicationGetsPersisted() {
+	public function testGivenValidRequest_applicationGetsPersisted(): void {
 		$this->newUseCase()->applyForMembership( $this->newValidRequest() );
 
 		$expectedApplication = ValidMembershipApplication::newDomainEntity();
@@ -186,7 +186,7 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $expectedApplication, $application );
 	}
 
-	public function testGivenValidRequest_confirmationEmailIsSend() {
+	public function testGivenValidRequest_confirmationEmailIsSend(): void {
 		$this->newUseCase()->applyForMembership( $this->newValidRequest() );
 
 		$this->mailer->assertCalledOnceWith(
@@ -202,14 +202,14 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenValidRequest_tokenIsGeneratedAndReturned() {
+	public function testGivenValidRequest_tokenIsGeneratedAndReturned(): void {
 		$response = $this->newUseCase()->applyForMembership( $this->newValidRequest() );
 
 		$this->assertSame( self::ACCESS_TOKEN, $response->getAccessToken() );
 		$this->assertSame( self::UPDATE_TOKEN, $response->getUpdateToken() );
 	}
 
-	public function testWhenValidationFails_failureResultIsReturned() {
+	public function testWhenValidationFails_failureResultIsReturned(): void {
 		$this->validator = $this->newFailingValidator();
 
 		$response = $this->newUseCase()->applyForMembership( $this->newValidRequest() );
@@ -238,13 +238,13 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $invalidResult;
 	}
 
-	public function testGivenValidRequest_moderationIsNotNeeded() {
+	public function testGivenValidRequest_moderationIsNotNeeded(): void {
 		$response = $this->newUseCase()->applyForMembership( $this->newValidRequest() );
 
 		$this->assertFalse( $response->getMembershipApplication()->needsModeration() );
 	}
 
-	public function testGivenFailingPolicyValidator_moderationIsNeeded() {
+	public function testGivenFailingPolicyValidator_moderationIsNeeded(): void {
 		$this->policyValidator = $this->newFailingPolicyValidator();
 
 		$response = $this->newUseCase()->applyForMembership( $this->newValidRequest() );
@@ -265,7 +265,7 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $policyValidator;
 	}
 
-	public function testWhenApplicationIsUnconfirmed_confirmationEmailIsNotSent() {
+	public function testWhenApplicationIsUnconfirmed_confirmationEmailIsNotSent(): void {
 		$this->newUseCase()->applyForMembership( $this->newValidRequestForUnconfirmedApplication() );
 
 		$this->assertSame( 0, count( $this->mailer->getSendMailCalls() ) );
@@ -306,13 +306,13 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 		return $policyValidator;
 	}
 
-	public function testWhenUsingBlacklistedEmailAddress_moderationIsAutomaticallyDeleted() {
+	public function testWhenUsingBlacklistedEmailAddress_moderationIsAutomaticallyDeleted(): void {
 		$this->policyValidator = $this->newAutoDeletingPolicyValidator();
 		$this->newUseCase()->applyForMembership( $this->newValidRequest() );
 		$this->assertTrue( $this->repository->getApplicationById( 1 )->isDeleted() );
 	}
 
-	public function testWhenUsingPayPalPayment_delayInDaysIsPersisted() {
+	public function testWhenUsingPayPalPayment_delayInDaysIsPersisted(): void {
 		$request = $this->newValidRequest();
 		$request->setPaymentType( 'PPL' );
 		$this->newUseCase()->applyForMembership( $request );

--- a/contexts/MembershipContext/tests/Integration/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCaseTest.php
+++ b/contexts/MembershipContext/tests/Integration/UseCases/CancelMembershipApplication/CancelMembershipApplicationUseCaseTest.php
@@ -40,13 +40,13 @@ class CancelMembershipApplicationUseCaseTest extends \PHPUnit\Framework\TestCase
 	 */
 	private $mailer;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->authorizer = new SucceedingAuthorizer();
 		$this->repository = new InMemoryApplicationRepository();
 		$this->mailer = new TemplateBasedMailerSpy( $this );
 	}
 
-	public function testGivenIdOfUnknownDonation_cancellationIsNotSuccessful() {
+	public function testGivenIdOfUnknownDonation_cancellationIsNotSuccessful(): void {
 		$useCase = $this->newUseCase();
 
 		$response = $useCase->cancelApplication( new CancellationRequest( self::ID_OF_NON_EXISTING_APPLICATION ) );
@@ -62,7 +62,7 @@ class CancelMembershipApplicationUseCaseTest extends \PHPUnit\Framework\TestCase
 		);
 	}
 
-	public function testFailureResponseContainsApplicationId() {
+	public function testFailureResponseContainsApplicationId(): void {
 		$useCase = $this->newUseCase();
 
 		$response = $useCase->cancelApplication( new CancellationRequest( self::ID_OF_NON_EXISTING_APPLICATION ) );
@@ -70,7 +70,7 @@ class CancelMembershipApplicationUseCaseTest extends \PHPUnit\Framework\TestCase
 		$this->assertEquals( self::ID_OF_NON_EXISTING_APPLICATION, $response->getMembershipApplicationId() );
 	}
 
-	public function testGivenIdOfCancellableApplication_cancellationIsSuccessful() {
+	public function testGivenIdOfCancellableApplication_cancellationIsSuccessful(): void {
 		$application = $this->newCancelableApplication();
 		$this->storeApplication( $application );
 
@@ -84,11 +84,11 @@ class CancelMembershipApplicationUseCaseTest extends \PHPUnit\Framework\TestCase
 		return ValidMembershipApplication::newDomainEntity();
 	}
 
-	private function storeApplication( Application $application ) {
+	private function storeApplication( Application $application ): void {
 		$this->repository->storeApplication( $application );
 	}
 
-	public function testWhenApplicationGetsCancelled_cancellationConfirmationEmailIsSend() {
+	public function testWhenApplicationGetsCancelled_cancellationConfirmationEmailIsSend(): void {
 		$application = $this->newCancelableApplication();
 		$this->storeApplication( $application );
 
@@ -107,7 +107,7 @@ class CancelMembershipApplicationUseCaseTest extends \PHPUnit\Framework\TestCase
 		);
 	}
 
-	public function testNotAuthorized_cancellationFails() {
+	public function testNotAuthorized_cancellationFails(): void {
 		$this->authorizer = new FailingAuthorizer();
 
 		$application = $this->newCancelableApplication();
@@ -118,7 +118,7 @@ class CancelMembershipApplicationUseCaseTest extends \PHPUnit\Framework\TestCase
 		$this->assertFalse( $response->cancellationWasSuccessful() );
 	}
 
-	public function testNotAuthorized_cancellationSucceeds() {
+	public function testNotAuthorized_cancellationSucceeds(): void {
 		$this->authorizer = new SucceedingAuthorizer();
 
 		$application = $this->newCancelableApplication();

--- a/contexts/MembershipContext/tests/Integration/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCaseTest.php
+++ b/contexts/MembershipContext/tests/Integration/UseCases/HandleSubscriptionPaymentNotification/HandleSubscriptionPaymentNotificationUseCaseTest.php
@@ -25,7 +25,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\ThrowingEntityManager;
  */
 class HandleSubscriptionPaymentNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenRepositoryThrowsException_requestIsNotHandled() {
+	public function testWhenRepositoryThrowsException_requestIsNotHandled(): void {
 		$useCase = new HandleSubscriptionPaymentNotificationUseCase(
 			new DoctrineApplicationRepository( ThrowingEntityManager::newInstance( $this ) ),
 			new SucceedingAuthorizer(),
@@ -38,7 +38,7 @@ class HandleSubscriptionPaymentNotificationUseCaseTest extends \PHPUnit\Framewor
 		$this->assertTrue( $response->hasErrors() );
 	}
 
-	public function testWhenApplicationDoesNotExist_requestIsNotHandled() {
+	public function testWhenApplicationDoesNotExist_requestIsNotHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 		$fakeRepository->storeApplication( ValidMembershipApplication::newDomainEntityUsingPayPal() );
 
@@ -55,7 +55,7 @@ class HandleSubscriptionPaymentNotificationUseCaseTest extends \PHPUnit\Framewor
 		$this->assertFalse( $response->notificationWasHandled() );
 	}
 
-	public function testWhenAuthorizationFails_requestIsNotHandled() {
+	public function testWhenAuthorizationFails_requestIsNotHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 		$fakeRepository->storeApplication( ValidMembershipApplication::newDomainEntityUsingPayPal() );
 
@@ -72,7 +72,7 @@ class HandleSubscriptionPaymentNotificationUseCaseTest extends \PHPUnit\Framewor
 		$this->assertFalse( $response->notificationWasHandled() );
 	}
 
-	public function testWhenTransactionTypeIsForSubscriptionChanges_requestIsNotHandled() {
+	public function testWhenTransactionTypeIsForSubscriptionChanges_requestIsNotHandled(): void {
 		$request = ValidPayPalNotificationRequest::newSubscriptionModification();
 
 		$useCase = new HandleSubscriptionPaymentNotificationUseCase(
@@ -86,7 +86,7 @@ class HandleSubscriptionPaymentNotificationUseCaseTest extends \PHPUnit\Framewor
 		$this->assertFalse( $response->notificationWasHandled() );
 	}
 
-	public function testGivenSubscriptionPaymentRequest_childDataSetIsCreated() {
+	public function testGivenSubscriptionPaymentRequest_childDataSetIsCreated(): void {
 		$application = ValidMembershipApplication::newConfirmedSubscriptionDomainEntity();
 
 		$fakeRepository = new FakeApplicationRepository();
@@ -120,7 +120,7 @@ class HandleSubscriptionPaymentNotificationUseCaseTest extends \PHPUnit\Framewor
 		$this->assertTrue( $childApplication->isConfirmed() );
 	}
 
-	public function testGivenExistingTransactionId_requestIsNotHandled() {
+	public function testGivenExistingTransactionId_requestIsNotHandled(): void {
 		$application = ValidMembershipApplication::newConfirmedSubscriptionDomainEntity();
 		/** @var PayPalPayment $payment */
 		$payment = $application->getPayment()->getPaymentMethod();
@@ -157,7 +157,7 @@ class HandleSubscriptionPaymentNotificationUseCaseTest extends \PHPUnit\Framewor
 		return $this->createMock( DonationEventLogger::class );
 	}
 
-	public function testGivenSubscriptionPaymentRequest_parentDataSetReferencesChildPaymentId() {
+	public function testGivenSubscriptionPaymentRequest_parentDataSetReferencesChildPaymentId(): void {
 		$application = ValidMembershipApplication::newConfirmedSubscriptionDomainEntity();
 
 		$fakeRepository = new FakeApplicationRepository();

--- a/contexts/MembershipContext/tests/Integration/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCaseTest.php
+++ b/contexts/MembershipContext/tests/Integration/UseCases/HandleSubscriptionSignupNotification/HandleSubscriptionSignupNotificationUseCaseTest.php
@@ -29,11 +29,11 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends \PHPUnit\Framework
 	 */
 	private $mailerSpy;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->mailerSpy = new TemplateBasedMailerSpy( $this );
 	}
 
-	public function testWhenPaymentMethodIsNotPayPal_requestIsNotHandled() {
+	public function testWhenPaymentMethodIsNotPayPal_requestIsNotHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 		$fakeRepository->storeApplication( ValidMembershipApplication::newDomainEntity() );
 
@@ -49,7 +49,7 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends \PHPUnit\Framework
 		$this->assertFalse( $response->notificationWasHandled() );
 	}
 
-	public function testWhenMembershipApplicationDoesNotExist_requestIsNotHandled() {
+	public function testWhenMembershipApplicationDoesNotExist_requestIsNotHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 		$fakeRepository->storeApplication( ValidMembershipApplication::newDomainEntity() );
 
@@ -66,7 +66,7 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends \PHPUnit\Framework
 		$this->assertFalse( $response->notificationWasHandled() );
 	}
 
-	public function testWhenRepositoryThrowsException_responseContainsErrors() {
+	public function testWhenRepositoryThrowsException_responseContainsErrors(): void {
 		$useCase = new HandleSubscriptionSignupNotificationUseCase(
 			new DoctrineApplicationRepository( ThrowingEntityManager::newInstance( $this ) ),
 			new SucceedingAuthorizer(),
@@ -79,7 +79,7 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends \PHPUnit\Framework
 		$this->assertTrue( $response->hasErrors() );
 	}
 
-	public function testWhenAuthorizationFails_requestIsNotHandled() {
+	public function testWhenAuthorizationFails_requestIsNotHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 		$fakeRepository->storeApplication( ValidMembershipApplication::newDomainEntityUsingPayPal() );
 
@@ -95,7 +95,7 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends \PHPUnit\Framework
 		$this->assertFalse( $response->notificationWasHandled() );
 	}
 
-	public function testWhenStatusIsNotAllowedForConfirming_requestIsNotHandled() {
+	public function testWhenStatusIsNotAllowedForConfirming_requestIsNotHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 
 		$application = ValidMembershipApplication::newDomainEntityUsingPayPal();
@@ -115,7 +115,7 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends \PHPUnit\Framework
 		$this->assertTrue( $response->hasErrors() );
 	}
 
-	public function testWhenValidRequestIsSent_itIsHandled() {
+	public function testWhenValidRequestIsSent_itIsHandled(): void {
 		$fakeRepository = new FakeApplicationRepository();
 
 		$application = ValidMembershipApplication::newDomainEntityUsingPayPal();
@@ -134,7 +134,7 @@ class HandleSubscriptionSignupNotificationUseCaseTest extends \PHPUnit\Framework
 		$this->assertFalse( $response->hasErrors() );
 	}
 
-	public function testWhenApplicationIsConfirmed_mailIsSent() {
+	public function testWhenApplicationIsConfirmed_mailIsSent(): void {
 		$fakeRepository = new FakeApplicationRepository();
 
 		$application = ValidMembershipApplication::newDomainEntityUsingPayPal();

--- a/contexts/MembershipContext/tests/Unit/Domain/Model/ApplicationTest.php
+++ b/contexts/MembershipContext/tests/Unit/Domain/Model/ApplicationTest.php
@@ -15,18 +15,18 @@ use WMDE\Fundraising\Frontend\MembershipContext\Tests\Data\ValidMembershipApplic
  */
 class ApplicationTest extends \PHPUnit\Framework\TestCase {
 
-	public function testIdIsNullWhenNotAssigned() {
+	public function testIdIsNullWhenNotAssigned(): void {
 		$this->assertNull( ValidMembershipApplication::newDomainEntity()->getId() );
 	}
 
-	public function testCanAssignIdToNewDonation() {
+	public function testCanAssignIdToNewDonation(): void {
 		$donation = ValidMembershipApplication::newDomainEntity();
 
 		$donation->assignId( 42 );
 		$this->assertSame( 42, $donation->getId() );
 	}
 
-	public function testCannotAssignIdToDonationWithIdentity() {
+	public function testCannotAssignIdToDonationWithIdentity(): void {
 		$donation = ValidMembershipApplication::newDomainEntity();
 		$donation->assignId( 42 );
 
@@ -34,7 +34,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase {
 		$donation->assignId( 43 );
 	}
 
-	public function testNewApplicationHasExpectedDefaults() {
+	public function testNewApplicationHasExpectedDefaults(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 
 		$this->assertNull( $application->getId() );
@@ -42,14 +42,14 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $application->needsModeration() );
 	}
 
-	public function testCancellationResultsInCancelledApplication() {
+	public function testCancellationResultsInCancelledApplication(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->cancel();
 
 		$this->assertTrue( $application->isCancelled() );
 	}
 
-	public function testMarkForModerationResultsInApplicationThatNeedsModeration() {
+	public function testMarkForModerationResultsInApplicationThatNeedsModeration(): void {
 		$application = ValidMembershipApplication::newDomainEntity();
 		$application->markForModeration();
 

--- a/contexts/MembershipContext/tests/Unit/Domain/Model/EmailAddressTest.php
+++ b/contexts/MembershipContext/tests/Unit/Domain/Model/EmailAddressTest.php
@@ -18,7 +18,7 @@ class EmailAddressTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider unparsableAddressProvider
 	 */
-	public function testWhenGivenMail_validatorMXValidatesCorrectly( $mailToTest ) {
+	public function testWhenGivenMail_validatorMXValidatesCorrectly( $mailToTest ): void {
 		$this->expectException( \InvalidArgumentException::class );
 		$this->expectExceptionMessage( 'Given email address could not be parsed' );
 
@@ -34,39 +34,39 @@ class EmailAddressTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	public function testWhenDomainIsEmpty_constructorThrowsException() {
+	public function testWhenDomainIsEmpty_constructorThrowsException(): void {
 		$this->expectException( \InvalidArgumentException::class );
 		new EmailAddress( 'jeroendedauw@' );
 	}
 
-	public function testGetFullAddressReturnsOriginalInput() {
+	public function testGetFullAddressReturnsOriginalInput(): void {
 		$email = new EmailAddress( 'jeroendedauw@gmail.com' );
 
 		$this->assertSame( 'jeroendedauw@gmail.com', $email->getFullAddress() );
 	}
 
-	public function testCanGetEmailParts() {
+	public function testCanGetEmailParts(): void {
 		$email = new EmailAddress( 'jeroendedauw@gmail.com' );
 
 		$this->assertSame( 'jeroendedauw', $email->getUserName() );
 		$this->assertSame( 'gmail.com', $email->getDomain() );
 	}
 
-	public function testCanNormalizedDomainName() {
+	public function testCanNormalizedDomainName(): void {
 		$email = new EmailAddress( 'info@triebwerk-grün.de' );
 
 		$this->assertSame( 'xn--triebwerk-grn-7ob.de', $email->getNormalizedDomain() );
 		$this->assertSame( 'info@xn--triebwerk-grn-7ob.de', $email->getNormalizedAddress() );
 	}
 
-	public function testInvalidDomainNamesAreNormalizedToEmpty() {
+	public function testInvalidDomainNamesAreNormalizedToEmpty(): void {
 		$email = new EmailAddress( 'oh_boy@...' );
 
 		$this->assertSame( '', $email->getNormalizedDomain() );
 		$this->assertSame( 'oh_boy@', $email->getNormalizedAddress() );
 	}
 
-	public function testToStringOriginalInput() {
+	public function testToStringOriginalInput(): void {
 		$email = new EmailAddress( 'jeroendedauw@gmail.com' );
 
 		$this->assertSame( 'jeroendedauw@gmail.com', (string)$email->getFullAddress() );

--- a/contexts/MembershipContext/tests/Unit/Domain/Model/EmailAddressTest.php
+++ b/contexts/MembershipContext/tests/Unit/Domain/Model/EmailAddressTest.php
@@ -18,14 +18,14 @@ class EmailAddressTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider unparsableAddressProvider
 	 */
-	public function testWhenGivenMail_validatorMXValidatesCorrectly( $mailToTest ): void {
+	public function testWhenGivenMail_validatorMXValidatesCorrectly( string $mailToTest ): void {
 		$this->expectException( \InvalidArgumentException::class );
 		$this->expectExceptionMessage( 'Given email address could not be parsed' );
 
 		new EmailAddress( $mailToTest );
 	}
 
-	public function unparsableAddressProvider() {
+	public function unparsableAddressProvider(): array {
 		return [
 			[ 'just.testing' ],
 			[ 'can.you@deliver@this' ],

--- a/contexts/MembershipContext/tests/Unit/Domain/Model/PaymentTest.php
+++ b/contexts/MembershipContext/tests/Unit/Domain/Model/PaymentTest.php
@@ -20,7 +20,7 @@ class PaymentTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider invalidIntervalProvider
 	 */
-	public function testGivenInvalidInterval_constructorThrowsException( int $invalidInterval ) {
+	public function testGivenInvalidInterval_constructorThrowsException( int $invalidInterval ): void {
 		$this->expectException( \InvalidArgumentException::class );
 		new Payment(
 			$invalidInterval,
@@ -39,17 +39,17 @@ class PaymentTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	public function testWhenIntervalIsTwelveMonths_yearlyPaymentIsBasePayment() {
+	public function testWhenIntervalIsTwelveMonths_yearlyPaymentIsBasePayment(): void {
 		$payment = new Payment( 12, Euro::newFromInt( 42 ), new DirectDebitPayment( new BankData() ) );
 		$this->assertEquals( 42, $payment->getYearlyAmount()->getEuroFloat() );
 	}
 
-	public function testWhenIntervalIsOneMonth_yearlyPaymentIsTwelveTimesBasePayment() {
+	public function testWhenIntervalIsOneMonth_yearlyPaymentIsTwelveTimesBasePayment(): void {
 		$payment = new Payment( 1, Euro::newFromInt( 10 ), new DirectDebitPayment( new BankData() ) );
 		$this->assertEquals( 120, $payment->getYearlyAmount()->getEuroFloat() );
 	}
 
-	public function testWhenIntervalIsOneQuarter_yearlyPaymentIsFourTimesBasePayment() {
+	public function testWhenIntervalIsOneQuarter_yearlyPaymentIsFourTimesBasePayment(): void {
 		$payment = new Payment( 3, Euro::newFromInt( 50 ), new DirectDebitPayment( new BankData() ) );
 		$this->assertEquals( 200, $payment->getYearlyAmount()->getEuroFloat() );
 	}

--- a/contexts/MembershipContext/tests/Unit/Domain/Model/PaymentTest.php
+++ b/contexts/MembershipContext/tests/Unit/Domain/Model/PaymentTest.php
@@ -29,7 +29,7 @@ class PaymentTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function invalidIntervalProvider() {
+	public function invalidIntervalProvider(): array {
 		return [
 			'you cant have infinity moneys' => [ 0 ],
 			'time travel is also not allowed' => [ -1 ],

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
@@ -42,7 +42,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 	}
 
 	/** @dataProvider blacklistedEmailAddressProvider */
-	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( $emailAddress ): void {
+	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( string $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$this->assertTrue(
 			$policyValidator->isAutoDeleted(
@@ -51,7 +51,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 		);
 	}
 
-	public function blacklistedEmailAddressProvider() {
+	public function blacklistedEmailAddressProvider(): array {
 		return [
 			[ 'foo@bar.baz' ],
 			[ 'test@example.com' ],
@@ -60,7 +60,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 	}
 
 	/** @dataProvider allowedEmailAddressProvider */
-	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( $emailAddress ): void {
+	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( string $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$this->assertFalse(
 			$policyValidator->isAutoDeleted(
@@ -69,7 +69,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 		);
 	}
 
-	public function allowedEmailAddressProvider() {
+	public function allowedEmailAddressProvider(): array {
 		return [
 			[ 'other.person@bar.baz' ],
 			[ 'test@example.computer.says.no' ],

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/ApplyForMembershipPolicyValidatorTest.php
@@ -10,7 +10,7 @@ use WMDE\Fundraising\Frontend\Validation\TextPolicyValidator;
 
 class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenQuarterlyAmountTooHigh_MembershipApplicationNeedsModeration() {
+	public function testGivenQuarterlyAmountTooHigh_MembershipApplicationNeedsModeration(): void {
 		$textPolicyValidator = $this->newSucceedingTextPolicyValidator();
 		$policyValidator = new ApplyForMembershipPolicyValidator( $textPolicyValidator );
 		$this->assertTrue( $policyValidator->needsModeration(
@@ -24,7 +24,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 		return $textPolicyValidator;
 	}
 
-	public function testGivenYearlyAmountTooHigh_MembershipApplicationNeedsModeration() {
+	public function testGivenYearlyAmountTooHigh_MembershipApplicationNeedsModeration(): void {
 		$textPolicyValidator = $this->newSucceedingTextPolicyValidator();
 		$policyValidator = new ApplyForMembershipPolicyValidator( $textPolicyValidator );
 		$this->assertTrue( $policyValidator->needsModeration(
@@ -32,7 +32,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 		) );
 	}
 
-	public function testFailingTextPolicyValidation_MembershipApplicationNeedsModeration() {
+	public function testFailingTextPolicyValidation_MembershipApplicationNeedsModeration(): void {
 		$textPolicyValidator = $this->createMock( TextPolicyValidator::class );
 		$textPolicyValidator->method( 'textIsHarmless' )->willReturn( false );
 		$policyValidator = new ApplyForMembershipPolicyValidator( $textPolicyValidator );
@@ -42,7 +42,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 	}
 
 	/** @dataProvider blacklistedEmailAddressProvider */
-	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( $emailAddress ) {
+	public function testWhenEmailAddressIsBlacklisted_isAutoDeletedReturnsTrue( $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$this->assertTrue(
 			$policyValidator->isAutoDeleted(
@@ -60,7 +60,7 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 	}
 
 	/** @dataProvider allowedEmailAddressProvider */
-	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( $emailAddress ) {
+	public function testWhenEmailAddressIsNotBlacklisted_isAutoDeletedReturnsFalse( $emailAddress ): void {
 		$policyValidator = $this->newPolicyValidatorWithEmailBlacklist();
 		$this->assertFalse(
 			$policyValidator->isAutoDeleted(
@@ -77,9 +77,6 @@ class ApplyForMembershipPolicyValidatorTest extends \PHPUnit\Framework\TestCase 
 		];
 	}
 
-	/**
-	 * @return ApplyForMembershipPolicyValidator
-	 */
 	private function newPolicyValidatorWithEmailBlacklist(): ApplyForMembershipPolicyValidator {
 		$textPolicyValidator = $this->newSucceedingTextPolicyValidator();
 		$policyValidator = new ApplyForMembershipPolicyValidator(

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
@@ -39,7 +39,7 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function newCompanyMembershipRequest( bool $omitOptionalFields = false ) {
+	private function newCompanyMembershipRequest( bool $omitOptionalFields = false ): ApplyForMembershipRequest {
 		$request = new ApplyForMembershipRequest();
 
 		$request->setMembershipType( ValidMembershipApplication::MEMBERSHIP_TYPE );

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationBuilderTest.php
@@ -25,7 +25,7 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 	const COMPANY_NAME = 'Malenfant asteroid mining';
 	const OMIT_OPTIONAL_FIELDS = true;
 
-	public function testCompanyMembershipRequestGetsBuildCorrectly() {
+	public function testCompanyMembershipRequestGetsBuildCorrectly(): void {
 		$request = $this->newCompanyMembershipRequest();
 
 		$application = ( new MembershipApplicationBuilder() )->newApplicationFromRequest( $request );
@@ -90,7 +90,7 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertIsExpectedCompanyPersonName( ApplicantName $name ) {
+	private function assertIsExpectedCompanyPersonName( ApplicantName $name ): void {
 		$this->assertEquals(
 			$this->getCompanyPersonName(),
 			$name
@@ -109,7 +109,7 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 		return $name->assertNoNullFields()->freeze();
 	}
 
-	private function assertIsExpectedAddress( ApplicantAddress $address ) {
+	private function assertIsExpectedAddress( ApplicantAddress $address ): void {
 		$this->assertEquals(
 			$this->getPhysicalAddress(),
 			$address
@@ -127,7 +127,7 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 		return $address->assertNoNullFields()->freeze();
 	}
 
-	public function testWhenNoBirthDateAndPhoneNumberIsGiven_membershipApplicationIsStillBuiltCorrectly() {
+	public function testWhenNoBirthDateAndPhoneNumberIsGiven_membershipApplicationIsStillBuiltCorrectly(): void {
 		$request = $this->newCompanyMembershipRequest( self::OMIT_OPTIONAL_FIELDS );
 
 		$application = ( new MembershipApplicationBuilder() )->newApplicationFromRequest( $request );
@@ -141,7 +141,7 @@ class MembershipApplicationBuilderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenBuildingCompanyApplication_salutationFieldIsSet() {
+	public function testWhenBuildingCompanyApplication_salutationFieldIsSet(): void {
 		$request = $this->newCompanyMembershipRequest( self::OMIT_OPTIONAL_FIELDS );
 
 		$application = ( new MembershipApplicationBuilder() )->newApplicationFromRequest( $request );

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -43,13 +43,13 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $emailValidator;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->feeValidator = $this->newSucceedingFeeValidator();
 		$this->bankDataValidator = $this->newSucceedingBankDataValidator();
 		$this->emailValidator = new SucceedingEmailValidator();
 	}
 
-	public function testGivenValidRequest_validationSucceeds() {
+	public function testGivenValidRequest_validationSucceeds(): void {
 		$validRequest = $this->newValidRequest();
 		$response = $this->newValidator()->validate( $validRequest );
 
@@ -66,7 +66,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenFeeValidationFails_overallValidationAlsoFails() {
+	public function testWhenFeeValidationFails_overallValidationAlsoFails(): void {
 		$this->feeValidator = $this->newFailingFeeValidator();
 
 		$response = $this->newValidator()->validate( $this->newValidRequest() );
@@ -114,7 +114,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		return $feeValidator;
 	}
 
-	public function testWhenIbanIsMissing_validationFails() {
+	public function testWhenIbanIsMissing_validationFails(): void {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
@@ -126,7 +126,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertRequestValidationResultInErrors( ApplyForMembershipRequest $request, array $expectedErrors ) {
+	private function assertRequestValidationResultInErrors( ApplyForMembershipRequest $request, array $expectedErrors ): void {
 		$this->assertEquals(
 			new Result( $expectedErrors ),
 			$this->newValidator()->validate( $request )
@@ -147,7 +147,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		return $ibanValidator;
 	}
 
-	public function testWhenBicIsMissing_validationFails() {
+	public function testWhenBicIsMissing_validationFails(): void {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
@@ -159,7 +159,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenBankNameIsMissing_validationSucceeds() {
+	public function testWhenBankNameIsMissing_validationSucceeds(): void {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
@@ -171,7 +171,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $response->isSuccessful() );
 	}
 
-	public function testWhenBankCodeIsMissing_validationFails() {
+	public function testWhenBankCodeIsMissing_validationFails(): void {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
@@ -183,7 +183,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenBankAccountIsMissing_validationFails() {
+	public function testWhenBankAccountIsMissing_validationFails(): void {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
@@ -195,7 +195,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenTooLongBankAccount_validationFails() {
+	public function testWhenTooLongBankAccount_validationFails(): void {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
@@ -207,7 +207,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenTooLongBankCode_validationFails() {
+	public function testWhenTooLongBankCode_validationFails(): void {
 		$this->bankDataValidator = $this->newRealBankDataValidator();
 
 		$request = $this->newValidRequest();
@@ -219,7 +219,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenDateOfBirthIsNotDate_validationFails() {
+	public function testWhenDateOfBirthIsNotDate_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantDateOfBirth( 'this is not a valid date' );
 
@@ -232,7 +232,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider invalidPhoneNumberProvider
 	 */
-	public function testWhenApplicantPhoneNumberIsInvalid_validationFails( string $invalidPhoneNumber ) {
+	public function testWhenApplicantPhoneNumberIsInvalid_validationFails( string $invalidPhoneNumber ): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantPhoneNumber( $invalidPhoneNumber );
 
@@ -254,7 +254,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider emailViolationTypeProvider
 	 */
-	public function testWhenApplicantEmailIsInvalid_validationFails( string $emailViolationType ) {
+	public function testWhenApplicantEmailIsInvalid_validationFails( string $emailViolationType ): void {
 		$this->emailValidator = $this->newFailingEmailValidator( $emailViolationType );
 
 		$request = $this->newValidRequest();
@@ -274,11 +274,6 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	/**
-	 * @param string $violationType
-	 *
-	 * @return EmailValidator
-	 */
 	private function newFailingEmailValidator( string $violationType ): EmailValidator {
 		$feeValidator = $this->getMockBuilder( EmailValidator::class )
 			->disableOriginalConstructor()->getMock();
@@ -289,7 +284,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		return $feeValidator;
 	}
 
-	public function testWhenCompanyIsMissingFromCompanyApplication_validationFails() {
+	public function testWhenCompanyIsMissingFromCompanyApplication_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->markApplicantAsCompany();
 		$request->setApplicantCompanyName( '' );
@@ -300,7 +295,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenFirstNameIsMissingFromPersonalApplication_validationFails() {
+	public function testWhenFirstNameIsMissingFromPersonalApplication_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantFirstName( '' );
 
@@ -310,7 +305,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenLastNameIsMissingFromPersonalApplication_validationFails() {
+	public function testWhenLastNameIsMissingFromPersonalApplication_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantLastName( '' );
 
@@ -320,7 +315,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenSalutationIsMissingFromPersonalApplication_validationFails() {
+	public function testWhenSalutationIsMissingFromPersonalApplication_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantSalutation( '' );
 
@@ -330,7 +325,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenStreetAddressIsMissing_validationFails() {
+	public function testWhenStreetAddressIsMissing_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantStreetAddress( '' );
 
@@ -340,7 +335,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenPostalCodeIsMissing_validationFails() {
+	public function testWhenPostalCodeIsMissing_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantPostalCode( '' );
 
@@ -350,7 +345,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenCityIsMissing_validationFails() {
+	public function testWhenCityIsMissing_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantCity( '' );
 
@@ -360,7 +355,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenCountryCodeIsMissing_validationFails() {
+	public function testWhenCountryCodeIsMissing_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantCountryCode( '' );
 
@@ -370,21 +365,21 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testPhoneNumberIsNotProvided_validationDoesNotFail() {
+	public function testPhoneNumberIsNotProvided_validationDoesNotFail(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantPhoneNumber( '' );
 
 		$this->assertTrue( $this->newValidator()->validate( $request )->isSuccessful() );
 	}
 
-	public function testDateOfBirthIsNotProvided_validationDoesNotFail() {
+	public function testDateOfBirthIsNotProvided_validationDoesNotFail(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantDateOfBirth( '' );
 
 		$this->assertTrue( $this->newValidator()->validate( $request )->isSuccessful() );
 	}
 
-	public function testPersonalInfoWithLongFields_validationFails() {
+	public function testPersonalInfoWithLongFields_validationFails(): void {
 		$longText = str_repeat( 'Cats ', 500 );
 		$request = $this->newValidRequest();
 		$request->setApplicantFirstName( $longText );
@@ -409,7 +404,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testContactInfoWithLongFields_validationFails() {
+	public function testContactInfoWithLongFields_validationFails(): void {
 		$request = $this->newValidRequest();
 		$request->setApplicantEmailAddress( str_repeat( 'Cats', 500 ) . '@example.com' );
 		$request->setApplicantPhoneNumber( str_repeat( '1234', 500 ) );
@@ -423,7 +418,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testBankDataWithLongFields_validationFails() {
+	public function testBankDataWithLongFields_validationFails(): void {
 		$longText = str_repeat( 'Cats ', 500 );
 		$request = $this->newValidRequest();
 		$bankData = $request->getBankData();
@@ -440,7 +435,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenValidRequestUsingPayPal_validationSucceeds() {
+	public function testGivenValidRequestUsingPayPal_validationSucceeds(): void {
 		$validRequest = $this->newValidRequestUsingPayPal();
 		$response = $this->newValidator()->validate( $validRequest );
 

--- a/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
+++ b/contexts/MembershipContext/tests/Unit/UseCases/ApplyForMembership/MembershipApplicationValidatorTest.php
@@ -58,7 +58,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $response->isSuccessful() );
 	}
 
-	private function newValidator() {
+	private function newValidator(): MembershipApplicationValidator {
 		return new MembershipApplicationValidator(
 			$this->feeValidator,
 			$this->bankDataValidator,
@@ -98,7 +98,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		return ValidMembershipApplicationRequest::newValidRequest();
 	}
 
-	private function newFeeViolationResult() {
+	private function newFeeViolationResult(): Result {
 		return new Result( [
 			Result::SOURCE_PAYMENT_AMOUNT => Result::VIOLATION_NOT_MONEY
 		] );
@@ -242,7 +242,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function invalidPhoneNumberProvider() {
+	public function invalidPhoneNumberProvider(): array {
 		return [
 			'potato' => [ 'potato' ],
 
@@ -266,7 +266,7 @@ class MembershipApplicationValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function emailViolationTypeProvider() {
+	public function emailViolationTypeProvider(): array {
 		return [
 			[ 'email_address_wrong_format' ],
 			[ 'email_address_invalid' ],

--- a/contexts/PaymentContext/src/Domain/BankDataLibraryInitializationException.php
+++ b/contexts/PaymentContext/src/Domain/BankDataLibraryInitializationException.php
@@ -15,12 +15,7 @@ class BankDataLibraryInitializationException extends \RuntimeException {
 	 */
 	private $bankDataFile;
 
-	/**
-	 * @param string $bankDataFile
-	 * @param string|null $message
-	 * @param \Exception $previous
-	 */
-	public function __construct( $bankDataFile, $message = null, \Exception $previous = null ) {
+	public function __construct( string $bankDataFile, ?string $message = null, \Exception $previous = null ) {
 		$this->bankDataFile = $bankDataFile;
 		parent::__construct(
 			$message !== null ?: 'Could not initialize library with bank data file: ' . $bankDataFile,
@@ -29,10 +24,7 @@ class BankDataLibraryInitializationException extends \RuntimeException {
 		);
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getBankDataFile() {
+	public function getBankDataFile(): string {
 		return $this->bankDataFile;
 	}
 

--- a/contexts/PaymentContext/src/Domain/Model/BankData.php
+++ b/contexts/PaymentContext/src/Domain/Model/BankData.php
@@ -24,7 +24,7 @@ class BankData {
 		return $this->bic;
 	}
 
-	public function setBic( string $bic ) {
+	public function setBic( string $bic ): self {
 		$this->assertIsWritable();
 		$this->bic = $bic;
 		return $this;
@@ -34,7 +34,7 @@ class BankData {
 		return $this->iban;
 	}
 
-	public function setIban( Iban $iban ) {
+	public function setIban( Iban $iban ): self {
 		$this->assertIsWritable();
 		$this->iban = $iban;
 		return $this;
@@ -44,7 +44,7 @@ class BankData {
 		return $this->account;
 	}
 
-	public function setAccount( string $account ) {
+	public function setAccount( string $account ): self {
 		$this->assertIsWritable();
 		$this->account = $account;
 		return $this;
@@ -54,7 +54,7 @@ class BankData {
 		return $this->bankCode;
 	}
 
-	public function setBankCode( string $bankCode ) {
+	public function setBankCode( string $bankCode ): self {
 		$this->assertIsWritable();
 		$this->bankCode = $bankCode;
 		return $this;
@@ -64,7 +64,7 @@ class BankData {
 		return $this->bankName;
 	}
 
-	public function setBankName( string $bankName ) {
+	public function setBankName( string $bankName ): self {
 		$this->assertIsWritable();
 		$this->bankName = $bankName;
 		return $this;

--- a/contexts/PaymentContext/src/Domain/Model/CreditCardPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/CreditCardPayment.php
@@ -20,14 +20,11 @@ class CreditCardPayment implements PaymentMethod {
 		return PaymentType::CREDIT_CARD;
 	}
 
-	/**
-	 * @return CreditCardTransactionData|null
-	 */
-	public function getCreditCardData() {
+	public function getCreditCardData(): ?CreditCardTransactionData {
 		return $this->creditCardData;
 	}
 
-	public function addCreditCardTransactionData( CreditCardTransactionData $creditCardData ) {
+	public function addCreditCardTransactionData( CreditCardTransactionData $creditCardData ): void {
 		$this->creditCardData = $creditCardData;
 	}
 }

--- a/contexts/PaymentContext/src/Domain/Model/CreditCardTransactionData.php
+++ b/contexts/PaymentContext/src/Domain/Model/CreditCardTransactionData.php
@@ -93,18 +93,11 @@ class CreditCardTransactionData {
 		return $this;
 	}
 
-	/**
-	 * @return CreditCardExpiry|null
-	 */
-	public function getCardExpiry() {
+	public function getCardExpiry(): ?CreditCardExpiry {
 		return $this->cardExpiry;
 	}
 
-	/**
-	 * @param CreditCardExpiry|null $cardExpiry
-	 * @return self
-	 */
-	public function setCardExpiry( $cardExpiry ) {
+	public function setCardExpiry( ?CreditCardExpiry $cardExpiry ): self {
 		$this->assertIsWritable();
 		$this->cardExpiry = $cardExpiry;
 		return $this;

--- a/contexts/PaymentContext/src/Domain/Model/PayPalData.php
+++ b/contexts/PaymentContext/src/Domain/Model/PayPalData.php
@@ -42,7 +42,7 @@ class PayPalData {
 		return $this->payerId;
 	}
 
-	public function setPayerId( string $payerId ) {
+	public function setPayerId( string $payerId ): self {
 		$this->assertIsWritable();
 		$this->payerId = $payerId;
 		return $this;
@@ -52,7 +52,7 @@ class PayPalData {
 		return $this->subscriberId;
 	}
 
-	public function setSubscriberId( string $subscriberId ) {
+	public function setSubscriberId( string $subscriberId ): self {
 		$this->assertIsWritable();
 		$this->subscriberId = $subscriberId;
 		return $this;
@@ -62,7 +62,7 @@ class PayPalData {
 		return $this->payerStatus;
 	}
 
-	public function setPayerStatus( string $payerStatus ) {
+	public function setPayerStatus( string $payerStatus ): self {
 		$this->assertIsWritable();
 		$this->payerStatus = $payerStatus;
 		return $this;
@@ -72,7 +72,7 @@ class PayPalData {
 		return $this->addressStatus;
 	}
 
-	public function setAddressStatus( string $addressStatus ) {
+	public function setAddressStatus( string $addressStatus ): self {
 		$this->assertIsWritable();
 		$this->addressStatus = $addressStatus;
 		return $this;
@@ -82,7 +82,7 @@ class PayPalData {
 		return $this->amount;
 	}
 
-	public function setAmount( Euro $amount ) {
+	public function setAmount( Euro $amount ): self {
 		$this->assertIsWritable();
 		$this->amount = $amount;
 		return $this;
@@ -92,7 +92,7 @@ class PayPalData {
 		return $this->currencyCode;
 	}
 
-	public function setCurrencyCode( string $currencyCode ) {
+	public function setCurrencyCode( string $currencyCode ): self {
 		$this->assertIsWritable();
 		$this->currencyCode = $currencyCode;
 		return $this;
@@ -102,7 +102,7 @@ class PayPalData {
 		return $this->fee;
 	}
 
-	public function setFee( Euro $fee ) {
+	public function setFee( Euro $fee ): self {
 		$this->assertIsWritable();
 		$this->fee = $fee;
 		return $this;
@@ -112,7 +112,7 @@ class PayPalData {
 		return $this->settleAmount;
 	}
 
-	public function setSettleAmount( Euro $settleAmount ) {
+	public function setSettleAmount( Euro $settleAmount ): self {
 		$this->assertIsWritable();
 		$this->settleAmount = $settleAmount;
 		return $this;
@@ -122,7 +122,7 @@ class PayPalData {
 		return $this->firstName;
 	}
 
-	public function setFirstName( string $firstName ) {
+	public function setFirstName( string $firstName ): self {
 		$this->assertIsWritable();
 		$this->firstName = $firstName;
 		return $this;
@@ -132,7 +132,7 @@ class PayPalData {
 		return $this->lastName;
 	}
 
-	public function setLastName( string $lastName ) {
+	public function setLastName( string $lastName ): self {
 		$this->assertIsWritable();
 		$this->lastName = $lastName;
 		return $this;
@@ -142,7 +142,7 @@ class PayPalData {
 		return $this->addressName;
 	}
 
-	public function setAddressName( string $addressName ) {
+	public function setAddressName( string $addressName ): self {
 		$this->assertIsWritable();
 		$this->addressName = $addressName;
 		return $this;
@@ -152,7 +152,7 @@ class PayPalData {
 		return $this->paymentId;
 	}
 
-	public function setPaymentId( string $paymentId ) {
+	public function setPaymentId( string $paymentId ): self {
 		$this->assertIsWritable();
 		$this->paymentId = $paymentId;
 		return $this;
@@ -162,7 +162,7 @@ class PayPalData {
 		return $this->paymentType;
 	}
 
-	public function setPaymentType( string $paymentType ) {
+	public function setPaymentType( string $paymentType ): self {
 		$this->assertIsWritable();
 		$this->paymentType = $paymentType;
 		return $this;
@@ -172,7 +172,7 @@ class PayPalData {
 		return $this->paymentStatus;
 	}
 
-	public function setPaymentStatus( string $paymentStatus ) {
+	public function setPaymentStatus( string $paymentStatus ): self {
 		$this->assertIsWritable();
 		$this->paymentStatus = $paymentStatus;
 		return $this;
@@ -182,7 +182,7 @@ class PayPalData {
 		return $this->paymentTimestamp;
 	}
 
-	public function setPaymentTimestamp( string $paymentTimestamp ) {
+	public function setPaymentTimestamp( string $paymentTimestamp ): self {
 		$this->assertIsWritable();
 		$this->paymentTimestamp = $paymentTimestamp;
 		return $this;
@@ -192,13 +192,13 @@ class PayPalData {
 		return $this->firstPaymentDate;
 	}
 
-	public function setFirstPaymentDate( string $firstPaymentDate ) {
+	public function setFirstPaymentDate( string $firstPaymentDate ): self {
 		$this->assertIsWritable();
 		$this->firstPaymentDate = $firstPaymentDate;
 		return $this;
 	}
 
-	public function addChildPayment( string $paymentId, int $entityId ) {
+	public function addChildPayment( string $paymentId, int $entityId ): self {
 		$this->childPayments[$paymentId] = $entityId;
 		return $this;
 	}

--- a/contexts/PaymentContext/src/Domain/Model/PayPalPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/PayPalPayment.php
@@ -24,7 +24,7 @@ class PayPalPayment implements PaymentMethod {
 		return $this->payPalData;
 	}
 
-	public function addPayPalData( PayPalData $palPayData ) {
+	public function addPayPalData( PayPalData $palPayData ): void {
 		$this->payPalData = $palPayData;
 	}
 }

--- a/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/CreditCard.php
+++ b/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/CreditCard.php
@@ -19,7 +19,7 @@ class CreditCard {
 	}
 
 	public function generateUrl( string $firstName, string $lastName, string $payText, int $donationId,
-								 string $accessToken, string $updateToken, Euro $amount ) {
+								 string $accessToken, string $updateToken, Euro $amount ): string {
 		// TODO: implement sealed parameters (https://techdoc.micropayment.de/payment/payments/payments_en.html#id302721)
 		$baseUrl = $this->config->getBaseUrl();
 		$params = [

--- a/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/CreditCardConfig.php
+++ b/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/CreditCardConfig.php
@@ -80,7 +80,7 @@ class CreditCardConfig {
 		return $this->theme;
 	}
 
-	public function isTestMode() {
+	public function isTestMode(): bool {
 		return $this->testMode;
 	}
 

--- a/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/PayPal.php
+++ b/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/PayPal.php
@@ -53,7 +53,7 @@ class PayPal {
 		];
 	}
 
-	private function getPaymentDelayParameters() {
+	private function getPaymentDelayParameters(): array {
 		if ( $this->config->getDelayInDays() > 0 ) {
 			return $this->getDelayedSubscriptionParams( $this->config->getDelayInDays() );
 		}

--- a/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/PayPalConfig.php
+++ b/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/PayPalConfig.php
@@ -88,7 +88,7 @@ class PayPalConfig {
 		return $this->itemName;
 	}
 
-	public function getDelayInDays() {
+	public function getDelayInDays(): int {
 		return $this->delayInDays;
 	}
 

--- a/contexts/PaymentContext/src/Infrastructure/CreditCardExpiry.php
+++ b/contexts/PaymentContext/src/Infrastructure/CreditCardExpiry.php
@@ -22,7 +22,7 @@ class CreditCardExpiry {
 		$this->year = $year;
 	}
 
-	public static function newFromString( string $expirationDate ) {
+	public static function newFromString( string $expirationDate ): ?self {
 		$dateParts = explode( '/', $expirationDate );
 		if ( count( $dateParts ) === 2 ) {
 			return new self( (int)$dateParts[0], (int)$dateParts[1] );

--- a/contexts/PaymentContext/src/RequestModel/PayPalPaymentNotificationRequest.php
+++ b/contexts/PaymentContext/src/RequestModel/PayPalPaymentNotificationRequest.php
@@ -71,7 +71,7 @@ class PayPalPaymentNotificationRequest {
 		return $this->subscriptionId;
 	}
 
-	public function setSubscriptionId( string $subscriptionId ) {
+	public function setSubscriptionId( string $subscriptionId ): self {
 		$this->subscriptionId = $subscriptionId;
 		return $this;
 	}
@@ -238,11 +238,11 @@ class PayPalPaymentNotificationRequest {
 		return $this;
 	}
 
-	public function getSettleAmount() {
+	public function getSettleAmount(): Euro {
 		return $this->settleAmount;
 	}
 
-	public function setSettleAmount( Euro $settleAmount ) {
+	public function setSettleAmount( Euro $settleAmount ): self {
 		$this->settleAmount = $settleAmount;
 		return $this;
 	}

--- a/contexts/PaymentContext/src/ResponseModel/IbanResponse.php
+++ b/contexts/PaymentContext/src/ResponseModel/IbanResponse.php
@@ -12,11 +12,11 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\BankData;
  */
 class IbanResponse {
 
-	public static function newSuccessResponse( BankData $bankData ) {
+	public static function newSuccessResponse( BankData $bankData ): self {
 		return new self( $bankData );
 	}
 
-	public static function newFailureResponse() {
+	public static function newFailureResponse(): self {
 		return new self();
 	}
 

--- a/contexts/PaymentContext/tests/Data/ValidSubscriptionSignupRequest.php
+++ b/contexts/PaymentContext/tests/Data/ValidSubscriptionSignupRequest.php
@@ -30,7 +30,7 @@ class ValidSubscriptionSignupRequest {
 	const PAYER_ADDRESS_COUNTRY = 'US';
 	const PAYER_EMAIL = 'hank.scorpio@globex.com';
 
-	public static function newValidRequest() {
+	public static function newValidRequest(): SubscriptionSignupRequest {
 		$request = new SubscriptionSignupRequest();
 		$request->setSubscriptionId( self::SUBSCRIPTION_ID );
 		$request->setSubscriptionDate( self::SUBSCRIPTION_DATE );

--- a/contexts/PaymentContext/tests/Integration/DataAccess/McpCreditCardServiceTest.php
+++ b/contexts/PaymentContext/tests/Integration/DataAccess/McpCreditCardServiceTest.php
@@ -27,7 +27,7 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 		'expiryYear' => self::EXPIRY_YEAR,
 	];
 
-	public function testMicroPaymentServiceGetsCalledWithAccessKeyAndCustomerId() {
+	public function testMicroPaymentServiceGetsCalledWithAccessKeyAndCustomerId(): void {
 		$microPaymentServiceMock = $this->getMicroPaymentServiceTestDouble();
 
 		$microPaymentServiceMock->expects( $this->once() )
@@ -50,7 +50,7 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 		return $this->createMock( \IMcpCreditcardService_v1_5::class );
 	}
 
-	public function testWhenValidDataIsReturned_creditCardExpiryIsCreated() {
+	public function testWhenValidDataIsReturned_creditCardExpiryIsCreated(): void {
 		$microPaymentServiceStub = $this->getMicroPaymentServiceTestDouble();
 
 		$microPaymentServiceStub->expects( $this->any() )
@@ -68,7 +68,7 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider invalidReturnDataProvider
 	 */
-	public function testWhenInvalidDataIsReturned_exceptionIsThrown( array $invalidReturnData ) {
+	public function testWhenInvalidDataIsReturned_exceptionIsThrown( array $invalidReturnData ): void {
 		$microPaymentServiceStub = $this->getMicroPaymentServiceTestDouble();
 
 		$microPaymentServiceStub->expects( $this->any() )

--- a/contexts/PaymentContext/tests/Integration/DataAccess/McpCreditCardServiceTest.php
+++ b/contexts/PaymentContext/tests/Integration/DataAccess/McpCreditCardServiceTest.php
@@ -81,7 +81,7 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 		$creditCardService->getExpirationDate( self::CUSTOMER_ID );
 	}
 
-	public function invalidReturnDataProvider() {
+	public function invalidReturnDataProvider(): array {
 		return [
 			[ [
 				'expiryMonth' => 'potato',

--- a/contexts/PaymentContext/tests/Integration/DataAccess/UniqueTransferCodeGeneratorTest.php
+++ b/contexts/PaymentContext/tests/Integration/DataAccess/UniqueTransferCodeGeneratorTest.php
@@ -28,7 +28,7 @@ class UniqueTransferCodeGeneratorTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $entityManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 	}
 
@@ -49,16 +49,16 @@ class UniqueTransferCodeGeneratorTest extends \PHPUnit\Framework\TestCase {
 		};
 	}
 
-	public function testWhenFirstResultIsUnique_itGetsReturned() {
+	public function testWhenFirstResultIsUnique_itGetsReturned(): void {
 		$this->assertSame( 'first', $this->newUniqueGenerator()->generateTransferCode() );
 	}
 
-	public function testWhenFirstResultIsNotUnique_secondResultGetsReturned() {
+	public function testWhenFirstResultIsNotUnique_secondResultGetsReturned(): void {
 		$this->storeDonationWithTransferCode( 'first' );
 		$this->assertSame( 'second', $this->newUniqueGenerator()->generateTransferCode() );
 	}
 
-	private function storeDonationWithTransferCode( string $code ) {
+	private function storeDonationWithTransferCode( string $code ): void {
 		$donation = new Donation(
 			null,
 			Donation::STATUS_NEW,
@@ -75,7 +75,7 @@ class UniqueTransferCodeGeneratorTest extends \PHPUnit\Framework\TestCase {
 		( new DoctrineDonationRepository( $this->entityManager ) )->storeDonation( $donation );
 	}
 
-	public function testWhenFirstAndSecondResultsAreNotUnique_thirdResultGetsReturned() {
+	public function testWhenFirstAndSecondResultsAreNotUnique_thirdResultGetsReturned(): void {
 		$this->storeDonationWithTransferCode( 'first' );
 		$this->storeDonationWithTransferCode( 'second' );
 		$this->assertSame( 'third', $this->newUniqueGenerator()->generateTransferCode() );

--- a/contexts/PaymentContext/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
+++ b/contexts/PaymentContext/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
@@ -20,13 +20,13 @@ use WMDE\Fundraising\Frontend\Validation\IbanValidator;
  */
 class GenerateIbanUseCaseTest extends \PHPUnit\Framework\TestCase {
 
-	public function setUp() {
+	public function setUp(): void {
 		if ( !function_exists( 'lut_init' ) ) {
 			$this->markTestSkipped( 'The konto_check needs to be installed!' );
 		}
 	}
 
-	public function testWhenValidBankAccountDataIsGiven_fullBankDataIsReturned() {
+	public function testWhenValidBankAccountDataIsGiven_fullBankDataIsReturned(): void {
 		$useCase = $this->newGenerateIbanUseCase();
 
 		$bankData = new BankData();
@@ -43,7 +43,7 @@ class GenerateIbanUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenInvalidBankAccountDataIsGiven_failureResponseIsReturned() {
+	public function testWhenInvalidBankAccountDataIsGiven_failureResponseIsReturned(): void {
 		$useCase = $this->newGenerateIbanUseCase();
 
 		$this->assertEquals(
@@ -52,7 +52,7 @@ class GenerateIbanUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenBlockedBankAccountDataIsGiven_failureResponseIsReturned() {
+	public function testWhenBlockedBankAccountDataIsGiven_failureResponseIsReturned(): void {
 		$useCase = $this->newGenerateIbanUseCase();
 
 		$this->assertEquals(

--- a/contexts/PaymentContext/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
+++ b/contexts/PaymentContext/tests/Integration/UseCases/GenerateIban/GenerateIbanUseCaseTest.php
@@ -61,7 +61,7 @@ class GenerateIbanUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function newGenerateIbanUseCase() {
+	private function newGenerateIbanUseCase(): GenerateIbanUseCase {
 		$bankDataConverter = new BankDataConverter( 'res/blz.lut2f' );
 		return new GenerateIbanUseCase(
 			$bankDataConverter,

--- a/contexts/PaymentContext/tests/Unit/Domain/BankDataConverterTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/BankDataConverterTest.php
@@ -19,17 +19,17 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\Iban;
  */
 class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 
-	public function setUp() {
+	public function setUp(): void {
 		if ( !function_exists( 'lut_init' ) ) {
 			$this->markTestSkipped( 'The konto_check needs to be installed!' );
 		}
 	}
 
-	public function testWhenUsingConfigLutPath_constructorCreatesConverter() {
+	public function testWhenUsingConfigLutPath_constructorCreatesConverter(): void {
 		$this->assertInstanceOf( BankDataConverter::class, $this->newBankDataConverter() );
 	}
 
-	public function testGivenNotExistingBankDataFile_constructorThrowsException() {
+	public function testGivenNotExistingBankDataFile_constructorThrowsException(): void {
 		$this->expectException( BankDataLibraryInitializationException::class );
 		$this->newBankDataConverter( '/foo/bar/awesome.data' );
 	}
@@ -37,7 +37,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider ibanTestProvider
 	 */
-	public function testWhenGivenInvalidIban_converterThrowsException( $ibanToTest ) {
+	public function testWhenGivenInvalidIban_converterThrowsException( $ibanToTest ): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$this->expectException( InvalidArgumentException::class );
@@ -57,13 +57,13 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider ibanTestProvider
 	 */
-	public function testWhenGivenInvalidIban_validateIbanReturnsFalse( $ibanToTest ) {
+	public function testWhenGivenInvalidIban_validateIbanReturnsFalse( $ibanToTest ): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$this->assertFalse( $bankConverter->validateIban( new Iban( $ibanToTest ) ) );
 	}
 
-	public function testWhenGivenValidIban_converterReturnsBankData() {
+	public function testWhenGivenValidIban_converterReturnsBankData(): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$bankData = new BankData();
@@ -80,7 +80,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenGivenValidNonDEIban_converterReturnsIBAN() {
+	public function testWhenGivenValidNonDEIban_converterReturnsIBAN(): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$bankData = new BankData();
@@ -97,7 +97,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenGivenValidIban_validateIbanReturnsTrue() {
+	public function testWhenGivenValidIban_validateIbanReturnsTrue(): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$this->assertTrue( $bankConverter->validateIban( new Iban( 'DE12500105170648489890' ) ) );
@@ -107,7 +107,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider accountTestProvider
 	 */
-	public function testWhenGivenInvalidAccountData_converterThrowsException( $accountToTest, $bankCodeToTest ) {
+	public function testWhenGivenInvalidAccountData_converterThrowsException( $accountToTest, $bankCodeToTest ): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$this->expectException( RuntimeException::class );
@@ -125,7 +125,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	public function testWhenGivenValidAccountData_converterReturnsBankData() {
+	public function testWhenGivenValidAccountData_converterReturnsBankData(): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$bankData = new BankData();

--- a/contexts/PaymentContext/tests/Unit/Domain/BankDataConverterTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/BankDataConverterTest.php
@@ -37,7 +37,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider ibanTestProvider
 	 */
-	public function testWhenGivenInvalidIban_converterThrowsException( $ibanToTest ): void {
+	public function testWhenGivenInvalidIban_converterThrowsException( string $ibanToTest ): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$this->expectException( InvalidArgumentException::class );
@@ -45,7 +45,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 		$bankConverter->getBankDataFromIban( new Iban( $ibanToTest ) );
 	}
 
-	public function ibanTestProvider() {
+	public function ibanTestProvider(): array {
 		return [
 			[ '' ],
 			[ 'DE120105170648489892' ],
@@ -57,7 +57,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider ibanTestProvider
 	 */
-	public function testWhenGivenInvalidIban_validateIbanReturnsFalse( $ibanToTest ): void {
+	public function testWhenGivenInvalidIban_validateIbanReturnsFalse( string $ibanToTest ): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$this->assertFalse( $bankConverter->validateIban( new Iban( $ibanToTest ) ) );
@@ -107,7 +107,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider accountTestProvider
 	 */
-	public function testWhenGivenInvalidAccountData_converterThrowsException( $accountToTest, $bankCodeToTest ): void {
+	public function testWhenGivenInvalidAccountData_converterThrowsException( string $accountToTest, string $bankCodeToTest ): void {
 		$bankConverter = $this->newBankDataConverter();
 
 		$this->expectException( RuntimeException::class );
@@ -115,7 +115,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 		$bankConverter->getBankDataFromAccountData( $accountToTest, $bankCodeToTest );
 	}
 
-	public function accountTestProvider() {
+	public function accountTestProvider(): array {
 		return [
 			[ '', '' ],
 			[ '0648489890', '' ],
@@ -142,7 +142,7 @@ class BankDataConverterTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function newBankDataConverter( string $filePath = 'res/blz.lut2f' ) {
+	private function newBankDataConverter( string $filePath = 'res/blz.lut2f' ): BankDataConverter {
 		return new BankDataConverter( $filePath );
 	}
 

--- a/contexts/PaymentContext/tests/Unit/Domain/CalculatingPaymentDelayCalculatorTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/CalculatingPaymentDelayCalculatorTest.php
@@ -17,12 +17,12 @@ class DefaultPaymentDelayCalculatorTest extends \PHPUnit\Framework\TestCase {
 
 	const PAYMENT_DELAY_IN_DAYS = 45;
 
-	public function testCalculatorAddsIntervalToGivenDate() {
+	public function testCalculatorAddsIntervalToGivenDate(): void {
 		$calculator = new DefaultPaymentDelayCalculator( self::PAYMENT_DELAY_IN_DAYS );
 		$this->assertEquals( '2013-02-03', $calculator->calculateFirstPaymentDate( '2012-12-20' )->format( 'Y-m-d' ) );
 	}
 
-	public function testGivenNoBaseDate_calculatorUsesCurrentDate() {
+	public function testGivenNoBaseDate_calculatorUsesCurrentDate(): void {
 		$calculator = new DefaultPaymentDelayCalculator( self::PAYMENT_DELAY_IN_DAYS );
 		$this->assertEquals(
 			self::PAYMENT_DELAY_IN_DAYS,

--- a/contexts/PaymentContext/tests/Unit/Domain/Model/IbanTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/Model/IbanTest.php
@@ -18,22 +18,22 @@ class IbanTest extends \PHPUnit\Framework\TestCase {
 	const TEST_IBAN = 'DE12500105170648489890';
 	const TEST_LOWERCASE_IBAN = 'de12500105170648489890';
 
-	public function testGivenIbanWithWhitespace_WhitespaceIsRemoved() {
+	public function testGivenIbanWithWhitespace_WhitespaceIsRemoved(): void {
 		$iban = new Iban( self::TEST_IBAN_WITH_WHITESPACE );
 		$this->assertSame( self::TEST_IBAN, $iban->toString() );
 	}
 
-	public function testCountryCodeIsReturnedCorrectly() {
+	public function testCountryCodeIsReturnedCorrectly(): void {
 		$iban = new Iban( self::TEST_IBAN );
 		$this->assertSame( 'DE', $iban->getCountryCode() );
 	}
 
-	public function testCountryCodeIsReturnedCorrectlyForLowercase() {
+	public function testCountryCodeIsReturnedCorrectlyForLowercase(): void {
 		$iban = new Iban( self::TEST_LOWERCASE_IBAN );
 		$this->assertSame( 'DE', $iban->getCountryCode() );
 	}
 
-	public function testGivenSameIbanWithDifferentCapitalization_objectsAreEqual() {
+	public function testGivenSameIbanWithDifferentCapitalization_objectsAreEqual(): void {
 		$this->assertEquals(
 			new Iban( self::TEST_IBAN ),
 			new Iban( self::TEST_LOWERCASE_IBAN )

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/CreditCardTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/CreditCardTest.php
@@ -56,7 +56,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function donationProvider() {
+	public function donationProvider(): array {
 		return [
 			[
 				'https://credit-card.micropayment.de/creditcard/event/index.php?project=wikimedia&bgcolor=CCE7CD&' .

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/CreditCardTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/CreditCardTest.php
@@ -18,7 +18,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase {
 
 	/** @dataProvider donationProvider */
 	public function testUrlGeneration( string $expected, string $firstName, string $lastName, string $payText,
-									   int $donationId, string $accessToken, string $updateToken, Euro $amount ) {
+									   int $donationId, string $accessToken, string $updateToken, Euro $amount ): void {
 		$urlGenerator = new CreditCard(
 			CreditCardConfig::newFromConfig( [
 				'base-url' => 'https://credit-card.micropayment.de/creditcard/event/index.php?',
@@ -35,7 +35,7 @@ class CreditCardTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenTestModeIsEnabled_urlPassesProperParameter() {
+	public function testWhenTestModeIsEnabled_urlPassesProperParameter(): void {
 		$urlGenerator = new CreditCard(
 			CreditCardConfig::newFromConfig( [
 				'base-url' => 'https://credit-card.micropayment.de/creditcard/event/index.php?',

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalConfigTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalConfigTest.php
@@ -19,7 +19,7 @@ class PayPalConfigTest extends \PHPUnit\Framework\TestCase {
 		$this->newIncompletePayPalUrlConfig();
 	}
 
-	private function newIncompletePayPalUrlConfig() {
+	private function newIncompletePayPalUrlConfig(): PayPalConfig {
 		return PayPalConfig::newFromConfig( [
 			PayPalConfig::CONFIG_KEY_BASE_URL => 'http://that.paymentprovider.com/?',
 			PayPalConfig::CONFIG_KEY_ACCOUNT_ADDRESS => 'some@email-adress.com',
@@ -34,7 +34,7 @@ class PayPalConfigTest extends \PHPUnit\Framework\TestCase {
 		$this->assertInstanceOf( PayPalConfig::class, $this->newPayPalUrlConfig() );
 	}
 
-	private function newPayPalUrlConfig() {
+	private function newPayPalUrlConfig(): PayPalConfig {
 		return PayPalConfig::newFromConfig( [
 			PayPalConfig::CONFIG_KEY_BASE_URL => 'http://that.paymentprovider.com/?',
 			PayPalConfig::CONFIG_KEY_ACCOUNT_ADDRESS => 'some@email-adress.com',

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalConfigTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalConfigTest.php
@@ -14,7 +14,7 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\PaymentUrlGenerator\PayPalCo
  */
 class PayPalConfigTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenIncompletePayPalUrlConfig_exceptionIsThrown() {
+	public function testGivenIncompletePayPalUrlConfig_exceptionIsThrown(): void {
 		$this->expectException( \RuntimeException::class );
 		$this->newIncompletePayPalUrlConfig();
 	}
@@ -30,7 +30,7 @@ class PayPalConfigTest extends \PHPUnit\Framework\TestCase {
 		] );
 	}
 
-	public function testGivenValidPayPalUrlConfig_payPalConfigIsReturned() {
+	public function testGivenValidPayPalUrlConfig_payPalConfigIsReturned(): void {
 		$this->assertInstanceOf( PayPalConfig::class, $this->newPayPalUrlConfig() );
 	}
 

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalTest.php
@@ -23,7 +23,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 	const CANCEL_URL = 'http://my.donation.app/donation/cancel/';
 	const ITEM_NAME = 'Mentioning that awesome organization on the invoice';
 
-	public function testSubscriptions() {
+	public function testSubscriptions(): void {
 		$generator = new PayPalUrlGenerator( $this->newPayPalUrlConfig() );
 
 		$this->assertUrlValidForSubscriptions(
@@ -31,12 +31,12 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertUrlValidForSubscriptions( $generatedUrl ) {
+	private function assertUrlValidForSubscriptions( $generatedUrl ): void {
 		$this->assertCommonParamsSet( $generatedUrl );
 		$this->assertSubscriptionRelatedParamsSet( $generatedUrl );
 	}
 
-	public function testSinglePayments() {
+	public function testSinglePayments(): void {
 		$generator = new PayPalUrlGenerator( $this->newPayPalUrlConfig() );
 
 		$this->assertUrlValidForSinglePayments(
@@ -44,7 +44,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertUrlValidForSinglePayments( $generatedUrl ) {
+	private function assertUrlValidForSinglePayments( $generatedUrl ): void {
 		$this->assertCommonParamsSet( $generatedUrl );
 		$this->assertSinglePaymentRelatedParamsSet( $generatedUrl );
 	}
@@ -60,7 +60,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		] );
 	}
 
-	public function testGivenIncompletePayPalUrlConfig_exceptionIsThrown() {
+	public function testGivenIncompletePayPalUrlConfig_exceptionIsThrown(): void {
 		$this->expectException( \RuntimeException::class );
 		$this->newIncompletePayPalUrlConfig();
 	}
@@ -76,7 +76,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		] );
 	}
 
-	public function testDelayedSubscriptions() {
+	public function testDelayedSubscriptions(): void {
 		$generator = new PayPalUrlGenerator( $this->newPayPalUrlConfigWithDelayedPayment() );
 
 		$this->assertUrlValidForDelayedSubscriptions(
@@ -84,7 +84,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertUrlValidForDelayedSubscriptions( $generatedUrl ) {
+	private function assertUrlValidForDelayedSubscriptions( $generatedUrl ): void {
 		$this->assertCommonParamsSet( $generatedUrl );
 		$this->assertSubscriptionRelatedParamsSet( $generatedUrl );
 		$this->assertTrialPeriodRelatedParametersSet( $generatedUrl );
@@ -102,7 +102,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		] );
 	}
 
-	private function assertCommonParamsSet( $generatedUrl ) {
+	private function assertCommonParamsSet( $generatedUrl ): void {
 		$this->assertContains( 'https://www.sandbox.paypal.com/cgi-bin/webscr', $generatedUrl );
 		$this->assertContains( 'business=foerderpp%40wikimedia.de', $generatedUrl );
 		$this->assertContains( 'currency_code=EUR', $generatedUrl );
@@ -118,18 +118,18 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		$this->assertContains( 'custom=%7B%22sid%22%3A1234%2C%22utoken%22%3A%22utoken%22%7D', $generatedUrl );
 	}
 
-	private function assertSinglePaymentRelatedParamsSet( string $generatedUrl ) {
+	private function assertSinglePaymentRelatedParamsSet( string $generatedUrl ): void {
 		$this->assertContains( 'cmd=_donations', $generatedUrl );
 		$this->assertContains( 'amount=12.34', $generatedUrl );
 	}
 
-	private function assertTrialPeriodRelatedParametersSet( string $generatedUrl ) {
+	private function assertTrialPeriodRelatedParametersSet( string $generatedUrl ): void {
 		$this->assertContains( 'a1=0', $generatedUrl );
 		$this->assertContains( 'p1=90', $generatedUrl );
 		$this->assertContains( 't1=D', $generatedUrl );
 	}
 
-	private function assertSubscriptionRelatedParamsSet( string $generatedUrl ) {
+	private function assertSubscriptionRelatedParamsSet( string $generatedUrl ): void {
 		$this->assertContains( 'cmd=_xclick-subscriptions', $generatedUrl );
 		$this->assertContains( 'no_shipping=1', $generatedUrl );
 		$this->assertContains( 'src=1', $generatedUrl );

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/PayPalTest.php
@@ -31,7 +31,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertUrlValidForSubscriptions( $generatedUrl ): void {
+	private function assertUrlValidForSubscriptions( string $generatedUrl ): void {
 		$this->assertCommonParamsSet( $generatedUrl );
 		$this->assertSubscriptionRelatedParamsSet( $generatedUrl );
 	}
@@ -44,7 +44,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertUrlValidForSinglePayments( $generatedUrl ): void {
+	private function assertUrlValidForSinglePayments( string $generatedUrl ): void {
 		$this->assertCommonParamsSet( $generatedUrl );
 		$this->assertSinglePaymentRelatedParamsSet( $generatedUrl );
 	}
@@ -65,7 +65,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		$this->newIncompletePayPalUrlConfig();
 	}
 
-	private function newIncompletePayPalUrlConfig() {
+	private function newIncompletePayPalUrlConfig(): PayPalConfig {
 		return PayPalConfig::newFromConfig( [
 			'base-url' => self::BASE_URL,
 			'account-address' => 'some@email-adress.com',
@@ -84,7 +84,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function assertUrlValidForDelayedSubscriptions( $generatedUrl ): void {
+	private function assertUrlValidForDelayedSubscriptions( string $generatedUrl ): void {
 		$this->assertCommonParamsSet( $generatedUrl );
 		$this->assertSubscriptionRelatedParamsSet( $generatedUrl );
 		$this->assertTrialPeriodRelatedParametersSet( $generatedUrl );
@@ -102,7 +102,7 @@ class PayPalTest extends \PHPUnit\Framework\TestCase {
 		] );
 	}
 
-	private function assertCommonParamsSet( $generatedUrl ): void {
+	private function assertCommonParamsSet( string $generatedUrl ): void {
 		$this->assertContains( 'https://www.sandbox.paypal.com/cgi-bin/webscr', $generatedUrl );
 		$this->assertContains( 'business=foerderpp%40wikimedia.de', $generatedUrl );
 		$this->assertContains( 'currency_code=EUR', $generatedUrl );

--- a/contexts/SubscriptionContext/src/DataAccess/DoctrineSubscriptionRepository.php
+++ b/contexts/SubscriptionContext/src/DataAccess/DoctrineSubscriptionRepository.php
@@ -27,7 +27,7 @@ class DoctrineSubscriptionRepository implements SubscriptionRepository {
 	 * @param Subscription $subscription
 	 * @throws SubscriptionRepositoryException
 	 */
-	public function storeSubscription( Subscription $subscription ) {
+	public function storeSubscription( Subscription $subscription ): void {
 		try {
 			$this->entityManager->persist( $subscription );
 			$this->entityManager->persist( $subscription->getAddress() );
@@ -56,7 +56,10 @@ class DoctrineSubscriptionRepository implements SubscriptionRepository {
 
 	}
 
-	public function findByConfirmationCode( string $confirmationCode ) {
+	/**
+	 * @throws SubscriptionRepositoryException
+	 */
+	public function findByConfirmationCode( string $confirmationCode ): ?Subscription {
 		try {
 			return $this->entityManager->getRepository( Subscription::class )->findOneBy( [
 				'confirmationCode' => $confirmationCode

--- a/contexts/SubscriptionContext/src/Domain/Repositories/SubscriptionRepository.php
+++ b/contexts/SubscriptionContext/src/Domain/Repositories/SubscriptionRepository.php
@@ -22,7 +22,7 @@ interface SubscriptionRepository {
 	 * @param Subscription $subscription
 	 * @throws SubscriptionRepositoryException
 	 */
-	public function storeSubscription( Subscription $subscription );
+	public function storeSubscription( Subscription $subscription ): void;
 
 	/**
 	 * Count the number of subscriptions with the same email address that were created after the cutoff date.
@@ -39,6 +39,6 @@ interface SubscriptionRepository {
 	 * @return Subscription|null
 	 * @throws SubscriptionRepositoryException
 	 */
-	public function findByConfirmationCode( string $confirmationCode );
+	public function findByConfirmationCode( string $confirmationCode ): ?Subscription;
 
 }

--- a/contexts/SubscriptionContext/src/Infrastructure/LoggingSubscriptionRepository.php
+++ b/contexts/SubscriptionContext/src/Infrastructure/LoggingSubscriptionRepository.php
@@ -35,7 +35,7 @@ class LoggingSubscriptionRepository implements SubscriptionRepository {
 	 *
 	 * @throws SubscriptionRepositoryException
 	 */
-	public function storeSubscription( Subscription $subscription ) {
+	public function storeSubscription( Subscription $subscription ): void {
 		try {
 			$this->repository->storeSubscription( $subscription );
 		}
@@ -72,7 +72,7 @@ class LoggingSubscriptionRepository implements SubscriptionRepository {
 	 * @return Subscription|null
 	 * @throws SubscriptionRepositoryException
 	 */
-	public function findByConfirmationCode( string $confirmationCode ) {
+	public function findByConfirmationCode( string $confirmationCode ): ?Subscription {
 		try {
 			return $this->repository->findByConfirmationCode( $confirmationCode );
 		}

--- a/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
+++ b/contexts/SubscriptionContext/src/UseCases/AddSubscription/AddSubscriptionUseCase.php
@@ -38,7 +38,7 @@ class AddSubscriptionUseCase {
 	 * @return ValidationResponse
 	 * @throws SubscriptionRepositoryException
 	 */
-	public function addSubscription( SubscriptionRequest $subscriptionRequest ) {
+	public function addSubscription( SubscriptionRequest $subscriptionRequest ): ValidationResponse {
 		$subscription = $this->createSubscriptionFromRequest( $subscriptionRequest );
 
 		$validationResult = $this->subscriptionValidator->validate( $subscription );
@@ -62,7 +62,7 @@ class AddSubscriptionUseCase {
 		return ValidationResponse::newSuccessResponse();
 	}
 
-	private function sendSubscriptionNotification( Subscription $subscription ) {
+	private function sendSubscriptionNotification( Subscription $subscription ): void {
 		$this->mailer->sendMail(
 			$this->newMailAddressFromSubscription( $subscription ),
 			// FIXME: this is an output similar to the main response model and should similarly not be an entity

--- a/contexts/SubscriptionContext/src/UseCases/AddSubscription/SubscriptionRequest.php
+++ b/contexts/SubscriptionContext/src/UseCases/AddSubscription/SubscriptionRequest.php
@@ -26,7 +26,7 @@ class SubscriptionRequest {
 		return $this->salutation;
 	}
 
-	public function setSalutation( string $salutation ) {
+	public function setSalutation( string $salutation ): void {
 		$this->salutation = $salutation;
 	}
 
@@ -34,7 +34,7 @@ class SubscriptionRequest {
 		return $this->title;
 	}
 
-	public function setTitle( string $title ) {
+	public function setTitle( string $title ): void {
 		$this->title = $title;
 	}
 
@@ -42,7 +42,7 @@ class SubscriptionRequest {
 		return $this->firstName;
 	}
 
-	public function setFirstName( string $firstName ) {
+	public function setFirstName( string $firstName ): void {
 		$this->firstName = $firstName;
 	}
 
@@ -50,7 +50,7 @@ class SubscriptionRequest {
 		return $this->lastName;
 	}
 
-	public function setLastName( string $lastName ) {
+	public function setLastName( string $lastName ): void {
 		$this->lastName = $lastName;
 	}
 
@@ -58,7 +58,7 @@ class SubscriptionRequest {
 		return $this->email;
 	}
 
-	public function setEmail( string $email ) {
+	public function setEmail( string $email ): void {
 		$this->email = $email;
 	}
 
@@ -66,7 +66,7 @@ class SubscriptionRequest {
 		return $this->address;
 	}
 
-	public function setAddress( string $address ) {
+	public function setAddress( string $address ): void {
 		$this->address = $address;
 	}
 
@@ -74,7 +74,7 @@ class SubscriptionRequest {
 		return $this->postcode;
 	}
 
-	public function setPostcode( string $postcode ) {
+	public function setPostcode( string $postcode ): void {
 		$this->postcode = $postcode;
 	}
 
@@ -82,7 +82,7 @@ class SubscriptionRequest {
 		return $this->city;
 	}
 
-	public function setCity( string $city ) {
+	public function setCity( string $city ): void {
 		$this->city = $city;
 	}
 
@@ -90,7 +90,7 @@ class SubscriptionRequest {
 		return $this->wikilogin;
 	}
 
-	public function setWikilogin( bool $wikilogin ) {
+	public function setWikilogin( bool $wikilogin ): void {
 		$this->wikilogin = $wikilogin;
 	}
 
@@ -98,7 +98,7 @@ class SubscriptionRequest {
 		return $this->trackingString;
 	}
 
-	public function setTrackingString( string $trackingString ) {
+	public function setTrackingString( string $trackingString ): void {
 		$this->trackingString = $trackingString;
 	}
 
@@ -106,7 +106,7 @@ class SubscriptionRequest {
 		return $this->source;
 	}
 
-	public function setSource( string $source ) {
+	public function setSource( string $source ): void {
 		$this->source = $source;
 	}
 
@@ -115,7 +115,7 @@ class SubscriptionRequest {
 	 *
 	 * @param array $values
 	 */
-	public function setWikiloginFromValues( array $values ) {
+	public function setWikiloginFromValues( array $values ): void {
 		$trueValues = ['yes', '1'];
 		$falseValues = ['no', '0'];
 		$matchingValues = array_intersect( $values, array_merge( $trueValues, $falseValues ) );

--- a/contexts/SubscriptionContext/src/UseCases/AddSubscription/SubscriptionRequest.php
+++ b/contexts/SubscriptionContext/src/UseCases/AddSubscription/SubscriptionRequest.php
@@ -86,7 +86,7 @@ class SubscriptionRequest {
 		$this->city = $city;
 	}
 
-	public function getWikilogin() {
+	public function getWikilogin(): bool {
 		return $this->wikilogin;
 	}
 

--- a/contexts/SubscriptionContext/src/Validation/SubscriptionValidator.php
+++ b/contexts/SubscriptionContext/src/Validation/SubscriptionValidator.php
@@ -55,7 +55,7 @@ class SubscriptionValidator {
 		) );
 	}
 
-	public function needsModeration( $subscription ): bool {
+	public function needsModeration( Subscription $subscription ): bool {
 		$this->textPolicyViolations = array_filter(
 			$this->getBadWordViolations( $subscription )
 		);
@@ -71,7 +71,7 @@ class SubscriptionValidator {
 		];
 	}
 
-	private function getBadWordViolations( Subscription $subscription ) {
+	private function getBadWordViolations( Subscription $subscription ): array {
 		$fieldTextValidator = new FieldTextPolicyValidator( $this->textPolicyValidator );
 		$address = $subscription->getAddress();
 

--- a/contexts/SubscriptionContext/tests/Fixtures/InMemorySubscriptionRepository.php
+++ b/contexts/SubscriptionContext/tests/Fixtures/InMemorySubscriptionRepository.php
@@ -18,7 +18,7 @@ class InMemorySubscriptionRepository implements SubscriptionRepository {
 	 */
 	private $subscriptions = [];
 
-	public function storeSubscription( Subscription $subscription ) {
+	public function storeSubscription( Subscription $subscription ): void {
 		$subscriptionKey = array_search( $subscription, $this->subscriptions, true );
 		if ( $subscriptionKey === false ) {
 			$subscriptionKey = count( $this->subscriptions );
@@ -43,7 +43,7 @@ class InMemorySubscriptionRepository implements SubscriptionRepository {
 		return $count;
 	}
 
-	public function findByConfirmationCode( string $confirmationCode ) {
+	public function findByConfirmationCode( string $confirmationCode ): ?Subscription {
 		foreach ( $this->subscriptions as $subscription ) {
 			if ( $subscription->getConfirmationCode() === $confirmationCode ) {
 				return $subscription;

--- a/contexts/SubscriptionContext/tests/Fixtures/SubscriptionRepositorySpy.php
+++ b/contexts/SubscriptionContext/tests/Fixtures/SubscriptionRepositorySpy.php
@@ -18,7 +18,7 @@ class SubscriptionRepositorySpy implements SubscriptionRepository {
 	 */
 	private $subscriptions = [];
 
-	public function storeSubscription( Subscription $subscription ) {
+	public function storeSubscription( Subscription $subscription ): void {
 		$this->subscriptions[] = $subscription;
 	}
 
@@ -33,7 +33,7 @@ class SubscriptionRepositorySpy implements SubscriptionRepository {
 		return 0;
 	}
 
-	public function findByConfirmationCode( string $confirmationCode ) {
+	public function findByConfirmationCode( string $confirmationCode ): ?Subscription {
 		return null;
 	}
 

--- a/contexts/SubscriptionContext/tests/Integration/DataAccess/DoctrineSubscriptionRepositoryTest.php
+++ b/contexts/SubscriptionContext/tests/Integration/DataAccess/DoctrineSubscriptionRepositoryTest.php
@@ -4,11 +4,13 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\Integration\SubscriptionContext\DataAccess;
 
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMException;
 use WMDE\Fundraising\Entities\Address;
 use WMDE\Fundraising\Entities\Subscription;
 use WMDE\Fundraising\Frontend\SubscriptionContext\DataAccess\DoctrineSubscriptionRepository;
+use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepository;
 use WMDE\Fundraising\Frontend\SubscriptionContext\Domain\Repositories\SubscriptionRepositoryException;
 use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
 
@@ -30,7 +32,7 @@ class DoctrineSubscriptionRepositoryTest extends \PHPUnit\Framework\TestCase {
 		parent::setUp();
 	}
 
-	private function getOrmRepository() {
+	private function getOrmRepository(): EntityRepository {
 		return $this->entityManager->getRepository( Subscription::class );
 	}
 

--- a/contexts/SubscriptionContext/tests/Integration/DataAccess/DoctrineSubscriptionRepositoryTest.php
+++ b/contexts/SubscriptionContext/tests/Integration/DataAccess/DoctrineSubscriptionRepositoryTest.php
@@ -25,7 +25,7 @@ class DoctrineSubscriptionRepositoryTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $entityManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->entityManager = TestEnvironment::newInstance()->getFactory()->getEntityManager();
 		parent::setUp();
 	}
@@ -34,7 +34,7 @@ class DoctrineSubscriptionRepositoryTest extends \PHPUnit\Framework\TestCase {
 		return $this->entityManager->getRepository( Subscription::class );
 	}
 
-	public function testGivenASubscription_itIsStored() {
+	public function testGivenASubscription_itIsStored(): void {
 		$subscription = new Subscription();
 		$subscription->setEmail( 'nyan@awesomecats.com' );
 		$subscription->setAddress( new Address() );
@@ -44,14 +44,14 @@ class DoctrineSubscriptionRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( [$subscription], $expected );
 	}
 
-	public function testGivenARecentSubscription_itIsCounted() {
+	public function testGivenARecentSubscription_itIsCounted(): void {
 		$firstSubscription = $this->persistFirstSubscription();
 		$this->entityManager->flush();
 		$repository = new DoctrineSubscriptionRepository( $this->entityManager );
 		$this->assertSame( 1, $repository->countSimilar( $firstSubscription, new \DateTime( '100 years ago' ) ) );
 	}
 
-	public function testMultipleSubscriptions_onlySimilarAreCounted() {
+	public function testMultipleSubscriptions_onlySimilarAreCounted(): void {
 		$this->persistFirstSubscription();
 		$this->persistSecondSubscription();
 		$thirdSubscription = $this->persistThirdSubscription();
@@ -62,7 +62,7 @@ class DoctrineSubscriptionRepositoryTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 2, $repository->countSimilar( $thirdSubscription, new \DateTime( '100 years ago' ) ) );
 	}
 
-	public function testDatabaseLayerExceptionsAreConvertedToDomainExceptions() {
+	public function testDatabaseLayerExceptionsAreConvertedToDomainExceptions(): void {
 		$entityManager = $this->getMockBuilder( EntityManager::class )
 			->setMethods( [ 'getRepository', 'getClassMetadata', 'persist', 'flush' ] )
 			->disableOriginalConstructor()

--- a/contexts/SubscriptionContext/tests/Integration/UseCases/AddSubscription/AddSubscriptionUseCaseTest.php
+++ b/contexts/SubscriptionContext/tests/Integration/UseCases/AddSubscription/AddSubscriptionUseCaseTest.php
@@ -42,7 +42,7 @@ class AddSubscriptionUseCaseTest extends TestCase {
 	 */
 	private $mailer;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->repo = $this->createMock( SubscriptionRepository::class );
 
 		$this->validator = $this->getMockBuilder( SubscriptionValidator::class )
@@ -60,14 +60,14 @@ class AddSubscriptionUseCaseTest extends TestCase {
 		return $request;
 	}
 
-	public function testGivenValidData_aSuccessResponseIsCreated() {
+	public function testGivenValidData_aSuccessResponseIsCreated(): void {
 		$this->validator->method( 'validate' )->willReturn( new ValidationResult() );
 		$useCase = new AddSubscriptionUseCase( $this->repo, $this->validator, $this->mailer );
 		$result = $useCase->addSubscription( $this->createValidSubscriptionRequest() );
 		$this->assertTrue( $result->isSuccessful() );
 	}
 
-	public function testGivenInvalidData_anErrorResponseTypeIsCreated() {
+	public function testGivenInvalidData_anErrorResponseTypeIsCreated(): void {
 		$this->validator->method( 'validate' )->willReturn( new FailedValidationResult() );
 		$useCase = new AddSubscriptionUseCase( $this->repo, $this->validator, $this->mailer );
 		$request = $this->createMock( SubscriptionRequest::class );
@@ -75,7 +75,7 @@ class AddSubscriptionUseCaseTest extends TestCase {
 		$this->assertFalse( $result->isSuccessful() );
 	}
 
-	public function testGivenValidData_requestWillBeStored() {
+	public function testGivenValidData_requestWillBeStored(): void {
 		$this->validator->method( 'validate' )->willReturn( new ValidationResult() );
 		$this->repo->expects( $this->once() )
 			->method( 'storeSubscription' )
@@ -84,7 +84,7 @@ class AddSubscriptionUseCaseTest extends TestCase {
 		$useCase->addSubscription( $this->createValidSubscriptionRequest() );
 	}
 
-	public function testGivenDataThatNeedsToBeModerated_requestWillBeStored() {
+	public function testGivenDataThatNeedsToBeModerated_requestWillBeStored(): void {
 		$this->validator->method( 'validate' )->willReturn( new ValidationResult() );
 		$this->validator->method( 'needsModeration' )->willReturn( true );
 		$this->repo->expects( $this->once() )
@@ -97,7 +97,7 @@ class AddSubscriptionUseCaseTest extends TestCase {
 		$useCase->addSubscription( $this->createValidSubscriptionRequest() );
 	}
 
-	public function testGivenInvalidData_requestWillNotBeStored() {
+	public function testGivenInvalidData_requestWillNotBeStored(): void {
 		$this->validator->method( 'validate' )->willReturn( new FailedValidationResult() );
 		$this->repo->expects( $this->never() )->method( 'storeSubscription' );
 		$useCase = new AddSubscriptionUseCase( $this->repo, $this->validator, $this->mailer );
@@ -105,7 +105,7 @@ class AddSubscriptionUseCaseTest extends TestCase {
 		$useCase->addSubscription( $request );
 	}
 
-	public function testGivenValidData_requestWillBeMailed() {
+	public function testGivenValidData_requestWillBeMailed(): void {
 		$this->validator->method( 'validate' )->willReturn( new ValidationResult() );
 		$this->mailer->expects( $this->once() )
 			->method( 'sendMail' )
@@ -126,7 +126,7 @@ class AddSubscriptionUseCaseTest extends TestCase {
 		$useCase->addSubscription( $this->createValidSubscriptionRequest() );
 	}
 
-	public function testGivenInvalidData_requestWillNotBeMailed() {
+	public function testGivenInvalidData_requestWillNotBeMailed(): void {
 		$this->validator->method( 'validate' )->willReturn( new FailedValidationResult() );
 		$this->mailer->expects( $this->never() )->method( 'sendMail' );
 		$useCase = new AddSubscriptionUseCase( $this->repo, $this->validator, $this->mailer );
@@ -134,7 +134,7 @@ class AddSubscriptionUseCaseTest extends TestCase {
 		$useCase->addSubscription( $request );
 	}
 
-	public function testGivenDataThatNeedsToBeModerated_requestNotBeMailed() {
+	public function testGivenDataThatNeedsToBeModerated_requestNotBeMailed(): void {
 		$this->validator->method( 'validate' )->willReturn( new ValidationResult() );
 		$this->validator->method( 'needsModeration' )->willReturn( true );
 		$this->mailer->expects( $this->never() )->method( 'sendMail' );

--- a/contexts/SubscriptionContext/tests/Integration/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCaseTest.php
+++ b/contexts/SubscriptionContext/tests/Integration/UseCases/ConfirmSubscription/ConfirmSubscriptionUseCaseTest.php
@@ -51,7 +51,7 @@ class ConfirmSubscriptionUseCaseTest extends \PHPUnit\Framework\TestCase {
 			->getMock();
 	}
 
-	public function testGivenNoSubscriptions_anErrorResponseIsCreated() {
+	public function testGivenNoSubscriptions_anErrorResponseIsCreated(): void {
 		$mailer = $this->newMailer();
 		$mailer->expects( $this->never() )->method( 'sendMail' );
 		$useCase = new ConfirmSubscriptionUseCase( new InMemorySubscriptionRepository(), $mailer );
@@ -59,7 +59,7 @@ class ConfirmSubscriptionUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $result->isSuccessful() );
 	}
 
-	public function testGivenASubscriptionWithWrongStatus_anErrorResponseIsCreated() {
+	public function testGivenASubscriptionWithWrongStatus_anErrorResponseIsCreated(): void {
 		$subscription = $this->newSubscription();
 		$subscription->markAsConfirmed();
 
@@ -74,7 +74,7 @@ class ConfirmSubscriptionUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $useCase->confirmSubscription( self::CONFIRMATION_CODE )->isSuccessful() );
 	}
 
-	public function testGivenASubscription_aSuccessIsCreated() {
+	public function testGivenASubscription_aSuccessIsCreated(): void {
 		$repo = new InMemorySubscriptionRepository();
 		$repo->storeSubscription( $this->newSubscription() );
 
@@ -83,7 +83,7 @@ class ConfirmSubscriptionUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $useCase->confirmSubscription( self::CONFIRMATION_CODE )->isSuccessful() );
 	}
 
-	public function testGivenASubscription_statusIsSetToConfirmed() {
+	public function testGivenASubscription_statusIsSetToConfirmed(): void {
 		$repo = new InMemorySubscriptionRepository();
 		$repo->storeSubscription( $this->newSubscription() );
 
@@ -93,7 +93,7 @@ class ConfirmSubscriptionUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $repo->getSubscriptions()[0]->isUnconfirmed(), 'Status needs to be set to confirmed' );
 	}
 
-	public function testGivenASubscription_aConfirmationMailIsSent() {
+	public function testGivenASubscription_aConfirmationMailIsSent(): void {
 		$repo = new InMemorySubscriptionRepository();
 		$repo->storeSubscription( $this->newSubscription() );
 

--- a/contexts/SubscriptionContext/tests/Unit/UseCases/AddSubscription/SubscriptionRequestTest.php
+++ b/contexts/SubscriptionContext/tests/Unit/UseCases/AddSubscription/SubscriptionRequestTest.php
@@ -14,13 +14,13 @@ use WMDE\Fundraising\Frontend\SubscriptionContext\UseCases\AddSubscription\Subsc
  */
 class SubscriptionRequestTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenInvalidValues_WikiloginIsFalse() {
+	public function testGivenInvalidValues_WikiloginIsFalse(): void {
 		$request = new SubscriptionRequest();
 		$request->setWikiloginFromValues( ['', 'foo', 'bar' ] );
 		$this->assertFalse( $request->getWikilogin() );
 	}
 
-	public function testGivenValues_WikiloginChoosesTheFirstValidValue() {
+	public function testGivenValues_WikiloginChoosesTheFirstValidValue(): void {
 		$request = new SubscriptionRequest();
 		$request->setWikiloginFromValues( ['', 'yes' ] );
 		$this->assertTrue( $request->getWikilogin() );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -135,6 +135,7 @@
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php">
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingPropertyTypeHint" />
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -134,6 +134,7 @@
 
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php">
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingPropertyTypeHint" />
     </rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,7 +15,7 @@
     <arg value="p"/>
 
     <!--<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace">-->
-        <!--<exclude name="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace/SpaceBeforeSingleLineCommentSniff.php" />-->
+    <!--<exclude name="vendor/mediawiki/mediawiki-codesniffer/MediaWiki/Sniffs/WhiteSpace/SpaceBeforeSingleLineCommentSniff.php" />-->
     <!--</rule>-->
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
@@ -131,6 +131,24 @@
     </rule>
 
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/ReturnTypeHintSpacingSniff.php" />
+
+    <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/TypeHintDeclarationSniff.php">
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableParameterTypeHintSpecification" />
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification" />
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+        <properties>
+            <property name="usefulAnnotations" type="array" value="
+				@see,
+				@throws,
+				@expectException,
+				@dataProvider,
+				@slowThreshold,
+				@noinspection
+			"/>
+        </properties>
+    </rule>
 
     <rule ref="./vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/Namespaces/UseDoesNotStartWithBackslashSniff.php" />
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -571,7 +571,7 @@ class FunFunFactory {
 		);
 	}
 
-	private function getDefaultTwigVariables() {
+	private function getDefaultTwigVariables(): array {
 		return [
 			'honorifics' => $this->getHonorifics()->getList(),
 			'header_template' => $this->config['default-layout-templates']['header'],
@@ -582,7 +582,7 @@ class FunFunFactory {
 		];
 	}
 
-	private function newReferrerGeneralizer() {
+	private function newReferrerGeneralizer(): ReferrerGeneralizer {
 		return new ReferrerGeneralizer(
 			$this->config['referrer-generalization']['default'],
 			$this->config['referrer-generalization']['domain-map']
@@ -672,7 +672,7 @@ class FunFunFactory {
 		return $this->addProfilingDecorator( $mailer, 'Mailer' );
 	}
 
-	public function getGreetingGenerator() {
+	public function getGreetingGenerator(): GreetingGenerator {
 		return $this->pimple['greeting_generator'];
 	}
 
@@ -688,7 +688,7 @@ class FunFunFactory {
 		return new IbanPresenter();
 	}
 
-	public function newBankDataConverter() {
+	public function newBankDataConverter(): BankDataConverter {
 		return new BankDataConverter( $this->config['bank-data-file'] );
 	}
 
@@ -696,7 +696,7 @@ class FunFunFactory {
 		$this->pimple['subscription_validator'] = $subscriptionValidator;
 	}
 
-	public function newGetInTouchUseCase() {
+	public function newGetInTouchUseCase(): GetInTouchUseCase {
 		return new GetInTouchUseCase(
 			$this->getContactValidator(),
 			$this->newContactOperatorMailer(),
@@ -787,7 +787,7 @@ class FunFunFactory {
 		return new EmailAddress( $this->config['contact-info']['suborganization']['email'] );
 	}
 
-	public function getOrganizationEmailAddress() {
+	public function getOrganizationEmailAddress(): EmailAddress {
 		return new EmailAddress( $this->config['contact-info']['organization']['email'] );
 	}
 
@@ -905,19 +905,19 @@ class FunFunFactory {
 		);
 	}
 
-	public function newPayPalUrlGeneratorForDonations() {
+	public function newPayPalUrlGeneratorForDonations(): PayPalUrlGenerator {
 		return new PayPalUrlGenerator( $this->getPayPalUrlConfigForDonations() );
 	}
 
-	public function newPayPalUrlGeneratorForMembershipApplications() {
+	public function newPayPalUrlGeneratorForMembershipApplications(): PayPalUrlGenerator {
 		return new PayPalUrlGenerator( $this->getPayPalUrlConfigForMembershipApplications() );
 	}
 
-	private function getPayPalUrlConfigForDonations() {
+	private function getPayPalUrlConfigForDonations(): PayPalConfig {
 		return PayPalConfig::newFromConfig( $this->config['paypal-donation'] );
 	}
 
-	private function getPayPalUrlConfigForMembershipApplications() {
+	private function getPayPalUrlConfigForMembershipApplications(): PayPalConfig {
 		return PayPalConfig::newFromConfig( $this->config['paypal-membership'] );
 	}
 
@@ -991,13 +991,13 @@ class FunFunFactory {
 		return $this->pimple['token_generator'];
 	}
 
-	public function newDonationConfirmationPresenter() {
+	public function newDonationConfirmationPresenter(): DonationConfirmationHtmlPresenter {
 		return new DonationConfirmationHtmlPresenter(
 			$this->getIncludeTemplate( 'Donation_Confirmation.html.twig', [ 'piwikGoals' => [ 3 ] ] )
 		);
 	}
 
-	public function newCreditCardPaymentHtmlPresenter() {
+	public function newCreditCardPaymentHtmlPresenter(): CreditCardPaymentHtmlPresenter {
 		return new CreditCardPaymentHtmlPresenter(
 			$this->getIncludeTemplate( 'Credit_Card_Payment_Iframe.html.twig' ),
 			$this->getTranslator(),
@@ -1005,7 +1005,7 @@ class FunFunFactory {
 		);
 	}
 
-	public function newCancelDonationHtmlPresenter() {
+	public function newCancelDonationHtmlPresenter(): CancelDonationHtmlPresenter {
 		return new CancelDonationHtmlPresenter(
 			$this->getIncludeTemplate( 'Donation_Cancellation_Confirmation.html.twig' )
 		);
@@ -1052,7 +1052,7 @@ class FunFunFactory {
 		return new DoctrineApplicationPiwikTracker( $this->getEntityManager() );
 	}
 
-	private function getPaymentDelayCalculator() {
+	private function getPaymentDelayCalculator(): PaymentDelayCalculator {
 		return $this->pimple['payment-delay-calculator'];
 	}
 
@@ -1101,7 +1101,7 @@ class FunFunFactory {
 		);
 	}
 
-	public function newMembershipApplicationConfirmationUseCase( string $accessToken ) {
+	public function newMembershipApplicationConfirmationUseCase( string $accessToken ): ShowMembershipApplicationConfirmationUseCase {
 		return new ShowMembershipApplicationConfirmationUseCase(
 			$this->newMembershipApplicationAuthorizer( null, $accessToken ), $this->getMembershipApplicationRepository(),
 			$this->newMembershipApplicationTokenFetcher()
@@ -1124,11 +1124,11 @@ class FunFunFactory {
 		return $this->pimple['confirmation-page-selector'];
 	}
 
-	public function newDonationFormViolationPresenter() {
+	public function newDonationFormViolationPresenter(): DonationFormViolationPresenter {
 		return new DonationFormViolationPresenter( $this->getDonationFormTemplate(), $this->newAmountFormatter() );
 	}
 
-	public function newDonationFormPresenter() {
+	public function newDonationFormPresenter(): DonationFormPresenter {
 		return new DonationFormPresenter( $this->getDonationFormTemplate(), $this->newAmountFormatter() );
 	}
 
@@ -1146,7 +1146,7 @@ class FunFunFactory {
 		} ) );
 	}
 
-	public function newHandlePayPalPaymentNotificationUseCase( string $updateToken ) {
+	public function newHandlePayPalPaymentNotificationUseCase( string $updateToken ): HandlePayPalPaymentNotificationUseCase {
 		return new HandlePayPalPaymentNotificationUseCase(
 			$this->getDonationRepository(),
 			$this->newDonationAuthorizer( $updateToken ),
@@ -1155,7 +1155,7 @@ class FunFunFactory {
 		);
 	}
 
-	public function newMembershipApplicationSubscriptionSignupNotificationUseCase( string $updateToken ) {
+	public function newMembershipApplicationSubscriptionSignupNotificationUseCase( string $updateToken ): HandleSubscriptionSignupNotificationUseCase {
 		return new HandleSubscriptionSignupNotificationUseCase(
 			$this->getMembershipApplicationRepository(),
 			$this->newMembershipApplicationAuthorizer( $updateToken ),
@@ -1164,7 +1164,7 @@ class FunFunFactory {
 		);
 	}
 
-	public function newMembershipApplicationSubscriptionPaymentNotificationUseCase( string $updateToken ) {
+	public function newMembershipApplicationSubscriptionPaymentNotificationUseCase( string $updateToken ): HandleSubscriptionPaymentNotificationUseCase {
 		return new HandleSubscriptionPaymentNotificationUseCase(
 			$this->getMembershipApplicationRepository(),
 			$this->newMembershipApplicationAuthorizer( $updateToken ),
@@ -1189,7 +1189,7 @@ class FunFunFactory {
 		$this->pimple['paypal-membership-fee-notification-verifier'] = $verifier;
 	}
 
-	public function newCreditCardNotificationUseCase( string $updateToken ) {
+	public function newCreditCardNotificationUseCase( string $updateToken ): CreditCardNotificationUseCase {
 		return new CreditCardNotificationUseCase(
 			$this->getDonationRepository(),
 			$this->newDonationAuthorizer( $updateToken ),
@@ -1200,19 +1200,19 @@ class FunFunFactory {
 		);
 	}
 
-	public function newCancelMembershipApplicationHtmlPresenter() {
+	public function newCancelMembershipApplicationHtmlPresenter(): CancelMembershipApplicationHtmlPresenter {
 		return new CancelMembershipApplicationHtmlPresenter(
 			$this->getIncludeTemplate( 'Membership_Application_Cancellation_Confirmation.html.twig' )
 		);
 	}
 
-	public function newMembershipApplicationConfirmationHtmlPresenter() {
+	public function newMembershipApplicationConfirmationHtmlPresenter(): MembershipApplicationConfirmationHtmlPresenter {
 		return new MembershipApplicationConfirmationHtmlPresenter(
 			$this->getIncludeTemplate( 'Membership_Application_Confirmation.html.twig' )
 		);
 	}
 
-	public function newMembershipFormViolationPresenter() {
+	public function newMembershipFormViolationPresenter(): MembershipFormViolationPresenter {
 		return new MembershipFormViolationPresenter(
 			$this->getLayoutTemplate( 'Membership_Application.html.twig' )
 		);
@@ -1289,7 +1289,7 @@ class FunFunFactory {
 		return $this->config['donation-timeframe-limit'];
 	}
 
-	public function newSystemMessageResponse( string $message ) {
+	public function newSystemMessageResponse( string $message ): string {
 		$test = $this->getIncludeTemplate( 'System_Message.html.twig' );
 		return $test->render( [ 'message' => $message ] );
 	}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1285,7 +1285,7 @@ class FunFunFactory {
 		return new AmountPolicyValidator( 1000, 1000 );
 	}
 
-	public function getDonationTimeframeLimit() {
+	public function getDonationTimeframeLimit(): string {
 		return $this->config['donation-timeframe-limit'];
 	}
 
@@ -1294,7 +1294,7 @@ class FunFunFactory {
 		return $test->render( [ 'message' => $message ] );
 	}
 
-	public function getMembershipApplicationTimeframeLimit() {
+	public function getMembershipApplicationTimeframeLimit(): string {
 		return $this->config['membership-application-timeframe-limit'];
 	}
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1320,7 +1320,7 @@ class FunFunFactory {
 		};
 	}
 
-	private function addProfilingDecorator( $objectToDecorate, string $profilingLabel ) {
+	private function addProfilingDecorator( $objectToDecorate, string $profilingLabel ) {	// @codingStandardsIgnoreLine
 		if ( $this->profiler === null ) {
 			return $objectToDecorate;
 		}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -493,7 +493,7 @@ class FunFunFactory {
 		return $this->pimple['subscription_repository'];
 	}
 
-	public function setSubscriptionRepository( SubscriptionRepository $subscriptionRepository ) {
+	public function setSubscriptionRepository( SubscriptionRepository $subscriptionRepository ): void {
 		$this->pimple['subscription_repository'] = $subscriptionRepository;
 	}
 
@@ -528,7 +528,7 @@ class FunFunFactory {
 		return new GetInTouchHtmlPresenter( $this->getLayoutTemplate( 'contact_form.html.twig' ), $this->getTranslator() );
 	}
 
-	public function setTwigEnvironment( Twig_Environment $twig ) {
+	public function setTwigEnvironment( Twig_Environment $twig ): void {
 		$this->pimple['twig_environment'] = $twig;
 	}
 
@@ -692,7 +692,7 @@ class FunFunFactory {
 		return new BankDataConverter( $this->config['bank-data-file'] );
 	}
 
-	public function setSubscriptionValidator( SubscriptionValidator $subscriptionValidator ) {
+	public function setSubscriptionValidator( SubscriptionValidator $subscriptionValidator ): void {
 		$this->pimple['subscription_validator'] = $subscriptionValidator;
 	}
 
@@ -760,7 +760,7 @@ class FunFunFactory {
 		return $this->pimple['messenger_suborganization'];
 	}
 
-	public function setSuborganizationMessenger( Messenger $messenger ) {
+	public function setSuborganizationMessenger( Messenger $messenger ): void {
 		$this->pimple['messenger_suborganization'] = $messenger;
 	}
 
@@ -768,11 +768,11 @@ class FunFunFactory {
 		return $this->pimple['messenger_organization'];
 	}
 
-	public function setOrganizationMessenger( Messenger $messenger ) {
+	public function setOrganizationMessenger( Messenger $messenger ): void {
 		$this->pimple['messenger_organization'] = $messenger;
 	}
 
-	public function setNullMessenger() {
+	public function setNullMessenger(): void {
 		$this->setSuborganizationMessenger( new Messenger(
 			Swift_NullTransport::newInstance(),
 			$this->getSubOrganizationEmailAddress()
@@ -803,7 +803,7 @@ class FunFunFactory {
 		return $this->pimple['translator'];
 	}
 
-	public function setTranslator( TranslatorInterface $translator ) {
+	public function setTranslator( TranslatorInterface $translator ): void {
 		$this->pimple['translator'] = $translator;
 	}
 
@@ -1056,7 +1056,7 @@ class FunFunFactory {
 		return $this->pimple['payment-delay-calculator'];
 	}
 
-	public function setPaymentDelayCalculator( PaymentDelayCalculator $paymentDelayCalculator ) {
+	public function setPaymentDelayCalculator( PaymentDelayCalculator $paymentDelayCalculator ): void {
 		$this->pimple['payment-delay-calculator'] = $paymentDelayCalculator;
 	}
 
@@ -1116,7 +1116,7 @@ class FunFunFactory {
 		);
 	}
 
-	public function setDonationConfirmationPageSelector( DonationConfirmationPageSelector $selector ) {
+	public function setDonationConfirmationPageSelector( DonationConfirmationPageSelector $selector ): void {
 		$this->pimple['confirmation-page-selector'] = $selector;
 	}
 
@@ -1177,7 +1177,7 @@ class FunFunFactory {
 		return $this->pimple['paypal-payment-notification-verifier'];
 	}
 
-	public function setPayPalPaymentNotificationVerifier( PaymentNotificationVerifier $verifier ) {
+	public function setPayPalPaymentNotificationVerifier( PaymentNotificationVerifier $verifier ): void {
 		$this->pimple['paypal-payment-notification-verifier'] = $verifier;
 	}
 
@@ -1185,7 +1185,7 @@ class FunFunFactory {
 		return $this->pimple['paypal-membership-fee-notification-verifier'];
 	}
 
-	public function setPayPalMembershipFeeNotificationVerifier( PaymentNotificationVerifier $verifier ) {
+	public function setPayPalMembershipFeeNotificationVerifier( PaymentNotificationVerifier $verifier ): void {
 		$this->pimple['paypal-membership-fee-notification-verifier'] = $verifier;
 	}
 
@@ -1218,7 +1218,7 @@ class FunFunFactory {
 		);
 	}
 
-	public function setCreditCardService( CreditCardService $ccService ) {
+	public function setCreditCardService( CreditCardService $ccService ): void {
 		$this->pimple['credit-card-api-service'] = $ccService;
 	}
 
@@ -1252,11 +1252,11 @@ class FunFunFactory {
 		);
 	}
 
-	public function setTokenGenerator( TokenGenerator $tokenGenerator ) {
+	public function setTokenGenerator( TokenGenerator $tokenGenerator ): void {
 		$this->pimple['token_generator'] = $tokenGenerator;
 	}
 
-	public function disableDoctrineSubscribers() {
+	public function disableDoctrineSubscribers(): void {
 		$this->addDoctrineSubscribers = false;
 	}
 
@@ -1310,7 +1310,7 @@ class FunFunFactory {
 		return $this->pimple['rendered_page_cache'];
 	}
 
-	public function enablePageCache() {
+	public function enablePageCache(): void {
 		$this->pimple['page_cache'] = function() {
 			return new FilesystemCache( $this->getCachePath() . '/pages/raw' );
 		};
@@ -1330,19 +1330,19 @@ class FunFunFactory {
 		return $builder->decorate( $objectToDecorate, $profilingLabel );
 	}
 
-	public function setProfiler( Stopwatch $profiler ) {
+	public function setProfiler( Stopwatch $profiler ): void {
 		$this->profiler = $profiler;
 	}
 
-	public function setEmailValidator( EmailValidator $validator ) {
+	public function setEmailValidator( EmailValidator $validator ): void {
 		$this->pimple['mail_validator'] = $validator;
 	}
 
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->pimple['logger'] = $logger;
 	}
 
-	public function setPaypalLogger( LoggerInterface $logger ) {
+	public function setPaypalLogger( LoggerInterface $logger ): void {
 		$this->pimple['paypal_logger'] = $logger;
 	}
 
@@ -1382,7 +1382,7 @@ class FunFunFactory {
 		return new PageNotFoundPresenter( $this->getLayoutTemplate( 'Page_not_found.html.twig' ) );
 	}
 
-	public function setPageViewTracker( PageViewTracker $tracker ) {
+	public function setPageViewTracker( PageViewTracker $tracker ): void {
 		$this->pimple['page_view_tracker'] = function () use ( $tracker )  {
 			return $tracker;
 		};

--- a/src/Factories/TranslationFactory.php
+++ b/src/Factories/TranslationFactory.php
@@ -22,7 +22,7 @@ class TranslationFactory {
 		return $translator;
 	}
 
-	public function newJsonLoader() {
+	public function newJsonLoader(): JsonFileLoader {
 		return new JsonFileLoader();
 	}
 }

--- a/src/Factories/TwigFactory.php
+++ b/src/Factories/TwigFactory.php
@@ -54,7 +54,7 @@ class TwigFactory {
 		return $this->convertToAbsolute( $appRoot, $templateDir );
 	}
 
-	private function convertToAbsolute( $root, array $dirs ): array {
+	private function convertToAbsolute( string $root, array $dirs ): array {
 		return array_map(
 				function( $dir ) use ( $root ) {
 					if ( strlen( $dir ) == 0 || $dir{0} != '/' ) {
@@ -66,24 +66,24 @@ class TwigFactory {
 		);
 	}
 
-	public function newArrayLoader() {
+	public function newArrayLoader(): Twig_Loader_Array {
 		$templates = $this->config['loaders']['array'] ?? [];
 		return new Twig_Loader_Array( $templates );
 	}
 
-	public function newStringLoaderExtension() {
+	public function newStringLoaderExtension(): Twig_Extension_StringLoader {
 		return new Twig_Extension_StringLoader();
 	}
 
-	public function newTranslationExtension( TranslatorInterface $translator ) {
+	public function newTranslationExtension( TranslatorInterface $translator ): TranslationExtension {
 		return new TranslationExtension( $translator );
 	}
 
-	public function newFilePrefixFilter( FilePrefixer $filePrefixer ) {
+	public function newFilePrefixFilter( FilePrefixer $filePrefixer ): Twig_SimpleFilter {
 		return new Twig_SimpleFilter( 'prefix_file', [ $filePrefixer, 'prefixFile' ] );
 	}
 
-	public function newTwigEnvironmentConfigurator() {
+	public function newTwigEnvironmentConfigurator(): TwigEnvironmentConfigurator {
 		return new TwigEnvironmentConfigurator( $this->config, $this->cachePath );
 	}
 }

--- a/src/Factories/TwigFactory.php
+++ b/src/Factories/TwigFactory.php
@@ -40,7 +40,7 @@ class TwigFactory {
 	 * @param array $config Configuration for the filesystem loader. The key 'template-dir' can be a string or an array.
 	 * @return array
 	 */
-	private function getTemplateDir( $config ): array {
+	private function getTemplateDir( array $config ): array {
 		if ( is_string( $config['template-dir'] ) ) {
 			$templateDir = [ $config['template-dir'] ];
 		}

--- a/src/Infrastructure/Cache/AllOfTheCachePurger.php
+++ b/src/Infrastructure/Cache/AllOfTheCachePurger.php
@@ -26,7 +26,7 @@ class AllOfTheCachePurger implements CachePurger {
 	/**
 	 * @throws CachePurgingException
 	 */
-	public function purgeCache() {
+	public function purgeCache(): void {
 		$this->twigEnvironment->clearCacheFiles();
 		$this->twigEnvironment->clearTemplateCache();
 

--- a/src/Infrastructure/Cache/CachePurger.php
+++ b/src/Infrastructure/Cache/CachePurger.php
@@ -13,6 +13,6 @@ interface CachePurger {
 	/**
 	 * @throws CachePurgingException
 	 */
-	public function purgeCache();
+	public function purgeCache(): void;
 
 }

--- a/src/Infrastructure/LoggingPaymentNotificationVerifier.php
+++ b/src/Infrastructure/LoggingPaymentNotificationVerifier.php
@@ -26,7 +26,7 @@ class LoggingPaymentNotificationVerifier implements PaymentNotificationVerifier 
 		$this->logLevel = LogLevel::CRITICAL;
 	}
 
-	public function verify( array $request ) {
+	public function verify( array $request ): void {
 		try {
 			$this->verifier->verify( $request );
 		} catch ( PayPalPaymentNotificationVerifierException $exception ) {

--- a/src/Infrastructure/Messenger.php
+++ b/src/Infrastructure/Messenger.php
@@ -30,14 +30,14 @@ class Messenger {
 	/**
 	 * @throws RuntimeException
 	 */
-	public function sendMessageToUser( Message $messageContent, EmailAddress $recipient ) {
+	public function sendMessageToUser( Message $messageContent, EmailAddress $recipient ): void {
 		$this->sendMessage( $this->createMessage( $messageContent, $recipient ) );
 	}
 
 	/**
 	 * @throws RuntimeException
 	 */
-	public function sendMessageToOperator( Message $messageContent, EmailAddress $replyTo = null ) {
+	public function sendMessageToOperator( Message $messageContent, EmailAddress $replyTo = null ): void {
 		$this->sendMessage( $this->createMessage( $messageContent, $this->operatorAddress, $replyTo ) );
 	}
 
@@ -54,7 +54,7 @@ class Messenger {
 		return $message;
 	}
 
-	private function sendMessage( Swift_Message $message ) {
+	private function sendMessage( Swift_Message $message ): void {
 		$deliveryCount = $this->mailTransport->send( $message );
 		if ( $deliveryCount === 0 ) {
 			throw new RuntimeException( 'Message delivery failed' );

--- a/src/Infrastructure/OperatorMailer.php
+++ b/src/Infrastructure/OperatorMailer.php
@@ -26,7 +26,7 @@ class OperatorMailer {
 	/**
 	 * @throws \RuntimeException
 	 */
-	public function sendMailToOperator( EmailAddress $replyToAddress, array $templateArguments = [] ) {
+	public function sendMailToOperator( EmailAddress $replyToAddress, array $templateArguments = [] ): void {
 		$this->messenger->sendMessageToOperator(
 			new Message(
 				$this->subject,

--- a/src/Infrastructure/PageViewTracker.php
+++ b/src/Infrastructure/PageViewTracker.php
@@ -20,7 +20,7 @@ class PageViewTracker {
 		$this->trackingUrlBase = $trackingUrlBase;
 	}
 
-	public function trackPaypalRedirection( string $campaign, string $keyword, string $visitorIP ) {
+	public function trackPaypalRedirection( string $campaign, string $keyword, string $visitorIP ): void {
 		$this->tracker->trackPageView(
 			$this->getPaypalRedirectionTrackingUrl( $campaign, $keyword ),
 			self::TRACKING_TITLE_PAYPAL_REDIRECT

--- a/src/Infrastructure/PayPalPaymentNotificationVerifier.php
+++ b/src/Infrastructure/PayPalPaymentNotificationVerifier.php
@@ -35,7 +35,7 @@ class PayPalPaymentNotificationVerifier implements PaymentNotificationVerifier {
 	 *
 	 * @throws PayPalPaymentNotificationVerifierException
 	 */
-	public function verify( array $request ) {
+	public function verify( array $request ): void {
 		if ( !$this->matchesReceiverAddress( $request ) ) {
 			throw new PayPalPaymentNotificationVerifierException(
 				'Payment receiver address does not match',

--- a/src/Infrastructure/PaymentNotificationVerifier.php
+++ b/src/Infrastructure/PaymentNotificationVerifier.php
@@ -18,6 +18,6 @@ interface PaymentNotificationVerifier {
 	 *
 	 * @throws PayPalPaymentNotificationVerifierException
 	 */
-	public function verify( array $request );
+	public function verify( array $request ): void;
 
 }

--- a/src/Infrastructure/PiwikEvents.php
+++ b/src/Infrastructure/PiwikEvents.php
@@ -37,11 +37,11 @@ class PiwikEvents {
 	 *
 	 * @throws \InvalidArgumentException
 	 */
-	public function triggerSetCustomVariable( int $variableId, string $value, string $scope ) {
+	public function triggerSetCustomVariable( int $variableId, string $value, string $scope ): void {
 		$this->events[] = [ self::EVENT_SET_CUSTOM_VARIABLE, $variableId, $this->getVariableName( $variableId ), $value, $scope ];
 	}
 
-	public function triggerTrackGoal( int $goalId ) {
+	public function triggerTrackGoal( int $goalId ): void {
 		$this->events[] = [ self::EVENT_TRACK_GOAL, $goalId ];
 	}
 

--- a/src/Infrastructure/PiwikServerSideTracker.php
+++ b/src/Infrastructure/PiwikServerSideTracker.php
@@ -16,12 +16,12 @@ class PiwikServerSideTracker implements ServerSideTracker {
 		$this->tracker = $tracker;
 	}
 
-	public function trackPageView( string $url, string $title ) {
+	public function trackPageView( string $url, string $title ): void {
 		$this->tracker->setUrl( $url );
 		$this->tracker->doTrackPageView( $title );
 	}
 
-	public function setIp( string $ip ) {
+	public function setIp( string $ip ): void {
 		$this->tracker->setIp( $ip );
 	}
 

--- a/src/Infrastructure/ProfilerDataCollector.php
+++ b/src/Infrastructure/ProfilerDataCollector.php
@@ -29,7 +29,7 @@ class ProfilerDataCollector extends DataCollector {
 		return 'fundraising';
 	}
 
-	public function getCalls() {
+	public function getCalls(): array {
 		return $this->data['calls'];
 	}
 

--- a/src/Infrastructure/ProfilerDataCollector.php
+++ b/src/Infrastructure/ProfilerDataCollector.php
@@ -22,7 +22,7 @@ class ProfilerDataCollector extends DataCollector {
 		$this->data['calls'] = [];
 	}
 
-	public function collect( Request $request, Response $response, \Exception $exception = null ) {
+	public function collect( Request $request, Response $response, \Exception $exception = null ): void {
 	}
 
 	public function getName(): string {
@@ -33,7 +33,7 @@ class ProfilerDataCollector extends DataCollector {
 		return $this->data['calls'];
 	}
 
-	public function addCall( string $serviceName, string $functionName, array $arguments ) {
+	public function addCall( string $serviceName, string $functionName, array $arguments ): void {
 		$this->data['calls'][] = [
 			'service' => $serviceName,
 			'function' => $functionName,

--- a/src/Infrastructure/ProfilingDecoratorBuilder.php
+++ b/src/Infrastructure/ProfilingDecoratorBuilder.php
@@ -50,7 +50,7 @@ class ProfilingDecoratorBuilder {
 		return debug_backtrace()[7]['function'];
 	}
 
-	private function getFunctionArgumentsWithKeys( array $arguments, string $className, string $methodName ) {
+	private function getFunctionArgumentsWithKeys( array $arguments, string $className, string $methodName ): array {
 		$reflection = new \ReflectionMethod( $className, $methodName );
 
 		foreach ( $reflection->getParameters() as $param ) {

--- a/src/Infrastructure/ProfilingDecoratorBuilder.php
+++ b/src/Infrastructure/ProfilingDecoratorBuilder.php
@@ -21,7 +21,7 @@ class ProfilingDecoratorBuilder {
 		$this->dataCollector = $dataCollector;
 	}
 
-	public function decorate( $objectToDecorate, string $profilingLabel ) {
+	public function decorate( $objectToDecorate, string $profilingLabel ) {	// @codingStandardsIgnoreLine
 		return ( new DecoratorBuilder( $objectToDecorate ) )
 			->withBefore( function () use ( $objectToDecorate, $profilingLabel ) {
 				$callingFunctionName = $this->getCallingFunctionName();
@@ -40,7 +40,7 @@ class ProfilingDecoratorBuilder {
 			->newDecorator();
 	}
 
-	private function getClassAndFunction( $objectToDecorate, string $callingFunction ): string {
+	private function getClassAndFunction( $objectToDecorate, string $callingFunction ): string {	// @codingStandardsIgnoreLine
 		$classNameParts = explode( '\\', get_class( $objectToDecorate ) );
 		return end( $classNameParts ) . '::' . $callingFunction;
 	}

--- a/src/Infrastructure/ServerSideTracker.php
+++ b/src/Infrastructure/ServerSideTracker.php
@@ -12,8 +12,8 @@ namespace WMDE\Fundraising\Frontend\Infrastructure;
  */
 interface ServerSideTracker {
 
-	public function trackPageView( string $url, string $title );
+	public function trackPageView( string $url, string $title ): void;
 
-	public function setIp( string $ip );
+	public function setIp( string $ip ): void;
 
 }

--- a/src/Presentation/DonationConfirmationPageSelector.php
+++ b/src/Presentation/DonationConfirmationPageSelector.php
@@ -43,7 +43,7 @@ class DonationConfirmationPageSelector {
 		);
 	}
 
-	private function parseCampaigns( $campaigns ): void {
+	private function parseCampaigns( array $campaigns ): void {
 		foreach ( $campaigns as $campaign ) {
 			$this->campaigns[] = new TemplateTestCampaign( $campaign );
 		}

--- a/src/Presentation/DonationConfirmationPageSelector.php
+++ b/src/Presentation/DonationConfirmationPageSelector.php
@@ -43,7 +43,7 @@ class DonationConfirmationPageSelector {
 		);
 	}
 
-	private function parseCampaigns( $campaigns ) {
+	private function parseCampaigns( $campaigns ): void {
 		foreach ( $campaigns as $campaign ) {
 			$this->campaigns[] = new TemplateTestCampaign( $campaign );
 		}

--- a/src/Presentation/FilePrefixer.php
+++ b/src/Presentation/FilePrefixer.php
@@ -16,7 +16,7 @@ class FilePrefixer {
 		$this->filePrefix = $filePrefix;
 	}
 
-	public function prefixFile( $filename ) {
+	public function prefixFile( string $filename ): string {
 		if ( !$this->filePrefix ) {
 			return $filename;
 		}

--- a/src/Presentation/Presenters/CreditCardPaymentHtmlPresenter.php
+++ b/src/Presentation/Presenters/CreditCardPaymentHtmlPresenter.php
@@ -34,7 +34,7 @@ class CreditCardPaymentHtmlPresenter {
 		return $this->template->render( $this->getArguments( $response ) );
 	}
 
-	private function getArguments( AddDonationResponse $response ) {
+	private function getArguments( AddDonationResponse $response ): array {
 		$personalInfo = $response->getDonation()->getDonor();
 		return [
 			'donation' => [

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -35,7 +35,7 @@ class DonationConfirmationHtmlPresenter {
 	}
 
 	private function getConfirmationPageArguments( Donation $donation, string $updateToken,
-												   SelectedConfirmationPage $selectedPage, PiwikEvents $piwikEvents ) {
+												   SelectedConfirmationPage $selectedPage, PiwikEvents $piwikEvents ): array {
 
 		return [
 			'main_template' => $selectedPage->getPageTitle(),
@@ -98,7 +98,7 @@ class DonationConfirmationHtmlPresenter {
 		return [];
 	}
 
-	private function getInitialMembershipFormValues( Donation $donation ) {
+	private function getInitialMembershipFormValues( Donation $donation ): array {
 		return array_merge(
 			$this->getMembershipFormPersonValues( $donation->getDonor() ),
 			$this->getMembershipFormBankDataValues( $donation->getPaymentMethod() )

--- a/src/Presentation/Presenters/DonationFormViolationPresenter.php
+++ b/src/Presentation/Presenters/DonationFormViolationPresenter.php
@@ -93,7 +93,7 @@ class DonationFormViolationPresenter {
 	 * @param ConstraintViolation[] $violations
 	 * @return array
 	 */
-	private function getViolatedFields( array $violations ) {
+	private function getViolatedFields( array $violations ): array {
 		$fieldNames = [];
 		foreach ( $violations as $violation ) {
 			$fieldNames[$violation->getSource()] = $violation->getMessageIdentifier();

--- a/src/Presentation/Presenters/DonationFormViolationPresenter.php
+++ b/src/Presentation/Presenters/DonationFormViolationPresenter.php
@@ -45,7 +45,7 @@ class DonationFormViolationPresenter {
 		);
 	}
 
-	private function getDonationFormArguments( AddDonationRequest $request ) {
+	private function getDonationFormArguments( AddDonationRequest $request ): array {
 		return array_merge(
 			[
 				'amount' => $this->amountFormatter->format( $request->getAmount() ),
@@ -57,7 +57,7 @@ class DonationFormViolationPresenter {
 		);
 	}
 
-	private function getPersonalInfo( AddDonationRequest $request ) {
+	private function getPersonalInfo( AddDonationRequest $request ): array {
 		if ( $request->donorIsAnonymous() ) {
 			return [];
 		}
@@ -69,7 +69,7 @@ class DonationFormViolationPresenter {
 		);
 	}
 
-	private function getPersonName( AddDonationRequest $request ) {
+	private function getPersonName( AddDonationRequest $request ): array {
 		return [
 			'addressType' => $request->getDonorType(),
 			'salutation' => $request->getDonorSalutation(),
@@ -80,7 +80,7 @@ class DonationFormViolationPresenter {
 		];
 	}
 
-	private function getPhysicalAddress( AddDonationRequest $request ) {
+	private function getPhysicalAddress( AddDonationRequest $request ): array {
 		return [
 			'street' => $request->getDonorStreetAddress(),
 			'postcode' => $request->getDonorPostalCode(),

--- a/src/Presentation/Presenters/IbanPresenter.php
+++ b/src/Presentation/Presenters/IbanPresenter.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\PaymentContext\ResponseModel\IbanResponse;
  */
 class IbanPresenter {
 
-	public function present( IbanResponse $iban ) {
+	public function present( IbanResponse $iban ): array {
 		if ( $iban->isSuccessful() ) {
 			return $this->newSuccessResponse( $iban->getBankData() );
 		}
@@ -21,7 +21,7 @@ class IbanPresenter {
 		return $this->newErrorResponse();
 	}
 
-	private function newSuccessResponse( BankData $bankData ) {
+	private function newSuccessResponse( BankData $bankData ): array {
 		return array_filter( [
 			'status' => 'OK',
 			'bic' => $bankData->getBic(),
@@ -32,7 +32,7 @@ class IbanPresenter {
 		] );
 	}
 
-	private function newErrorResponse() {
+	private function newErrorResponse(): array {
 		return [ 'status' => 'ERR' ];
 	}
 

--- a/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenter.php
@@ -82,7 +82,7 @@ class MembershipApplicationConfirmationHtmlPresenter {
 		return [];
 	}
 
-	private function getPayPalDataArguments( PaymentMethod $payment ) {
+	private function getPayPalDataArguments( PaymentMethod $payment ): array {
 		if ( $payment instanceof PayPalPayment ) {
 			return [
 				'firstPaymentDate' => ( new DateTime( $payment->getPayPalData()->getFirstPaymentDate() ) )->format( 'd.m.Y' )

--- a/src/Presentation/Presenters/MembershipFormViolationPresenter.php
+++ b/src/Presentation/Presenters/MembershipFormViolationPresenter.php
@@ -28,7 +28,7 @@ class MembershipFormViolationPresenter {
 		);
 	}
 
-	private function getMembershipFormArguments( ApplyForMembershipRequest $request ) {
+	private function getMembershipFormArguments( ApplyForMembershipRequest $request ): array {
 		return [
 			'addressType' => $request->isCompanyApplication() ? 'firma' : 'person',
 			'salutation' => $request->getApplicantSalutation(),

--- a/src/Presentation/TemplateTestCampaign.php
+++ b/src/Presentation/TemplateTestCampaign.php
@@ -60,7 +60,7 @@ class TemplateTestCampaign {
 		return $this->isActive() && $this->hasStarted() && !$this->hasEnded();
 	}
 
-	public function getRandomTemplate() {
+	public function getRandomTemplate(): string {
 		return $this->templates[array_rand( $this->templates )];
 	}
 

--- a/src/UseCases/GetInTouch/GetInTouchUseCase.php
+++ b/src/UseCases/GetInTouch/GetInTouchUseCase.php
@@ -57,7 +57,7 @@ class GetInTouchUseCase {
 		$this->userMailer->sendMail( new EmailAddress( $request->getEmailAddress() ) );
 	}
 
-	private function getTemplateParams( GetInTouchRequest $request ) {
+	private function getTemplateParams( GetInTouchRequest $request ): array {
 		return [
 			'firstName' => $request->getFirstName(),
 			'lastName' => $request->getLastName(),

--- a/src/UseCases/GetInTouch/GetInTouchUseCase.php
+++ b/src/UseCases/GetInTouch/GetInTouchUseCase.php
@@ -44,14 +44,14 @@ class GetInTouchUseCase {
 		return ValidationResponse::newSuccessResponse();
 	}
 
-	private function sendContactRequestToOperator( GetInTouchRequest $request ) {
+	private function sendContactRequestToOperator( GetInTouchRequest $request ): void {
 		$this->operatorMailer->sendMailToOperator(
 			new EmailAddress( $request->getEmailAddress() ),
 			$this->getTemplateParams( $request )
 		);
 	}
 
-	private function sendNotificationToUser( GetInTouchRequest $request ) {
+	private function sendNotificationToUser( GetInTouchRequest $request ): void {
 		// We don't send any template input here to avoid misusing the form for spam.
 		// The user just gets a "We received your inquiry and will contact you shortly" message
 		$this->userMailer->sendMail( new EmailAddress( $request->getEmailAddress() ) );

--- a/src/Validation/AllowedValuesValidator.php
+++ b/src/Validation/AllowedValuesValidator.php
@@ -23,7 +23,7 @@ class AllowedValuesValidator {
 		$this->allowedValues = $allowedValues;
 	}
 
-	public function validate( $value ): ValidationResult {
+	public function validate( $value ): ValidationResult {	// @codingStandardsIgnoreLine
 		if ( in_array( $value, $this->allowedValues, true ) ) {
 			return new ValidationResult();
 		}

--- a/src/Validation/CanValidateField.php
+++ b/src/Validation/CanValidateField.php
@@ -10,13 +10,7 @@ namespace WMDE\Fundraising\Frontend\Validation;
  */
 trait CanValidateField {
 
-	/**
-	 * @param ValidationResult $validationResult
-	 * @param string $fieldName
-	 *
-	 * @return ConstraintViolation|null
-	 */
-	private function getFieldViolation( ValidationResult $validationResult, string $fieldName ) {
+	private function getFieldViolation( ValidationResult $validationResult, string $fieldName ): ?ConstraintViolation {
 		if ( $validationResult->isSuccessful() ) {
 			return null;
 		}

--- a/src/Validation/ConstraintViolation.php
+++ b/src/Validation/ConstraintViolation.php
@@ -39,7 +39,7 @@ class ConstraintViolation {
 		return $this->source;
 	}
 
-	public function setSource( string $source ) {
+	public function setSource( string $source ): void {
 		$this->source = $source;
 	}
 

--- a/src/Validation/EmailValidator.php
+++ b/src/Validation/EmailValidator.php
@@ -21,7 +21,7 @@ class EmailValidator {
 		$this->domainValidator = $tldValidator;
 	}
 
-	public function validate( $emailAddress ): ValidationResult {
+	public function validate( $emailAddress ): ValidationResult {	// @codingStandardsIgnoreLine
 		$mailAddress = null;
 
 		try {

--- a/src/Validation/FieldTextPolicyValidator.php
+++ b/src/Validation/FieldTextPolicyValidator.php
@@ -18,7 +18,7 @@ class FieldTextPolicyValidator {
 		$this->textPolicyValidator = $textPolicyValidator;
 	}
 
-	public function validate( $value ): ValidationResult {
+	public function validate( $value ): ValidationResult {	// @codingStandardsIgnoreLine
 		if ( $value === '' ) {
 			return new ValidationResult();
 		}

--- a/src/Validation/MembershipFeeValidator.php
+++ b/src/Validation/MembershipFeeValidator.php
@@ -42,7 +42,7 @@ class MembershipFeeValidator {
 		return new Result( $this->violations );
 	}
 
-	private function validateAmount() {
+	private function validateAmount(): void {
 		try {
 			$amount = Euro::newFromString( $this->membershipFee );
 		}
@@ -54,11 +54,11 @@ class MembershipFeeValidator {
 		$this->validateAmountMeetsYearlyMinimum( $amount );
 	}
 
-	private function addViolation( string $source, string $type ) {
+	private function addViolation( string $source, string $type ): void {
 		$this->violations[$source] = $type;
 	}
 
-	private function validateAmountMeetsYearlyMinimum( Euro $amount ) {
+	private function validateAmountMeetsYearlyMinimum( Euro $amount ): void {
 		if ( $this->getYearlyPaymentAmount( $amount ) < $this->getYearlyPaymentRequirement() ) {
 			$this->addViolation( Result::SOURCE_PAYMENT_AMOUNT, Result::VIOLATION_TOO_LOW );
 		}

--- a/src/Validation/RequiredFieldValidator.php
+++ b/src/Validation/RequiredFieldValidator.php
@@ -10,7 +10,7 @@ namespace WMDE\Fundraising\Frontend\Validation;
  */
 class RequiredFieldValidator {
 
-	public function validate( $value ): ValidationResult {
+	public function validate( $value ): ValidationResult {	// @codingStandardsIgnoreLine
 		if ( $value === '' ) {
 			return new ValidationResult( new ConstraintViolation( $value, 'field_required' ) );
 		}

--- a/src/Validation/StringLengthValidator.php
+++ b/src/Validation/StringLengthValidator.php
@@ -10,7 +10,7 @@ namespace WMDE\Fundraising\Frontend\Validation;
  */
 class StringLengthValidator {
 
-	public function validate( $value, int $maxLength, int $minLength = 0 ): ValidationResult {
+	public function validate( $value, int $maxLength, int $minLength = 0 ): ValidationResult {	// @codingStandardsIgnoreLine
 		if ( strlen( $value ) < $minLength || strlen( $value ) > $maxLength ) {
 			return new ValidationResult( new ConstraintViolation( $value, 'incorrect_length' ) );
 		}

--- a/src/Validation/TemplateNameValidator.php
+++ b/src/Validation/TemplateNameValidator.php
@@ -17,11 +17,9 @@ class TemplateNameValidator {
 	}
 
 	/**
-	 * @param $value
-	 * @return ValidationResult+
 	 * @throws \Twig_Error_Syntax
 	 */
-	public function validate( $value ): ValidationResult {
+	public function validate( $value ): ValidationResult {	// @codingStandardsIgnoreLine
 		try {
 			$this->twig->loadTemplate( $value );
 		}

--- a/src/Validation/TextPolicyValidator.php
+++ b/src/Validation/TextPolicyValidator.php
@@ -43,11 +43,6 @@ class TextPolicyValidator {
 		return $this->whiteWords->toArray();
 	}
 
-	/**
-	 * @param string $text
-	 *
-	 * @return bool
-	 */
 	public function textIsHarmless( string $text ): bool {
 		return $this->hasHarmlessContent(
 			$text,
@@ -80,14 +75,14 @@ class TextPolicyValidator {
 	/**
 	 * @param string[] $newBadWordsArray
 	 */
-	public function addBadWordsFromArray( array $newBadWordsArray ) {
+	public function addBadWordsFromArray( array $newBadWordsArray ): void {
 		$this->badWords = new ArrayBasedStringList( array_merge( $this->getBadWords(), $newBadWordsArray ) );
 	}
 
 	/**
 	 * @param string[] $newWhiteWordsArray
 	 */
-	public function addWhiteWordsFromArray( array $newWhiteWordsArray ) {
+	public function addWhiteWordsFromArray( array $newWhiteWordsArray ): void {
 		$this->whiteWords = new ArrayBasedStringList( array_merge( $this->getWhiteWords(), $newWhiteWordsArray ) );
 	}
 

--- a/src/Validation/ValidationResponse.php
+++ b/src/Validation/ValidationResponse.php
@@ -17,7 +17,7 @@ class ValidationResponse {
 	 * @param ConstraintViolation[] $requestValidationErrors
 	 * @param bool $needsModeration
 	 */
-	public function __construct( array $requestValidationErrors = [], $needsModeration = false ) {
+	public function __construct( array $requestValidationErrors = [], bool $needsModeration = false ) {
 		$this->validationErrors = $requestValidationErrors;
 		$this->needsModerationValue = $needsModeration;
 	}

--- a/tests/EdgeToEdge/PiwikTest.php
+++ b/tests/EdgeToEdge/PiwikTest.php
@@ -12,13 +12,13 @@ class PiwikTest extends WebRouteTestCase {
 
 	const PIWIK_SITE_ID = 1;
 
-	public function testPiwikScriptGetsEmbedded() {
+	public function testPiwikScriptGetsEmbedded(): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
 		$client->request( 'GET', '/' );
 		$this->assertContains( '<!-- Piwik -->', $client->getResponse()->getContent() );
 	}
 
-	public function testConfigParametersAreUsed() {
+	public function testConfigParametersAreUsed(): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
 		$client->request( 'GET', '/' );
 

--- a/tests/EdgeToEdge/RouteNotFoundTest.php
+++ b/tests/EdgeToEdge/RouteNotFoundTest.php
@@ -10,14 +10,14 @@ namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge;
  */
 class RouteNotFoundTest extends WebRouteTestCase {
 
-	public function testGivenUnknownRoute_404isReturned() {
+	public function testGivenUnknownRoute_404isReturned(): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
 		$client->request( 'GET', '/kittens' );
 
 		$this->assert404( $client->getResponse() );
 	}
 
-	public function testGivenUnknownRoute_responseIsHTML() {
+	public function testGivenUnknownRoute_responseIsHTML(): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
 		$client->request( 'GET', '/kittens' );
 
@@ -25,7 +25,7 @@ class RouteNotFoundTest extends WebRouteTestCase {
 		$this->assertContains( '<html', $client->getResponse()->getContent() );
 	}
 
-	public function testGivenUnknownRouteAndJSONRquest_responseIsJSON() {
+	public function testGivenUnknownRouteAndJSONRquest_responseIsJSON(): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
 		$client->request( 'GET', '/kittens', [], [], ['HTTP_Accept' => 'application/json'] );
 

--- a/tests/EdgeToEdge/Routes/AddCommentRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddCommentRouteTest.php
@@ -20,14 +20,14 @@ class AddCommentRouteTest extends WebRouteTestCase {
 	const CORRECT_UPDATE_TOKEN = 'b5b249c8beefb986faf8d186a3f16e86ef509ab2';
 	const NON_EXISTING_DONATION_ID = 25502;
 
-	public function testGivenGetRequest_resultHasMethodNotAllowedStatus() {
+	public function testGivenGetRequest_resultHasMethodNotAllowedStatus(): void {
 		$this->assertGetRequestCausesMethodNotAllowedResponse(
 			'add-comment',
 			[]
 		);
 	}
 
-	public function testGivenRequestWithoutParameters_resultIsError() {
+	public function testGivenRequestWithoutParameters_resultIsError(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -42,7 +42,7 @@ class AddCommentRouteTest extends WebRouteTestCase {
 		$this->assertErrorJsonResponse( $response );
 	}
 
-	public function testGivenRequestWithoutTokens_resultIsError() {
+	public function testGivenRequestWithoutTokens_resultIsError(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$donation = $this->getNewlyStoredDonation( $factory );
 
@@ -74,7 +74,7 @@ class AddCommentRouteTest extends WebRouteTestCase {
 		return $donation;
 	}
 
-	public function testGivenRequestWithValidParameters_resultIsSuccess() {
+	public function testGivenRequestWithValidParameters_resultIsSuccess(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$donation = $this->getNewlyStoredDonation( $factory );
 
@@ -95,7 +95,7 @@ class AddCommentRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenRequestWithUnknownDonationId_resultIsError() {
+	public function testGivenRequestWithUnknownDonationId_resultIsError(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$this->getNewlyStoredDonation( $factory );
 
@@ -116,7 +116,7 @@ class AddCommentRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenRequestWithInvalidUpdateToken_resultIsError() {
+	public function testGivenRequestWithInvalidUpdateToken_resultIsError(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$donation = $this->getNewlyStoredDonation( $factory );
 

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -88,11 +88,11 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertNotContains( 'donation_rejected_limit', $client->getResponse()->getContent() );
 	}
 
-	private function getPastTimestamp( string $interval = 'PT10S' ) {
+	private function getPastTimestamp( string $interval = 'PT10S' ): string {
 		return ( new \DateTime() )->sub( new \DateInterval( $interval ) )->format( 'Y-m-d H:i:s' );
 	}
 
-	private function newValidFormInput() {
+	private function newValidFormInput(): array {
 		return [
 			'betrag' => '5,51',
 			'zahlweise' => 'BEZ',
@@ -233,7 +233,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newValidBankTransferInput() {
+	private function newValidBankTransferInput(): array {
 		return [
 			'betrag' => '12,34',
 			'zahlweise' => 'UEB',
@@ -283,7 +283,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newComplementableFormInput() {
+	private function newComplementableFormInput(): array {
 		return [
 			'betrag' => '5,51',
 			'zahlweise' => 'BEZ',
@@ -324,7 +324,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'sandbox.paypal.com', $response->getContent() );
 	}
 
-	private function newValidPayPalInput() {
+	private function newValidPayPalInput(): array {
 		return [
 			'betrag' => '12,34',
 			'zahlweise' => 'PPL',
@@ -370,7 +370,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertTrue( $client->getResponse()->isRedirect( 'https://bankingpin.please' ) );
 	}
 
-	private function newValidCreditCardInput() {
+	private function newValidCreditCardInput(): array {
 		return [
 			'betrag' => '12,34',
 			'zahlweise' => 'MCP',
@@ -451,7 +451,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'Amount: 0,00', $response );
 	}
 
-	private function newInvalidFormInput() {
+	private function newInvalidFormInput(): array {
 		return [
 			'betrag' => '0',
 			'zahlweise' => 'BEZ',
@@ -499,7 +499,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'Value of field "amount" violates rule: Amount too low', $response );
 	}
 
-	private function newAnonymousFormInput() {
+	private function newAnonymousFormInput(): array {
 		return [
 			'betrag' => '0',
 			'zahlweise' => 'UEB',
@@ -677,7 +677,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newValidMobilePayPalInput() {
+	private function newValidMobilePayPalInput(): array {
 		return [
 			'betrag' => '12,34',
 			'zahlweise' => 'PPL',

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -26,7 +26,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 
 	const SOME_TOKEN = 'SomeToken';
 
-	public function testGivenValidRequest_donationGetsPersisted() {
+	public function testGivenValidRequest_donationGetsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 
 			$client->setServerParameter( 'HTTP_REFERER', 'https://en.wikipedia.org/wiki/Karla_Kennichnich' );
@@ -42,7 +42,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenDonationGetsPersisted_timestampIsStoredInCookie() {
+	public function testWhenDonationGetsPersisted_timestampIsStoredInCookie(): void {
 		$client = $this->createClient();
 		$client->followRedirects( true );
 		$client->request(
@@ -57,7 +57,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertEquals( time(), $donationTimestamp->getTimestamp(), 'Timestamp should be not more than 5 seconds old', 5.0 );
 	}
 
-	public function testWhenMultipleDonationFormSubmissions_requestGetsRejected() {
+	public function testWhenMultipleDonationFormSubmissions_requestGetsRejected(): void {
 		$client = $this->createClient();
 		$client->getCookieJar()->set( new Cookie( 'donation_timestamp', $this->getPastTimestamp() ) );
 
@@ -70,7 +70,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'donation_rejected_limit', $client->getResponse()->getContent() );
 	}
 
-	public function testWhenMultipleDonationsInAccordanceToTimeLimit_requestIsNotRejected() {
+	public function testWhenMultipleDonationsInAccordanceToTimeLimit_requestIsNotRejected(): void {
 		$client = $this->createClient();
 		$client->getCookieJar()->set(
 			new Cookie(
@@ -124,7 +124,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function assertIsExpectedDonation( Donation $donation ) {
+	private function assertIsExpectedDonation( Donation $donation ): void {
 		$data = $donation->getDecodedData();
 		$this->assertSame( '5.51', $donation->getAmount() );
 		$this->assertSame( 'BEZ', $donation->getPaymentType() );
@@ -159,7 +159,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertTrue( $donation->getDonorOptsIntoNewsletter() );
 	}
 
-	public function testGivenValidRequest_confirmationPageContainsEnteredData() {
+	public function testGivenValidRequest_confirmationPageContainsEnteredData(): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -182,7 +182,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'send-info', $response );
 	}
 
-	public function testGivenValidBankTransferRequest_donationGetsPersisted() {
+	public function testGivenValidBankTransferRequest_donationGetsPersisted(): void {
 		/**
 		 * @var FunFunFactory
 		 */
@@ -260,7 +260,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenComplementableBankData_donationStillGetsPersisted() {
+	public function testGivenComplementableBankData_donationStillGetsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 
 			$client->setServerParameter( 'HTTP_REFERER', 'https://en.wikipedia.org/wiki/Karla_Kennichnich' );
@@ -309,7 +309,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		return $donation;
 	}
 
-	public function testGivenValidPayPalData_redirectsToPayPal() {
+	public function testGivenValidPayPalData_redirectsToPayPal(): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 
@@ -333,7 +333,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenValidCreditCardData_showsIframeEmbeddingPage() {
+	public function testGivenValidCreditCardData_showsIframeEmbeddingPage(): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -388,7 +388,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenInvalidRequest_formIsReloadedAndPrefilled() {
+	public function testGivenInvalidRequest_formIsReloadedAndPrefilled(): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -417,7 +417,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'Email address: karla@kennichnich.de', $response );
 	}
 
-	public function testGivenInvalidRequest_formStillContainsBannerTrackingData() {
+	public function testGivenInvalidRequest_formStillContainsBannerTrackingData(): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -434,7 +434,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'Banner Impression Count: 3', $response );
 	}
 
-	public function testGivenNegativeDonationAmount_formIsReloadedAndPrefilledWithZero() {
+	public function testGivenNegativeDonationAmount_formIsReloadedAndPrefilledWithZero(): void {
 		$client = $this->createClient();
 
 		$formValues = $this->newInvalidFormInput();
@@ -483,7 +483,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenInvalidAnonymousRequest_formIsReloadedAndPrefilled() {
+	public function testGivenInvalidAnonymousRequest_formIsReloadedAndPrefilled(): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -508,7 +508,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenValidRequest_tokensAreReturned() {
+	public function testGivenValidRequest_tokensAreReturned(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator( self::SOME_TOKEN ) );
 
@@ -527,7 +527,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenValidRequest_clientIsRedirected() {
+	public function testGivenValidRequest_clientIsRedirected(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator( self::SOME_TOKEN ) );
 			$client->followRedirects( false );
@@ -542,7 +542,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenTrackingCookieExists_valueIsPersisted() {
+	public function testWhenTrackingCookieExists_valueIsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$client->getCookieJar()->set( new Cookie( 'spenden_tracking', 'test/blue' ) );
 
@@ -559,7 +559,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenTrackableInputDataIsSubmitted_theyAreStoredInSession() {
+	public function testWhenTrackableInputDataIsSubmitted_theyAreStoredInSession(): void {
 		$this->createAppEnvironment( [], function ( Client $client, FunFunFactory $factory, Application $app ) {
 
 			$client->request(
@@ -579,7 +579,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenTolstojNovelIsPassed_isIsNotStoredInSession() {
+	public function testWhenTolstojNovelIsPassed_isIsNotStoredInSession(): void {
 		$this->createAppEnvironment( [], function ( Client $client, FunFunFactory $factory, Application $app ) {
 
 			$client->request(
@@ -605,7 +605,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenParameterIsOmitted_itIsNotStoredInSession() {
+	public function testWhenParameterIsOmitted_itIsNotStoredInSession(): void {
 		$this->createAppEnvironment( [], function ( Client $client, FunFunFactory $factory, Application $app ) {
 
 			$client->request(
@@ -624,7 +624,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenInitiallyIntendedPaymentOptionsDifferFromActual_itIsReflectedInPiwikTrackingEvents() {
+	public function testWhenInitiallyIntendedPaymentOptionsDifferFromActual_itIsReflectedInPiwikTrackingEvents(): void {
 		$client = $this->createClient( [] );
 		$client->request(
 			'GET',
@@ -654,7 +654,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		$this->assertContains( '12/0', $responseContent );
 	}
 
-	public function testWhenMobileTrackingIsRequested_piwikTrackerIsCalledForPaypalPayment() {
+	public function testWhenMobileTrackingIsRequested_piwikTrackerIsCalledForPaypalPayment(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setNullMessenger();
 			$client->followRedirects( false );
@@ -689,7 +689,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testWhenMobileTrackingIsRequested_piwikTrackerIsNotCalledForNonPaypalPayment() {
+	public function testWhenMobileTrackingIsRequested_piwikTrackerIsNotCalledForNonPaypalPayment(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setNullMessenger();
 			$client->followRedirects( false );
@@ -712,7 +712,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenCommasInStreetInput_donationGetsPersisted() {
+	public function testGivenCommasInStreetInput_donationGetsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 
 			$client->setServerParameter( 'HTTP_REFERER', 'https://en.wikipedia.org/wiki/Karla_Kennichnich' );
@@ -731,7 +731,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenSufficientForeignBankData_donationGetsPersisted() {
+	public function testGivenSufficientForeignBankData_donationGetsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$formInput = $this->newValidFormInput();
 			$formInput['iban'] = 'AT022050302101023600';

--- a/tests/EdgeToEdge/Routes/AddSubscriptionRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddSubscriptionRouteTest.php
@@ -40,7 +40,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		'wikilogin' => true
 	];
 
-	public function testValidSubscriptionRequestGetsPersisted() {
+	public function testValidSubscriptionRequestGetsPersisted(): void {
 
 		$subscriptionRepository = new SubscriptionRepositorySpy();
 
@@ -74,7 +74,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 
 	}
 
-	public function testGivenValidDataAndNoContentType_routeReturnsRedirectToSucccessPage() {
+	public function testGivenValidDataAndNoContentType_routeReturnsRedirectToSucccessPage(): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request(
@@ -87,7 +87,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		$this->assertSame( '/page/Subscription_Success', $response->headers->get( 'Location' ) );
 	}
 
-	public function testGivenInvalidDataAndNoContentType_routeDisplaysFormPage() {
+	public function testGivenInvalidDataAndNoContentType_routeDisplaysFormPage(): void {
 		$client = $this->createClient();
 
 		$crawler = $client->request(
@@ -109,7 +109,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenInvalidDataAndJSONContentType_routeReturnsSuccessResult() {
+	public function testGivenInvalidDataAndJSONContentType_routeReturnsSuccessResult(): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request(
@@ -123,7 +123,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		$this->assertJsonSuccessResponse( ['status' => 'OK'], $response );
 	}
 
-	public function testGivenInvalidDataAndJSONContentType_routeReturnsErrorResult() {
+	public function testGivenInvalidDataAndJSONContentType_routeReturnsErrorResult(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -143,7 +143,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		$this->assertSame( 'email_address_wrong_format', $responseData['errors']['email'] );
 	}
 
-	public function testGivenValidDataAndJSONPRequest_routeReturnsResult() {
+	public function testGivenValidDataAndJSONPRequest_routeReturnsResult(): void {
 		$client = $this->createClient();
 		$client->request(
 			'GET',
@@ -164,7 +164,7 @@ class AddSubscriptionRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenDataNeedingModerationAndNoContentType_routeReturnsRedirectToModerationPage() {
+	public function testGivenDataNeedingModerationAndNoContentType_routeReturnsRedirectToModerationPage(): void {
 		$config = ['text-policies' => ['fields' => ['badwords' => 'tests/templates/Banned_Cats.txt']]];
 		$client = $this->createClient( $config );
 		$client->followRedirects( false );

--- a/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
@@ -236,7 +236,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		$this->assertNotContains( 'membership_application_rejected_limit', $client->getResponse()->getContent() );
 	}
 
-	private function getPastTimestamp( string $interval = 'PT10S' ) {
+	private function getPastTimestamp( string $interval = 'PT10S' ): string {
 		return ( new \DateTime() )->sub( new \DateInterval( $interval ) )->format( 'Y-m-d H:i:s' );
 	}
 

--- a/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
@@ -27,7 +27,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 	const FIXED_TIMESTAMP = '2020-12-01 20:12:01';
 	const FIRST_PAYMENT_DATE = '2017-09-21';
 
-	public function testGivenGetRequestMembership_formIsShown() {
+	public function testGivenGetRequestMembership_formIsShown(): void {
 		$client = $this->createClient();
 
 		$crawler = $client->request( 'GET', 'apply-for-membership' );
@@ -42,7 +42,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenGetRequestSustainingMembership_formIsShown() {
+	public function testGivenGetRequestSustainingMembership_formIsShown(): void {
 		$client = $this->createClient();
 
 		$crawler = $client->request( 'GET', 'apply-for-membership', ['type' => 'sustaining'] );
@@ -92,7 +92,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenRequestWithInsufficientAmount_failureResponseIsReturned() {
+	public function testGivenRequestWithInsufficientAmount_failureResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$httpParameters = $this->newValidHttpParameters();
@@ -124,7 +124,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testFlagForShowingMembershipTypeOptionGetsPassedAround() {
+	public function testFlagForShowingMembershipTypeOptionGetsPassedAround(): void {
 		$client = $this->createClient();
 
 		$httpParameters = $this->newValidHttpParameters();
@@ -143,7 +143,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenValidRequest_applicationIsPersisted() {
+	public function testGivenValidRequest_applicationIsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPaymentDelayCalculator( new FixedPaymentDelayCalculator( new \DateTime( self::FIRST_PAYMENT_DATE ) ) );
 
@@ -164,7 +164,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenValidRequest_confirmationPageContainsCancellationParameters() {
+	public function testGivenValidRequest_confirmationPageContainsCancellationParameters(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator( self::FIXED_TOKEN ) );
 
@@ -181,7 +181,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenValidRequest_requestIsRedirected() {
+	public function testGivenValidRequest_requestIsRedirected(): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 
@@ -196,7 +196,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'show-membership-confirmation', $response->headers->get( 'Location' ) );
 	}
 
-	public function testWhenApplicationGetsPersisted_timestampIsStoredInCookie() {
+	public function testWhenApplicationGetsPersisted_timestampIsStoredInCookie(): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -210,7 +210,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		$this->assertEquals( time(), $donationTimestamp->getTimestamp(), 'Timestamp should be not more than 5 seconds old', 5.0 );
 	}
 
-	public function testWhenMultipleMembershipFormSubmissions_requestGetsRejected() {
+	public function testWhenMultipleMembershipFormSubmissions_requestGetsRejected(): void {
 		$client = $this->createClient();
 		$client->getCookieJar()->set( new Cookie( 'memapp_timestamp', $this->getPastTimestamp() ) );
 
@@ -223,7 +223,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'membership_application_rejected_limit', $client->getResponse()->getContent() );
 	}
 
-	public function testWhenMultipleMembershipInAccordanceToTimeLimit_isNotRejected() {
+	public function testWhenMultipleMembershipInAccordanceToTimeLimit_isNotRejected(): void {
 		$client = $this->createClient();
 		$client->getCookieJar()->set( new Cookie( 'memapp_timestamp', $this->getPastTimestamp( 'PT12M' ) ) );
 
@@ -240,7 +240,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		return ( new \DateTime() )->sub( new \DateInterval( $interval ) )->format( 'Y-m-d H:i:s' );
 	}
 
-	public function testWhenTrackingCookieExists_valueIsPersisted() {
+	public function testWhenTrackingCookieExists_valueIsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$client->getCookieJar()->set( new Cookie( 'spenden_tracking', 'test/blue' ) );
 
@@ -262,7 +262,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		return $application;
 	}
 
-	public function testGivenValidRequestUsingPayPal_applicationIsPersisted() {
+	public function testGivenValidRequestUsingPayPal_applicationIsPersisted(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPaymentDelayCalculator( new FixedPaymentDelayCalculator( new \DateTime( self::FIRST_PAYMENT_DATE ) ) );
 
@@ -316,7 +316,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenValidRequestUsingPayPal_requestIsRedirectedToPayPalUrl() {
+	public function testGivenValidRequestUsingPayPal_requestIsRedirectedToPayPalUrl(): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 
@@ -331,7 +331,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'sandbox.paypal.com', $response->headers->get( 'Location' ) );
 	}
 
-	public function testCommasInStreetNamesAreRemoved() {
+	public function testCommasInStreetNamesAreRemoved(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 
 			$params = $this->newValidHttpParameters();
@@ -354,7 +354,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenCompaniesApply_salutationIsSetToFixedValue() {
+	public function testWhenCompaniesApply_salutationIsSetToFixedValue(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 
 			$params = $this->newValidHttpParametersForCompanies();

--- a/tests/EdgeToEdge/Routes/CancelDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CancelDonationRouteTest.php
@@ -143,7 +143,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newThrowingMessenger() {
+	private function newThrowingMessenger(): Messenger {
 		$failingMessenger = $this->getMockBuilder( Messenger::class )->disableOriginalConstructor()->getMock();
 		$failingMessenger->method( 'sendMessageToUser' )->willThrowException( new \RuntimeException() );
 		return $failingMessenger;

--- a/tests/EdgeToEdge/Routes/CancelDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CancelDonationRouteTest.php
@@ -23,7 +23,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 
 	const CORRECT_UPDATE_TOKEN = 'b5b249c8beefb986faf8d186a3f16e86ef509ab2';
 
-	public function testGivenValidArguments_requestResultsIn200() {
+	public function testGivenValidArguments_requestResultsIn200(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -38,7 +38,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 		$this->assertSame( 200, $client->getResponse()->getStatusCode() );
 	}
 
-	public function testCancellationIsSuccessful_cookieIsCleared() {
+	public function testCancellationIsSuccessful_cookieIsCleared(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$client->getCookieJar()->set( new Cookie( 'donation_timestamp', '49152 B.C.' ) );
 
@@ -60,7 +60,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenValidUpdateToken_confirmationPageIsShown() {
+	public function testGivenValidUpdateToken_confirmationPageIsShown(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 
 			$donationId = $this->storeDonation( $factory->getDonationRepository(), $factory->getEntityManager() );
@@ -78,7 +78,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenGetRequest_resultHasMethodNotAllowedStatus() {
+	public function testGivenGetRequest_resultHasMethodNotAllowedStatus(): void {
 		$this->assertGetRequestCausesMethodNotAllowedResponse(
 			'/donation/cancel',
 			[
@@ -88,7 +88,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenInvalidUpdateToken_resultIsError() {
+	public function testGivenInvalidUpdateToken_resultIsError(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$donationId = $this->storeDonation( $factory->getDonationRepository(), $factory->getEntityManager() );
 
@@ -125,7 +125,7 @@ class CancelDonationRouteTest extends WebRouteTestCase {
 		return $donation->getId();
 	}
 
-	public function testWhenMailDeliveryFails_noticeIsDisplayed() {
+	public function testWhenMailDeliveryFails_noticeIsDisplayed(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$donationId = $this->storeDonation( $factory->getDonationRepository(), $factory->getEntityManager() );
 			$factory->setSuborganizationMessenger( $this->newThrowingMessenger() );

--- a/tests/EdgeToEdge/Routes/CancelMembershipApplicationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CancelMembershipApplicationRouteTest.php
@@ -19,7 +19,7 @@ class CancelMembershipApplicationRouteTest extends WebRouteTestCase {
 
 	const CORRECT_UPDATE_TOKEN = 'b5b249c8beefb986faf8d186a3f16e86ef509ab2';
 
-	public function testGivenValidUpdateToken_confirmationPageIsShown() {
+	public function testGivenValidUpdateToken_confirmationPageIsShown(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 
 			$applicationId = $this->storeApplication( $factory->getEntityManager() );
@@ -37,7 +37,7 @@ class CancelMembershipApplicationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenInvalidUpdateToken_resultIsError() {
+	public function testGivenInvalidUpdateToken_resultIsError(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$applicationId = $this->storeApplication( $factory->getEntityManager() );
 

--- a/tests/EdgeToEdge/Routes/CheckIbanRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CheckIbanRouteTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class CheckIbanRouteTest extends WebRouteTestCase {
 
-	public function testGivenInvalidBankAccountData_failureResponseIsReturned() {
+	public function testGivenInvalidBankAccountData_failureResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -33,7 +33,7 @@ class CheckIbanRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenBlockedBankAccountData_failureResponseIsReturned() {
+	public function testGivenBlockedBankAccountData_failureResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -50,7 +50,7 @@ class CheckIbanRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenValidBankAccountData_successResponseIsReturned() {
+	public function testGivenValidBankAccountData_successResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -74,7 +74,7 @@ class CheckIbanRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenValidBankAccountDataOfNonGermanBank_successResponseIsReturned() {
+	public function testGivenValidBankAccountDataOfNonGermanBank_successResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(

--- a/tests/EdgeToEdge/Routes/ConfirmSubscriptionRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ConfirmSubscriptionRouteTest.php
@@ -25,7 +25,7 @@ class ConfirmSubscriptionRouteTest extends WebRouteTestCase {
 		return $address;
 	}
 
-	public function testGivenAnUnconfirmedSubscriptionRequest_successPageIsDisplayed() {
+	public function testGivenAnUnconfirmedSubscriptionRequest_successPageIsDisplayed(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$subscription = new Subscription();
 			$subscription->setConfirmationCode( 'deadbeef' );
@@ -45,7 +45,7 @@ class ConfirmSubscriptionRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenANonHexadecimalConfirmationCode_confirmationPageIsNotFound() {
+	public function testGivenANonHexadecimalConfirmationCode_confirmationPageIsNotFound(): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
 
 		$client->request(
@@ -56,7 +56,7 @@ class ConfirmSubscriptionRouteTest extends WebRouteTestCase {
 		$this->assert404( $client->getResponse() );
 	}
 
-	public function testGivenNoSubscription_anErrorIsDisplayed() {
+	public function testGivenNoSubscription_anErrorIsDisplayed(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -69,7 +69,7 @@ class ConfirmSubscriptionRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'subscription_confirmation_code_not_found', $response->getContent() );
 	}
 
-	public function testGivenAConfirmedSubscriptionRequest_successPageIsDisplayed() {
+	public function testGivenAConfirmedSubscriptionRequest_successPageIsDisplayed(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$subscription = new Subscription();
 			$subscription->setConfirmationCode( 'deadbeef' );

--- a/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
@@ -75,7 +75,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newRequest() {
+	private function newRequest(): array {
 		return [
 			'function' => self::FUNCTION,
 			'donation_id' => (string)self::DONATION_ID,
@@ -92,7 +92,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function assertCreditCardDataGotPersisted( DonationRepository $donationRepo, $request ): void {
+	private function assertCreditCardDataGotPersisted( DonationRepository $donationRepo, array $request ): void {
 		$donation = $donationRepo->getDonationById( self::DONATION_ID );
 
 		/** @var \WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\CreditCardPayment $paymentMethod */

--- a/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/CreditCardPaymentNotificationRouteTest.php
@@ -33,7 +33,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 	const CURRENCY_CODE = 'EUR';
 	const STATUS = 'processed';
 
-	public function testGivenInvalidRequest_applicationIndicatesError() {
+	public function testGivenInvalidRequest_applicationIndicatesError(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setCreditCardService( new FakeCreditCardService() );
 			$client->request(
@@ -48,7 +48,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenValidRequest_applicationIndicatesSuccess() {
+	public function testGivenValidRequest_applicationIndicatesSuccess(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator(
 				self::UPDATE_TOKEN,
@@ -92,7 +92,7 @@ class CreditCardPaymentNotificationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function assertCreditCardDataGotPersisted( DonationRepository $donationRepo, $request ) {
+	private function assertCreditCardDataGotPersisted( DonationRepository $donationRepo, $request ): void {
 		$donation = $donationRepo->getDonationById( self::DONATION_ID );
 
 		/** @var \WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\CreditCardPayment $paymentMethod */

--- a/tests/EdgeToEdge/Routes/DefaultRouteTest.php
+++ b/tests/EdgeToEdge/Routes/DefaultRouteTest.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class DefaultRouteTest extends WebRouteTestCase {
 
-	public function testWhenFormParametersArePassedInRequest_theyArePassedToTheTemplate() {
+	public function testWhenFormParametersArePassedInRequest_theyArePassedToTheTemplate(): void {
 		$client = $this->createClient();
 		$client->request(
 			'GET',
@@ -30,7 +30,7 @@ class DefaultRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'Interval: 6', $responseContent );
 	}
 
-	public function testWhenFormParametersContainNegativeAmount_zeroAmountIsPassedToTheTemplate() {
+	public function testWhenFormParametersContainNegativeAmount_zeroAmountIsPassedToTheTemplate(): void {
 		$client = $this->createClient();
 		$client->request(
 			'GET',

--- a/tests/EdgeToEdge/Routes/DisplayPageRouteTest.php
+++ b/tests/EdgeToEdge/Routes/DisplayPageRouteTest.php
@@ -18,7 +18,7 @@ use WMDE\Fundraising\ContentProvider\ContentProvider;
  */
 class DisplayPageRouteTest extends WebRouteTestCase {
 
-	public function testWhenPageDoesNotExist_missingResponseIsReturnedAndHasHeaderAndFooter() {
+	public function testWhenPageDoesNotExist_missingResponseIsReturnedAndHasHeaderAndFooter(): void {
 		$client = $this->createClient(
 			[],
 			function ( FunFunFactory $factory ) {
@@ -50,7 +50,7 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testWhenPageDoesNotExist_noUnescapedPageNameIsShown() {
+	public function testWhenPageDoesNotExist_noUnescapedPageNameIsShown(): void {
 		$client = $this->createClient(
 			[],
 			function ( FunFunFactory $factory ) {
@@ -70,7 +70,7 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testWhenRequestedContentPageExists_itGetsEmbeddedAndHasHeaderAndFooter() {
+	public function testWhenRequestedContentPageExists_itGetsEmbeddedAndHasHeaderAndFooter(): void {
 		$this->createEnvironment(
 			[],
 			function ( Client $client, FunFunFactory $factory ) {
@@ -107,7 +107,7 @@ class DisplayPageRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testWhenPageNameContainsSlash_404isReturned() {
+	public function testWhenPageNameContainsSlash_404isReturned(): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
 		$client->request( 'GET', '/page/unicorns/of-doom' );
 

--- a/tests/EdgeToEdge/Routes/DonationAcceptedRouteTest.php
+++ b/tests/EdgeToEdge/Routes/DonationAcceptedRouteTest.php
@@ -20,7 +20,7 @@ class DonationAcceptedRouteTest extends WebRouteTestCase {
 	const WRONG_UPDATE_TOKEN = 'Wrong update token';
 	const CORRECT_UPDATE_TOKEN = 'Correct update token';
 
-	public function testGivenInvalidUpdateToken_errorIsReturned() {
+	public function testGivenInvalidUpdateToken_errorIsReturned(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 			$existingDonationId = $this->storeDonation( $factory );
 
@@ -49,7 +49,7 @@ class DonationAcceptedRouteTest extends WebRouteTestCase {
 		return $donation->getId();
 	}
 
-	public function testGivenKnownIdAndValidUpdateToken_successIsReturned() {
+	public function testGivenKnownIdAndValidUpdateToken_successIsReturned(): void {
 		$this->createEnvironment( [], function( Client $client, FunFunFactory $factory ) {
 
 			$existingDonationId = $this->storeDonation( $factory );

--- a/tests/EdgeToEdge/Routes/GenerateIbanRouteTest.php
+++ b/tests/EdgeToEdge/Routes/GenerateIbanRouteTest.php
@@ -19,7 +19,7 @@ class GenerateIbanRouteTest extends WebRouteTestCase {
 	const INVALID_ACCOUNT_NUMBER = '1015754241';
 	const VALID_ACCOUNT_NUMBER = '1015754243';
 
-	public function testGivenInvalidBankAccountData_failureResponseIsReturned() {
+	public function testGivenInvalidBankAccountData_failureResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -37,7 +37,7 @@ class GenerateIbanRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenValidBankAccountData_successResponseIsReturned() {
+	public function testGivenValidBankAccountData_successResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(

--- a/tests/EdgeToEdge/Routes/GetInTouchRouteTest.php
+++ b/tests/EdgeToEdge/Routes/GetInTouchRouteTest.php
@@ -15,7 +15,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\SucceedingEmailValidator;
  */
 class GetInTouchRouteTest extends WebRouteTestCase {
 
-	public function testGivenValidRequest_contactRequestIsProperlyProcessed() {
+	public function testGivenValidRequest_contactRequestIsProperlyProcessed(): void {
 		$client = $this->createClient( [], function ( FunFunFactory $factory ) {
 			$factory->setEmailValidator( new SucceedingEmailValidator() );
 		} );
@@ -38,7 +38,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 		$this->assertSame( '/page/Kontakt_Bestaetigung', $response->headers->get( 'Location' ) );
 	}
 
-	public function testGivenInvalidRequest_validationFails() {
+	public function testGivenInvalidRequest_validationFails(): void {
 
 		$client = $this->createClient();
 
@@ -70,7 +70,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenGetRequest_formShownWithoutErrors() {
+	public function testGivenGetRequest_formShownWithoutErrors(): void {
 
 		$client = $this->createClient();
 
@@ -86,7 +86,7 @@ class GetInTouchRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testOnException_errorPageIsRendered() {
+	public function testOnException_errorPageIsRendered(): void {
 		$client = $this->createClient(
 			[],
 			function ( FunFunFactory $factory ) {

--- a/tests/EdgeToEdge/Routes/HandlePayPalMembershipFeePaymentRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalMembershipFeePaymentRouteTest.php
@@ -30,7 +30,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 	const VERIFICATION_SUCCESSFUL = 'VERIFIED';
 	const VERIFICATION_FAILED = 'INVALID';
 
-	public function testGivenValidSubscriptionSignupRequest_applicationIndicatesSuccess() {
+	public function testGivenValidSubscriptionSignupRequest_applicationIndicatesSuccess(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator(
 				self::UPDATE_TOKEN,
@@ -108,7 +108,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		return $client;
 	}
 
-	public function testWhenPaymentProviderDoesNotVerify_errorCodeIsReturned() {
+	public function testWhenPaymentProviderDoesNotVerify_errorCodeIsReturned(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$request = $this->newSubscriptionSignupRequest();
 
@@ -125,7 +125,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenWrongTransactionType_applicationIgnoresRequest() {
+	public function testGivenWrongTransactionType_applicationIgnoresRequest(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$invalidRequest = $this->newInvalidTransactionRequest();
 
@@ -173,7 +173,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function assertPayPalDataGotPersisted( ApplicationRepository $applicationRepo, array $request ) {
+	private function assertPayPalDataGotPersisted( ApplicationRepository $applicationRepo, array $request ): void {
 		$membershipApplication = $applicationRepo->getApplicationById( self::MEMBERSHIP_APPLICATION_ID );
 
 		/** @var PayPalPayment $paymentMethod */
@@ -191,7 +191,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		$this->assertSame( $request['payment_type'], $pplData->getPaymentType() );
 	}
 
-	public function testGivenPaymentNotificationForInvalidMembershipId_applicationReturnsError() {
+	public function testGivenPaymentNotificationForInvalidMembershipId_applicationReturnsError(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$invalidRequest = $this->newInvalidMembershipIdRequest();
 

--- a/tests/EdgeToEdge/Routes/HandlePayPalMembershipFeePaymentRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalMembershipFeePaymentRouteTest.php
@@ -57,15 +57,15 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newSucceedingVerifier( array $request ) {
+	private function newSucceedingVerifier( array $request ): PayPalPaymentNotificationVerifier {
 		return $this->newVerifierMock( $request, self::VERIFICATION_SUCCESSFUL );
 	}
 
-	private function newFailingVerifier( array $request ) {
+	private function newFailingVerifier( array $request ): PayPalPaymentNotificationVerifier {
 		return $this->newVerifierMock( $request, self::VERIFICATION_FAILED );
 	}
 
-	private function newVerifierMock( array $request, string $expectedResponse ) {
+	private function newVerifierMock( array $request, string $expectedResponse ): PayPalPaymentNotificationVerifier {
 		return new PayPalPaymentNotificationVerifier(
 			$this->newGuzzleClientMock( $request, $expectedResponse ),
 			self::BASE_URL,
@@ -142,7 +142,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newSubscriptionSignupRequest() {
+	private function newSubscriptionSignupRequest(): array {
 		return [
 			'txn_type' => 'subscr_signup',
 
@@ -165,7 +165,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function newInvalidTransactionRequest() {
+	private function newInvalidTransactionRequest(): array {
 		return [
 			'txn_type' => 'invalid_transaction',
 			'receiver_email' => 'paypaldev-facilitator@wikimedia.de',
@@ -208,7 +208,7 @@ class HandlePayPalMembershipFeePaymentRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newInvalidMembershipIdRequest() {
+	private function newInvalidMembershipIdRequest(): array {
 		return [
 			'txn_type' => 'subscr_payment',
 

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -33,7 +33,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 	const VALID_VERIFICATION_RESPONSE = 'VERIFIED';
 	const FAILING_VERIFICATION_RESPONSE = 'FAIL';
 
-	public function testGivenValidRequest_applicationIndicatesSuccess() {
+	public function testGivenValidRequest_applicationIndicatesSuccess(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator(
 				self::UPDATE_TOKEN,
@@ -108,7 +108,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		return $client;
 	}
 
-	private function assertPayPalDataGotPersisted( DonationRepository $donationRepo, array $request ) {
+	private function assertPayPalDataGotPersisted( DonationRepository $donationRepo, array $request ): void {
 		$donation = $donationRepo->getDonationById( self::DONATION_ID );
 
 		/** @var PayPalPayment $paymentMethod */
@@ -160,7 +160,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenInvalidReceiverEmail_applicationReturnsError() {
+	public function testGivenInvalidReceiverEmail_applicationReturnsError(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPayPalPaymentNotificationVerifier(
 				$this->newNonNetworkUsingNotificationVerifier( $this->newHttpParamsForPayment() )
@@ -180,7 +180,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenUnsupportedPaymentStatus_applicationReturnsOK() {
+	public function testGivenUnsupportedPaymentStatus_applicationReturnsOK(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPayPalPaymentNotificationVerifier(
 				$this->newNonNetworkUsingNotificationVerifier( $this->newPendingPaymentParams() )
@@ -197,7 +197,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenUnsupportedPaymentStatus_requestDataIsLogged() {
+	public function testGivenUnsupportedPaymentStatus_requestDataIsLogged(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPayPalPaymentNotificationVerifier(
 				$this->newNonNetworkUsingNotificationVerifier( $this->newPendingPaymentParams() )
@@ -224,7 +224,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenFailingVerification_applicationReturnsError() {
+	public function testGivenFailingVerification_applicationReturnsError(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPayPalPaymentNotificationVerifier(
 				$this->newFailingNotifierMock()
@@ -241,7 +241,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenUnsupportedCurrency_applicationReturnsError() {
+	public function testGivenUnsupportedCurrency_applicationReturnsError(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPayPalPaymentNotificationVerifier(
 				$this->newNonNetworkUsingNotificationVerifier( $this->newHttpParamsForPayment() )
@@ -260,7 +260,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenTransactionTypeForSubscriptionChanges_requestDataIsLogged() {
+	public function testGivenTransactionTypeForSubscriptionChanges_requestDataIsLogged(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPayPalPaymentNotificationVerifier(
 				$this->newNonNetworkUsingNotificationVerifier( $this->newSubscriptionModificationParams() )
@@ -338,7 +338,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testGivenNegativeTransactionFee_exceptionIsThrown() {
+	public function testGivenNegativeTransactionFee_exceptionIsThrown(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setPayPalPaymentNotificationVerifier( $this->newSucceedingNotificationVerifier() );
 

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -57,7 +57,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newNonNetworkUsingNotificationVerifier( array $requestParams ) {
+	private function newNonNetworkUsingNotificationVerifier( array $requestParams ): PayPalPaymentNotificationVerifier {
 		return new PayPalPaymentNotificationVerifier(
 			$this->newGuzzleClientMock( self::VALID_VERIFICATION_RESPONSE, $requestParams ),
 			self::BASE_URL,
@@ -65,7 +65,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	private function newFailingNotifierMock() {
+	private function newFailingNotifierMock(): PayPalPaymentNotificationVerifier {
 		return new PayPalPaymentNotificationVerifier(
 			$this->newGuzzleClientMock( self::FAILING_VERIFICATION_RESPONSE, $this->newHttpParamsForPayment() ),
 			self::BASE_URL,

--- a/tests/EdgeToEdge/Routes/ListCommentsHtmlRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ListCommentsHtmlRouteTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 
-	public function testWhenThereAreNoComments_rssFeedIsEmpty() {
+	public function testWhenThereAreNoComments_rssFeedIsEmpty(): void {
 		$client = $this->createClient();
 		$crawler = $client->request( 'GET', '/list-comments.html' );
 
@@ -29,7 +29,7 @@ class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testWhenAreThreeComments_listSizeIsShownAsThree() {
+	public function testWhenAreThreeComments_listSizeIsShownAsThree(): void {
 		$client = $this->createClient( [], function ( FunFunFactory $factory ) {
 			$this->createThreeComments( $factory->getEntityManager() );
 		} );
@@ -49,7 +49,7 @@ class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 		$entityManager->flush();
 	}
 
-	private function persistFirstComment( EntityManager $entityManager ) {
+	private function persistFirstComment( EntityManager $entityManager ): void {
 		$firstDonation = new Donation();
 		$firstDonation->setPublicRecord( 'First name' );
 		$firstDonation->setComment( 'First comment' );
@@ -59,7 +59,7 @@ class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 		$entityManager->persist( $firstDonation );
 	}
 
-	private function persistSecondComment( EntityManager $entityManager ) {
+	private function persistSecondComment( EntityManager $entityManager ): void {
 		$secondDonation = new Donation();
 		$secondDonation->setPublicRecord( 'Second name' );
 		$secondDonation->setComment( 'Second comment' );
@@ -69,7 +69,7 @@ class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 		$entityManager->persist( $secondDonation );
 	}
 
-	private function persistEvilComment( EntityManager $entityManager ) {
+	private function persistEvilComment( EntityManager $entityManager ): void {
 		$secondDonation = new Donation();
 		$secondDonation->setPublicRecord( 'Third name & company' );
 		$secondDonation->setComment( 'Third <script> comment' );
@@ -79,7 +79,7 @@ class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 		$entityManager->persist( $secondDonation );
 	}
 
-	public function testWhenAreComments_theyAreInTheHtml() {
+	public function testWhenAreComments_theyAreInTheHtml(): void {
 		$client = $this->createClient( [], function ( FunFunFactory $factory ) {
 			$this->createThreeComments( $factory->getEntityManager() );
 		} );
@@ -115,7 +115,7 @@ class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testCommentsGetEscaped() {
+	public function testCommentsGetEscaped(): void {
 		$client = $this->createClient( [], function ( FunFunFactory $factory ) {
 			$this->createThreeComments( $factory->getEntityManager() );
 		} );
@@ -128,7 +128,7 @@ class ListCommentsHtmlRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenLimitAndPageTwo_limitNumberOfCommentsAreSkipped() {
+	public function testGivenLimitAndPageTwo_limitNumberOfCommentsAreSkipped(): void {
 		$client = $this->createClient( [], function ( FunFunFactory $factory ) {
 			$this->createThreeComments( $factory->getEntityManager() );
 		} );

--- a/tests/EdgeToEdge/Routes/ListCommentsJsonRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ListCommentsJsonRouteTest.php
@@ -49,7 +49,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	private function getFirstCommentAsArray() {
+	private function getFirstCommentAsArray(): array {
 		return [
 			'betrag' => 100,
 			'spender' => 'First name',
@@ -59,7 +59,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function getSecondCommentAsArray() {
+	private function getSecondCommentAsArray(): array {
 		return [
 			'betrag' => 200,
 			'spender' => 'Second name',
@@ -124,7 +124,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	private function assertJsonpSuccessResponse( $expectedJson, string $expectedCallback, Response $response ): void {
+	private function assertJsonpSuccessResponse( array $expectedJson, string $expectedCallback, Response $response ): void {
 		$this->assertSame(
 			'/**/' . $expectedCallback . '(' . json_encode( $expectedJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . ');',
 			$response->getContent()

--- a/tests/EdgeToEdge/Routes/ListCommentsJsonRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ListCommentsJsonRouteTest.php
@@ -17,11 +17,11 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class ListCommentsJsonRouteTest extends WebRouteTestCase {
 
-	public function setUp() {
+	public function setUp(): void {
 		date_default_timezone_set( 'Europe/Berlin' );
 	}
 
-	public function testWhenThereAreNoComments_emptyArrayIsShown() {
+	public function testWhenThereAreNoComments_emptyArrayIsShown(): void {
 		$client = $this->createClient();
 		$client->request( 'GET', '/list-comments.json?n=10' );
 
@@ -31,7 +31,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testRouteShowsComments() {
+	public function testRouteShowsComments(): void {
 		$client = $this->createClient( [], function( FunFunFactory $factory ) {
 			$this->persistFirstComment( $factory->getEntityManager() );
 			$this->persistSecondComment( $factory->getEntityManager() );
@@ -69,7 +69,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function persistFirstComment( EntityManager $entityManager ) {
+	private function persistFirstComment( EntityManager $entityManager ): void {
 		$firstDonation = new Donation();
 		$firstDonation->setPublicRecord( 'First name' );
 		$firstDonation->setComment( 'First comment' );
@@ -79,7 +79,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		$entityManager->persist( $firstDonation );
 	}
 
-	private function persistSecondComment( EntityManager $entityManager ) {
+	private function persistSecondComment( EntityManager $entityManager ): void {
 		$secondDonation = new Donation();
 		$secondDonation->setPublicRecord( 'Second name' );
 		$secondDonation->setComment( 'Second comment' );
@@ -89,7 +89,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		$entityManager->persist( $secondDonation );
 	}
 
-	public function testGivenLimitSmallerThanCommentCount_onlySoManyCommentsAreShown() {
+	public function testGivenLimitSmallerThanCommentCount_onlySoManyCommentsAreShown(): void {
 		$client = $this->createClient( [], function( FunFunFactory $factory ) {
 			$this->persistFirstComment( $factory->getEntityManager() );
 			$this->persistSecondComment( $factory->getEntityManager() );
@@ -106,7 +106,7 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenJsonpCallback_jsonIsWrappedInCallback() {
+	public function testGivenJsonpCallback_jsonIsWrappedInCallback(): void {
 		$client = $this->createClient( [], function( FunFunFactory $factory ) {
 			$this->persistFirstComment( $factory->getEntityManager() );
 			$this->persistSecondComment( $factory->getEntityManager() );
@@ -124,14 +124,14 @@ class ListCommentsJsonRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	private function assertJsonpSuccessResponse( $expectedJson, string $expectedCallback, Response $response ) {
+	private function assertJsonpSuccessResponse( $expectedJson, string $expectedCallback, Response $response ): void {
 		$this->assertSame(
 			'/**/' . $expectedCallback . '(' . json_encode( $expectedJson, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . ');',
 			$response->getContent()
 		);
 	}
 
-	public function testGivenLimitAndPageTwo_limitNumberOfCommentsAreSkipped() {
+	public function testGivenLimitAndPageTwo_limitNumberOfCommentsAreSkipped(): void {
 		$client = $this->createClient( [], function( FunFunFactory $factory ) {
 			$this->persistFirstComment( $factory->getEntityManager() );
 			$this->persistSecondComment( $factory->getEntityManager() );

--- a/tests/EdgeToEdge/Routes/ListCommentsRssRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ListCommentsRssRouteTest.php
@@ -17,7 +17,7 @@ use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
  */
 class ListCommentsRssRouteTest extends WebRouteTestCase {
 
-	public function testWhenThereAreNoComments_rssFeedIsEmpty() {
+	public function testWhenThereAreNoComments_rssFeedIsEmpty(): void {
 		$client = $this->createClient();
 		$client->request( 'GET', '/list-comments.rss' );
 
@@ -29,7 +29,7 @@ class ListCommentsRssRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testWhenAreComments_theyAreInTheRss() {
+	public function testWhenAreComments_theyAreInTheRss(): void {
 		$client = $this->createClient( [], function( FunFunFactory $factory ) {
 			$this->persistFirstComment( $factory->getEntityManager() );
 			$this->persistSecondComment( $factory->getEntityManager() );
@@ -72,7 +72,7 @@ class ListCommentsRssRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	private function persistFirstComment( EntityManager $entityManager ) {
+	private function persistFirstComment( EntityManager $entityManager ): void {
 		$firstDonation = new Donation();
 		$firstDonation->setPublicRecord( 'First name' );
 		$firstDonation->setComment( 'First comment' );
@@ -82,7 +82,7 @@ class ListCommentsRssRouteTest extends WebRouteTestCase {
 		$entityManager->persist( $firstDonation );
 	}
 
-	private function persistSecondComment( EntityManager $entityManager ) {
+	private function persistSecondComment( EntityManager $entityManager ): void {
 		$secondDonation = new Donation();
 		$secondDonation->setPublicRecord( 'Second name' );
 		$secondDonation->setComment( 'Second comment' );
@@ -92,7 +92,7 @@ class ListCommentsRssRouteTest extends WebRouteTestCase {
 		$entityManager->persist( $secondDonation );
 	}
 
-	private function persistEvilComment( EntityManager $entityManager ) {
+	private function persistEvilComment( EntityManager $entityManager ): void {
 		$secondDonation = new Donation();
 		$secondDonation->setPublicRecord( 'Third name & company' );
 		$secondDonation->setComment( 'Third <script> comment' );

--- a/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
 class NewDonationRouteTest extends WebRouteTestCase {
 
 	/** @dataProvider paymentInputProvider */
-	public function testGivenPaymentInput_paymentDataIsInitiallyValidated( $validPaymentInput, $expectedValidity ): void {
+	public function testGivenPaymentInput_paymentDataIsInitiallyValidated( array $validPaymentInput, string $expectedValidity ): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -27,7 +27,7 @@ class NewDonationRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function paymentInputProvider() {
+	public function paymentInputProvider(): array {
 		return [
 			[
 				[

--- a/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/NewDonationRouteTest.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
 class NewDonationRouteTest extends WebRouteTestCase {
 
 	/** @dataProvider paymentInputProvider */
-	public function testGivenPaymentInput_paymentDataIsInitiallyValidated( $validPaymentInput, $expectedValidity ) {
+	public function testGivenPaymentInput_paymentDataIsInitiallyValidated( $validPaymentInput, $expectedValidity ): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',
@@ -64,7 +64,7 @@ class NewDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testWhenPassingTrackingData_itGetsPassedToThePresenter() {
+	public function testWhenPassingTrackingData_itGetsPassedToThePresenter(): void {
 		$client = $this->createClient();
 		$client->request(
 			'POST',

--- a/tests/EdgeToEdge/Routes/PurgeCacheRouteTest.php
+++ b/tests/EdgeToEdge/Routes/PurgeCacheRouteTest.php
@@ -14,7 +14,7 @@ class PurgeCacheRouteTest extends WebRouteTestCase {
 
 	const INVALID_SECRET = 'pedo mellon a minno';
 
-	public function testGivenInvalidSecret_responseIsReturned() {
+	public function testGivenInvalidSecret_responseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(

--- a/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
+++ b/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
@@ -21,7 +21,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 	}
 
 	/** @dataProvider simplePageDisplayProvider */
-	public function testPageDisplayRequestsAreRedirected( $requestedUrl, $expectedRedirection ) {
+	public function testPageDisplayRequestsAreRedirected( $requestedUrl, $expectedRedirection ): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request( 'GET', $requestedUrl );
@@ -44,7 +44,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 	}
 
 	/** @dataProvider shouldRedirectToDefaultRouteProvider */
-	public function testRequestsAreRedirectedToDefaultRoute( $requestedUrl, $expectedRedirection ) {
+	public function testRequestsAreRedirectedToDefaultRoute( $requestedUrl, $expectedRedirection ): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request( 'GET', $requestedUrl );
@@ -63,7 +63,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 	}
 
 	/** @dataProvider commentListUrlProvider */
-	public function testCallsToCommentListIsRedirected( $requestedUrl, $expectedRedirection ) {
+	public function testCallsToCommentListIsRedirected( $requestedUrl, $expectedRedirection ): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request( 'GET', $requestedUrl );

--- a/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
+++ b/tests/EdgeToEdge/Routes/RouteRedirectionTest.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class RouteRedirectionTest extends WebRouteTestCase {
 
-	public function simplePageDisplayProvider() {
+	public function simplePageDisplayProvider(): array {
 		return [
 			[ '/spenden/Mitgliedschaft', '/page/Membership_Application' ],
 			[ '/spenden/Fördermitgliedschaft', '/page/Fördermitgliedschaft' ],
@@ -21,7 +21,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 	}
 
 	/** @dataProvider simplePageDisplayProvider */
-	public function testPageDisplayRequestsAreRedirected( $requestedUrl, $expectedRedirection ): void {
+	public function testPageDisplayRequestsAreRedirected( string $requestedUrl, string $expectedRedirection ): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request( 'GET', $requestedUrl );
@@ -31,7 +31,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 		$this->assertSame( $expectedRedirection, $response->headers->get( 'Location' ) );
 	}
 
-	public function shouldRedirectToDefaultRouteProvider() {
+	public function shouldRedirectToDefaultRouteProvider(): array {
 		return [
 			[ '/spenden/spende.php', '/' ],
 			[ '/spenden/contact.php', '/' ],
@@ -44,7 +44,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 	}
 
 	/** @dataProvider shouldRedirectToDefaultRouteProvider */
-	public function testRequestsAreRedirectedToDefaultRoute( $requestedUrl, $expectedRedirection ): void {
+	public function testRequestsAreRedirectedToDefaultRoute( string $requestedUrl, string $expectedRedirection ): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request( 'GET', $requestedUrl );
@@ -54,7 +54,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 		$this->assertSame( $expectedRedirection, $response->headers->get( 'Location' ) );
 	}
 
-	public function commentListUrlProvider() {
+	public function commentListUrlProvider(): array {
 		return [
 			[ '/spenden/list.php', '/list-comments.html' ],
 			[ '/spenden/rss.php', '/list-comments.rss' ],
@@ -63,7 +63,7 @@ class RouteRedirectionTest extends WebRouteTestCase {
 	}
 
 	/** @dataProvider commentListUrlProvider */
-	public function testCallsToCommentListIsRedirected( $requestedUrl, $expectedRedirection ): void {
+	public function testCallsToCommentListIsRedirected( string $requestedUrl, string $expectedRedirection ): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 		$client->request( 'GET', $requestedUrl );

--- a/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
@@ -130,7 +130,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function retrieveDonationConfirmation( Client $client, int $donationId ) {
+	private function retrieveDonationConfirmation( Client $client, int $donationId ): string {
 		$client->request(
 			'GET',
 			'show-donation-confirmation',
@@ -244,7 +244,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function newConfirmationPageConfig() {
+	private function newConfirmationPageConfig(): array {
 		return [
 			'default' => 'DonationConfirmation.twig',
 			'campaigns' => [
@@ -259,7 +259,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function newEmptyConfirmationPageConfig() {
+	private function newEmptyConfirmationPageConfig(): array {
 		return [
 			'default' => 'DonationConfirmation.twig',
 			'campaigns' => [

--- a/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
@@ -26,7 +26,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 
 	const ACCESS_DENIED_TEXT = 'access_denied_donation_confirmation';
 
-	public function testGivenValidRequest_confirmationPageContainsDonationData() {
+	public function testGivenValidRequest_confirmationPageContainsDonationData(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setDonationConfirmationPageSelector(
 				new DonationConfirmationPageSelector( $this->newEmptyConfirmationPageConfig() )
@@ -41,7 +41,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenValidPostRequest_confirmationPageContainsDonationData() {
+	public function testGivenValidPostRequest_confirmationPageContainsDonationData(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setDonationConfirmationPageSelector(
 				new DonationConfirmationPageSelector( $this->newEmptyConfirmationPageConfig() )
@@ -56,7 +56,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenValidPostRequest_embeddedMembershipFormContainsDonationData() {
+	public function testGivenValidPostRequest_embeddedMembershipFormContainsDonationData(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setDonationConfirmationPageSelector(
 				new DonationConfirmationPageSelector( $this->newEmptyConfirmationPageConfig() )
@@ -71,7 +71,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function assertEmbeddedMembershipFormIsPrefilled( Donation $donation, string $responseContent ) {
+	private function assertEmbeddedMembershipFormIsPrefilled( Donation $donation, string $responseContent ): void {
 		$personName = $donation->getDonor()->getName();
 		$physicalAddress = $donation->getDonor()->getPhysicalAddress();
 		/** @var DirectDebitPayment $paymentMethod */
@@ -95,7 +95,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'initialFormValues.bankname: ' . $bankData->getBankName(), $responseContent );
 	}
 
-	public function testGivenAlternativeConfirmationPageConfig_alternativeContentIsDisplayed() {
+	public function testGivenAlternativeConfirmationPageConfig_alternativeContentIsDisplayed(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setDonationConfirmationPageSelector(
 				new DonationConfirmationPageSelector( $this->newConfirmationPageConfig() )
@@ -110,7 +110,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenAnonymousDonation_confirmationPageReflectsThat() {
+	public function testGivenAnonymousDonation_confirmationPageReflectsThat(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$donation = $this->newBookedAnonymousPayPalDonation( $factory );
 
@@ -120,7 +120,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testGivenAnonymousDonation_confirmationPageShowsStatusText() {
+	public function testGivenAnonymousDonation_confirmationPageShowsStatusText(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$donation = $this->newBookedAnonymousPayPalDonation( $factory );
 
@@ -163,7 +163,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		return $donation;
 	}
 
-	private function assertDonationDataInResponse( Donation $donation, string $responseContent ) {
+	private function assertDonationDataInResponse( Donation $donation, string $responseContent ): void {
 		$donor = $donation->getDonor();
 		$personName = $donor->getName();
 		$physicalAddress = $donor->getPhysicalAddress();
@@ -192,7 +192,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		$this->assertContains( 'bankData.bankname: ' . $paymentMethod->getBankData()->getBankName(), $responseContent );
 	}
 
-	public function testGivenWrongToken_accessIsDenied() {
+	public function testGivenWrongToken_accessIsDenied(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setDonationConfirmationPageSelector(
 				new DonationConfirmationPageSelector( $this->newEmptyConfirmationPageConfig() )
@@ -212,14 +212,14 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	private function assertDonationIsNotShown( Donation $donation, string $responseContent ) {
+	private function assertDonationIsNotShown( Donation $donation, string $responseContent ): void {
 		$this->assertNotContains( $donation->getDonor()->getName()->getFirstName(), $responseContent );
 		$this->assertNotContains( $donation->getDonor()->getName()->getLastName(), $responseContent );
 
 		$this->assertContains( self::ACCESS_DENIED_TEXT, $responseContent );
 	}
 
-	public function testGivenWrongId_accessIsDenied() {
+	public function testGivenWrongId_accessIsDenied(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setDonationConfirmationPageSelector(
 				new DonationConfirmationPageSelector( $this->newEmptyConfirmationPageConfig() )
@@ -233,7 +233,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		} );
 	}
 
-	public function testWhenNoDonation_accessIsDenied() {
+	public function testWhenNoDonation_accessIsDenied(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setDonationConfirmationPageSelector(
 				new DonationConfirmationPageSelector( $this->newEmptyConfirmationPageConfig() )
@@ -274,7 +274,7 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testWhenDonationTimestampCookieIsSet_itIsNotOverwritten() {
+	public function testWhenDonationTimestampCookieIsSet_itIsNotOverwritten(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$donation = $this->newStoredDonation( $factory );
 

--- a/tests/EdgeToEdge/Routes/ShowMembershipConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowMembershipConfirmationRouteTest.php
@@ -33,7 +33,7 @@ class ShowMembershipConfirmationRouteTest extends WebRouteTestCase {
 		return $membershipApplication;
 	}
 
-	public function testWhenDonationTimestampCookieIsSet_itIsNotOverwritten() {
+	public function testWhenDonationTimestampCookieIsSet_itIsNotOverwritten(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$donation = $this->newStoredMembershipApplication( $factory );
 

--- a/tests/EdgeToEdge/Routes/ValidateAddressRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ValidateAddressRouteTest.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class ValidateAddressRouteTest extends WebRouteTestCase {
 
-	public function testGivenValidAddress_validationReturnsSuccess() {
+	public function testGivenValidAddress_validationReturnsSuccess(): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 
@@ -27,7 +27,7 @@ class ValidateAddressRouteTest extends WebRouteTestCase {
 		$this->assertJsonSuccessResponse( ['status' => 'OK'], $response );
 	}
 
-	public function testGivenInvalidCompanyAddress_validationReturnsErrorMessage() {
+	public function testGivenInvalidCompanyAddress_validationReturnsErrorMessage(): void {
 		$client = $this->createClient();
 		$client->followRedirects( false );
 

--- a/tests/EdgeToEdge/Routes/ValidateAddressRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ValidateAddressRouteTest.php
@@ -48,7 +48,7 @@ class ValidateAddressRouteTest extends WebRouteTestCase {
 		$this->assertJsonSuccessResponse( $expectedResponse, $response );
 	}
 
-	private function newPersonFormInput() {
+	private function newPersonFormInput(): array {
 		return [
 			'addressType' => 'person',
 			'salutation' => 'Frau',
@@ -64,7 +64,7 @@ class ValidateAddressRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	private function newCompanyWithMissingNameFormInput() {
+	private function newCompanyWithMissingNameFormInput(): array {
 		return [
 			'addressType' => 'firma',
 			'salutation' => 'Frau',

--- a/tests/EdgeToEdge/Routes/ValidateEmailRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ValidateEmailRouteTest.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class ValidateEmailRouteTest extends WebRouteTestCase {
 
-	public function testGivenValidEmail_successResponseIsReturned() {
+	public function testGivenValidEmail_successResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -27,7 +27,7 @@ class ValidateEmailRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenInvalidEmail_errorResponseIsReturned() {
+	public function testGivenInvalidEmail_errorResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -42,7 +42,7 @@ class ValidateEmailRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenNoEmail_errorResponseIsReturned() {
+	public function testGivenNoEmail_errorResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(

--- a/tests/EdgeToEdge/Routes/ValidateFeeRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ValidateFeeRouteTest.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class ValidateFeeRouteTest extends WebRouteTestCase {
 
-	public function testGivenValidParameters_successResponseIsReturned() {
+	public function testGivenValidParameters_successResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -27,7 +27,7 @@ class ValidateFeeRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenInvalidParameters_failureResponseIsReturned() {
+	public function testGivenInvalidParameters_failureResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(

--- a/tests/EdgeToEdge/Routes/ValidateFeeRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ValidateFeeRouteTest.php
@@ -41,7 +41,7 @@ class ValidateFeeRouteTest extends WebRouteTestCase {
 		$this->assertSame( $this->newErrorResponse(), json_decode( $response->getContent(), true ) );
 	}
 
-	private function newErrorResponse() {
+	private function newErrorResponse(): array {
 		return [
 			'status' => 'ERR',
 			'messages' => [

--- a/tests/EdgeToEdge/Routes/ValidatePaymentDataRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ValidatePaymentDataRouteTest.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
  */
 class ValidatePaymentDataRouteTest extends WebRouteTestCase {
 
-	public function testGivenValidAmount_successResponseIsReturned() {
+	public function testGivenValidAmount_successResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(
@@ -28,7 +28,7 @@ class ValidatePaymentDataRouteTest extends WebRouteTestCase {
 		);
 	}
 
-	public function testGivenInvalidAmount_failureResponseIsReturned() {
+	public function testGivenInvalidAmount_failureResponseIsReturned(): void {
 		$client = $this->createClient();
 
 		$client->request(

--- a/tests/EdgeToEdge/TrackingCookieTest.php
+++ b/tests/EdgeToEdge/TrackingCookieTest.php
@@ -17,7 +17,7 @@ class TrackingCookieTest extends WebRouteTestCase {
 
 	const COOKIE_NAME = 'spenden_tracking';
 
-	public function testWhenTrackingParamsArePassed_valuesAreStoredInCookie() {
+	public function testWhenTrackingParamsArePassed_valuesAreStoredInCookie(): void {
 		$client = $this->createClient();
 		$client->request( 'get', '/', [
 			self::PARAM_NAME_CAMPAIGN => 'campaign',
@@ -27,14 +27,14 @@ class TrackingCookieTest extends WebRouteTestCase {
 		$this->assertSame( 'campaign/keyword', $client->getCookieJar()->get( self::COOKIE_NAME )->getValue() );
 	}
 
-	public function testWhenTrackingParamsAreNotPassed_noCookieIsCreated() {
+	public function testWhenTrackingParamsAreNotPassed_noCookieIsCreated(): void {
 		$client = $this->createClient();
 		$client->request( 'get', '/', [] );
 
 		$this->assertNull( $client->getCookieJar()->get( self::COOKIE_NAME ) );
 	}
 
-	public function testWhenEmptyTrackingParamsArePassed_noCookieIsCreated() {
+	public function testWhenEmptyTrackingParamsArePassed_noCookieIsCreated(): void {
 		$client = $this->createClient();
 		$client->request( 'get', '/', [
 			self::PARAM_NAME_CAMPAIGN => '',
@@ -44,7 +44,7 @@ class TrackingCookieTest extends WebRouteTestCase {
 		$this->assertNull( $client->getCookieJar()->get( self::COOKIE_NAME ) );
 	}
 
-	public function testNewValuesAreProvided_theOldOnesAreKept() {
+	public function testNewValuesAreProvided_theOldOnesAreKept(): void {
 		$client = $this->createClient();
 
 		$client->getCookieJar()->set( new Cookie(

--- a/tests/EdgeToEdge/TranslatorTest.php
+++ b/tests/EdgeToEdge/TranslatorTest.php
@@ -14,7 +14,7 @@ use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
  */
 class TranslatorTest extends WebRouteTestCase {
 
-	public function testGivenDefinedMessageKey_responseContainsTranslatedMessages() {
+	public function testGivenDefinedMessageKey_responseContainsTranslatedMessages(): void {
 		$client = $this->createClient(
 			[],
 			function ( FunFunFactory $factory ) {
@@ -25,7 +25,7 @@ class TranslatorTest extends WebRouteTestCase {
 		$this->assertContains( 'Seite nicht gefunden', $client->getResponse()->getContent() );
 	}
 
-	public function testGivenUndefinedMessageKey_responseContainsMessageKey() {
+	public function testGivenUndefinedMessageKey_responseContainsMessageKey(): void {
 		$client = $this->createClient();
 		$client->request( 'GET', '/anything' );
 		$this->assertContains( 'page_not_found', $client->getResponse()->getContent() );

--- a/tests/EdgeToEdge/TranslatorTest.php
+++ b/tests/EdgeToEdge/TranslatorTest.php
@@ -31,7 +31,7 @@ class TranslatorTest extends WebRouteTestCase {
 		$this->assertContains( 'page_not_found', $client->getResponse()->getContent() );
 	}
 
-	private function newTranslator( array $translatableMessages, string $locale ) {
+	private function newTranslator( array $translatableMessages, string $locale ): Translator {
 		$translator = new Translator( $locale );
 		$translator->addLoader( 'array', new ArrayLoader() );
 		$translator->addResource( 'array', $translatableMessages, $locale );

--- a/tests/EdgeToEdge/TrimValuesTest.php
+++ b/tests/EdgeToEdge/TrimValuesTest.php
@@ -44,7 +44,7 @@ class TrimValuesTest extends WebRouteTestCase {
 		return $params;
 	}
 
-	private function trimValue( &$value ): void {
+	private function trimValue( &$value ): void {	// @codingStandardsIgnoreLine
 		$value = is_string( $value ) ? trim( $value ) : $value;
 	}
 

--- a/tests/EdgeToEdge/TrimValuesTest.php
+++ b/tests/EdgeToEdge/TrimValuesTest.php
@@ -28,7 +28,7 @@ class TrimValuesTest extends WebRouteTestCase {
 		$this->assertSame( $this->trimArray( $params ), $client->getRequest()->request->all() );
 	}
 
-	private function newParams() {
+	private function newParams(): array {
 		return [
 			'var1' => '  val1 ',
 			'var2' => 'val2 ',
@@ -39,7 +39,7 @@ class TrimValuesTest extends WebRouteTestCase {
 		];
 	}
 
-	private function trimArray( array $params ) {
+	private function trimArray( array $params ): array {
 		array_walk( $params, [ self::class, 'trimValue' ] );
 		return $params;
 	}

--- a/tests/EdgeToEdge/TrimValuesTest.php
+++ b/tests/EdgeToEdge/TrimValuesTest.php
@@ -10,42 +10,46 @@ namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge;
  */
 class TrimValuesTest extends WebRouteTestCase {
 
-	public function testPassedGetParametersAreTrimmed(): void {
-		$params = $this->newParams();
-
+	/**
+	 * @dataProvider getTestData
+	 */
+	public function testPassedGetParametersAreTrimmed( array $expected, array $request ): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
-		$client->request( 'GET', '/actually-every-route', $params );
+		$client->request( 'GET', '/actually-every-route', $request );
 
-		$this->assertSame( $this->trimArray( $params ), $client->getRequest()->query->all() );
+		$this->assertSame( $expected, $client->getRequest()->query->all() );
 	}
 
-	public function testPassedPostParametersAreTrimmed(): void {
-		$params = $this->newParams();
-
+	/**
+	 * @dataProvider getTestData
+	 */
+	public function testPassedPostParametersAreTrimmed( array $expected, array $request ): void {
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
-		$client->request( 'POST', '/actually-every-route', $params );
+		$client->request( 'POST', '/actually-every-route', $request );
 
-		$this->assertSame( $this->trimArray( $params ), $client->getRequest()->request->all() );
+		$this->assertSame( $expected, $client->getRequest()->request->all() );
 	}
 
-	private function newParams(): array {
+	public function getTestData(): array {
 		return [
-			'var1' => '  val1 ',
-			'var2' => 'val2 ',
-			'var3' => ' val3 ',
-			'var4' => '   val4  ',
-			'var5' => 0,
-			'var6' => 1234.56,
+			[
+				[
+					'var1' => 'val1',
+					'var2' => 'val2',
+					'var3' => 'val3',
+					'var4' => 'val4',
+					'var5' => 0,
+					'var6' => 1234.56
+				],
+				[
+					'var1' => '  val1 ',
+					'var2' => 'val2 ',
+					'var3' => ' val3 ',
+					'var4' => '   val4  ',
+					'var5' => 0,
+					'var6' => 1234.56
+				]
+			]
 		];
 	}
-
-	private function trimArray( array $params ): array {
-		array_walk( $params, [ self::class, 'trimValue' ] );
-		return $params;
-	}
-
-	private function trimValue( &$value ): void {	// @codingStandardsIgnoreLine
-		$value = is_string( $value ) ? trim( $value ) : $value;
-	}
-
 }

--- a/tests/EdgeToEdge/TrimValuesTest.php
+++ b/tests/EdgeToEdge/TrimValuesTest.php
@@ -10,7 +10,7 @@ namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge;
  */
 class TrimValuesTest extends WebRouteTestCase {
 
-	public function testPassedGetParametersAreTrimmed() {
+	public function testPassedGetParametersAreTrimmed(): void {
 		$params = $this->newParams();
 
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
@@ -19,7 +19,7 @@ class TrimValuesTest extends WebRouteTestCase {
 		$this->assertSame( $this->trimArray( $params ), $client->getRequest()->query->all() );
 	}
 
-	public function testPassedPostParametersAreTrimmed() {
+	public function testPassedPostParametersAreTrimmed(): void {
 		$params = $this->newParams();
 
 		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
@@ -44,7 +44,7 @@ class TrimValuesTest extends WebRouteTestCase {
 		return $params;
 	}
 
-	private function trimValue( &$value ) {
+	private function trimValue( &$value ): void {
 		$value = is_string( $value ) ? trim( $value ) : $value;
 	}
 

--- a/tests/EdgeToEdge/WebRouteTestCase.php
+++ b/tests/EdgeToEdge/WebRouteTestCase.php
@@ -52,7 +52,7 @@ abstract class WebRouteTestCase extends TestCase {
 	 * @param array $config
 	 * @param callable $onEnvironmentCreated
 	 */
-	public function createEnvironment( array $config, callable $onEnvironmentCreated ) {
+	public function createEnvironment( array $config, callable $onEnvironmentCreated ): void {
 		$testEnvironment = TestEnvironment::newInstance( $config );
 
 		$client = new Client( $this->createApplication(
@@ -79,7 +79,7 @@ abstract class WebRouteTestCase extends TestCase {
 	 * @param array $config
 	 * @param callable $onEnvironmentCreated
 	 */
-	public function createAppEnvironment( array $config, callable $onEnvironmentCreated ) {
+	public function createAppEnvironment( array $config, callable $onEnvironmentCreated ): void {
 		$testEnvironment = TestEnvironment::newInstance( $config );
 
 		$application = $this->createApplication( $testEnvironment->getFactory(), self::ENABLE_DEBUG );
@@ -109,31 +109,31 @@ abstract class WebRouteTestCase extends TestCase {
 		return $app;
 	}
 
-	protected function assert404( Response $response ) {
+	protected function assert404( Response $response ): void {
 		$this->assertSame( 404, $response->getStatusCode() );
 	}
 
-	protected function assertJsonResponse( $expected, Response $response ) {
+	protected function assertJsonResponse( $expected, Response $response ): void {
 		$this->assertSame(
 			json_encode( $expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
 			$response->getContent()
 		);
 	}
 
-	protected function assertJsonSuccessResponse( $expected, Response $response ) {
+	protected function assertJsonSuccessResponse( $expected, Response $response ): void {
 		$this->assertTrue( $response->isSuccessful(), 'request is successful' );
 		$this->assertJson( $response->getContent(), 'response is json' );
 		$this->assertJsonResponse( $expected, $response );
 	}
 
-	protected function assertGetRequestCausesMethodNotAllowedResponse( string $route, array $params ) {
+	protected function assertGetRequestCausesMethodNotAllowedResponse( string $route, array $params ): void {
 		$client = $this->createClient();
 
 		$this->expectException( MethodNotAllowedHttpException::class );
 		$client->request( 'GET', $route, $params );
 	}
 
-	protected function assertErrorJsonResponse( Response $response ) {
+	protected function assertErrorJsonResponse( Response $response ): void {
 		$responseData = $this->getJsonFromResponse( $response );
 		$this->assertArrayHasKey( 'status', $responseData );
 		$this->assertEquals( $responseData['status'], 'ERR' );
@@ -151,7 +151,7 @@ abstract class WebRouteTestCase extends TestCase {
 		return json_decode( $response->getContent(), true );
 	}
 
-	protected function assertSuccessJsonResponse( Response $response ) {
+	protected function assertSuccessJsonResponse( Response $response ): void {
 		$responseData = $this->getJsonFromResponse( $response );
 		$this->assertArrayHasKey( 'status', $responseData );
 		$this->assertEquals( $responseData['status'], 'OK' );

--- a/tests/EdgeToEdge/WebRouteTestCase.php
+++ b/tests/EdgeToEdge/WebRouteTestCase.php
@@ -113,14 +113,14 @@ abstract class WebRouteTestCase extends TestCase {
 		$this->assertSame( 404, $response->getStatusCode() );
 	}
 
-	protected function assertJsonResponse( $expected, Response $response ): void {
+	protected function assertJsonResponse( array $expected, Response $response ): void {
 		$this->assertSame(
 			json_encode( $expected, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
 			$response->getContent()
 		);
 	}
 
-	protected function assertJsonSuccessResponse( $expected, Response $response ): void {
+	protected function assertJsonSuccessResponse( array $expected, Response $response ): void {
 		$this->assertTrue( $response->isSuccessful(), 'request is successful' );
 		$this->assertJson( $response->getContent(), 'response is json' );
 		$this->assertJsonResponse( $expected, $response );
@@ -146,7 +146,7 @@ abstract class WebRouteTestCase extends TestCase {
 		);
 	}
 
-	protected function getJsonFromResponse( Response $response ) {
+	protected function getJsonFromResponse( Response $response ): array {
 		$this->assertJson( $response->getContent(), 'response is json' );
 		return json_decode( $response->getContent(), true );
 	}

--- a/tests/EdgeToEdge/WebRouteTestSetupTest.php
+++ b/tests/EdgeToEdge/WebRouteTestSetupTest.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
  */
 class WebRouteTestSetupTest extends WebRouteTestCase {
 
-	public function testPersistenceGetsInitialized() {
+	public function testPersistenceGetsInitialized(): void {
 		$factory = TestEnvironment::newInstance()->getFactory();
 
 		$tableNames = $this->removeDatabaseNames(

--- a/tests/Fixtures/FrozenValueObject.php
+++ b/tests/Fixtures/FrozenValueObject.php
@@ -21,7 +21,7 @@ class FrozenValueObject {
 		return $this->mainContent;
 	}
 
-	public function setMainContent( string $mainContent ) {
+	public function setMainContent( string $mainContent ): void {
 		$this->assertIsWritable();
 		$this->mainContent = $mainContent;
 	}
@@ -30,7 +30,7 @@ class FrozenValueObject {
 		return $this->headerContent;
 	}
 
-	public function setHeaderContent( string $headerContent ) {
+	public function setHeaderContent( string $headerContent ): void {
 		$this->assertIsWritable();
 		$this->headerContent = $headerContent;
 	}
@@ -39,7 +39,7 @@ class FrozenValueObject {
 		return $this->footerContent;
 	}
 
-	public function setFooterContent( string $footerContent ) {
+	public function setFooterContent( string $footerContent ): void {
 		$this->assertIsWritable();
 		$this->footerContent = $footerContent;
 	}

--- a/tests/Fixtures/ServerSideTrackerSpy.php
+++ b/tests/Fixtures/ServerSideTrackerSpy.php
@@ -19,7 +19,7 @@ class ServerSideTrackerSpy implements ServerSideTracker {
 
 	private $ips = [];
 
-	public function trackPageView( string $url, string $title ) {
+	public function trackPageView( string $url, string $title ): void {
 		$this->pageViews[] = [
 			'url' => $url,
 			'title' => $title,
@@ -33,7 +33,7 @@ class ServerSideTrackerSpy implements ServerSideTracker {
 		return $this->pageViews;
 	}
 
-	public function setIp( string $ip ) {
+	public function setIp( string $ip ): void {
 		$this->ips[] = $ip;
 	}
 

--- a/tests/Fixtures/SucceedingEmailValidator.php
+++ b/tests/Fixtures/SucceedingEmailValidator.php
@@ -16,7 +16,7 @@ class SucceedingEmailValidator extends EmailValidator {
 	public function __construct() {
 	}
 
-	public function validate( $emailAddress ): ValidationResult {
+	public function validate( $emailAddress ): ValidationResult {	// @codingStandardsIgnoreLine
 		return new ValidationResult();
 	}
 

--- a/tests/Fixtures/SucceedingStringLengthValidator.php
+++ b/tests/Fixtures/SucceedingStringLengthValidator.php
@@ -16,7 +16,7 @@ class SucceedingStringLengthValidator extends StringLengthValidator {
 	public function __construct() {
 	}
 
-	public function validate( $string ): ValidationResult {
+	public function validate( $string ): ValidationResult {	// @codingStandardsIgnoreLine
 		return new ValidationResult();
 	}
 }

--- a/tests/Fixtures/TemplateBasedMailerSpy.php
+++ b/tests/Fixtures/TemplateBasedMailerSpy.php
@@ -29,7 +29,7 @@ class TemplateBasedMailerSpy extends TemplateBasedMailer {
 		return $this->sendMailCalls;
 	}
 
-	public function assertCalledOnceWith( EmailAddress $expectedEmail, array $expectedArguments ) {
+	public function assertCalledOnceWith( EmailAddress $expectedEmail, array $expectedArguments ): void {
 		$this->assertCalledOnce();
 
 		$this->testCase->assertEquals(
@@ -41,7 +41,7 @@ class TemplateBasedMailerSpy extends TemplateBasedMailer {
 		);
 	}
 
-	public function assertCalledOnce() {
+	public function assertCalledOnce(): void {
 		$this->testCase->assertCount( 1, $this->sendMailCalls, 'Mailer should be called exactly once' );
 	}
 

--- a/tests/Integration/MailTemplateFilenameTraversableTest.php
+++ b/tests/Integration/MailTemplateFilenameTraversableTest.php
@@ -12,7 +12,7 @@ use WMDE\Fundraising\Frontend\Tests\TestEnvironment;
  */
 class MailTemplateFilenameTraversableTest extends \PHPUnit\Framework\TestCase {
 
-	public function testTraversableContainsSomeEntriesInTheRightFormat() {
+	public function testTraversableContainsSomeEntriesInTheRightFormat(): void {
 		$mailTemplatePaths = TestEnvironment::newInstance()->getFactory()->newMailTemplateFilenameTraversable();
 
 		$pathArray = iterator_to_array( $mailTemplatePaths );

--- a/tests/Integration/MailTemplatesTest.php
+++ b/tests/Integration/MailTemplatesTest.php
@@ -19,11 +19,11 @@ class MailTemplatesTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private $factory;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->createMissingTestFiles();
 	}
 
-	private function createMissingTestFiles() {
+	private function createMissingTestFiles(): void {
 		foreach ( $this->getFreshlyRenderedContent() as $testFilePath => $testFileContent ) {
 			if ( !file_exists( $testFilePath ) ) {
 				file_put_contents( $testFilePath, $testFileContent );
@@ -103,7 +103,7 @@ class MailTemplatesTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider storedRenderedContentProvider
 	 */
-	public function testCurrentRenderingMatchesStoredRendering( string $testFilePath, string $testFileContent ) {
+	public function testCurrentRenderingMatchesStoredRendering( string $testFilePath, string $testFileContent ): void {
 		$this->assertSame(
 			file_get_contents( $testFilePath ),
 			$testFileContent

--- a/tests/Integration/Presentation/Presenters/ConfirmSubscriptionHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/ConfirmSubscriptionHtmlPresenterTest.php
@@ -19,7 +19,7 @@ use WMDE\Fundraising\Frontend\Validation\ConstraintViolation;
  */
 class ConfirmSubscriptionHtmlPresenterTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenSuccessResponse_templateIsRenderedWithoutMessages() {
+	public function testGivenSuccessResponse_templateIsRenderedWithoutMessages(): void {
 		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
 		$translator = $this->getMockBuilder( Translator::class )->disableOriginalConstructor()->getMock();
 		$twig->expects( $this->once() )
@@ -29,7 +29,7 @@ class ConfirmSubscriptionHtmlPresenterTest extends \PHPUnit\Framework\TestCase {
 		$presenter->present( ValidationResponse::newSuccessResponse() );
 	}
 
-	public function testGivenFailureResponse_templateIsRenderedWithoutMessages() {
+	public function testGivenFailureResponse_templateIsRenderedWithoutMessages(): void {
 		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
 		$twig->expects( $this->once() )
 			->method( 'render' )

--- a/tests/Integration/Presentation/Presenters/ConfirmSubscriptionHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/ConfirmSubscriptionHtmlPresenterTest.php
@@ -39,7 +39,7 @@ class ConfirmSubscriptionHtmlPresenterTest extends \PHPUnit\Framework\TestCase {
 		$presenter->present( ValidationResponse::newFailureResponse( [ $constraintViolation ] ) );
 	}
 
-	private function getTranslator() {
+	private function getTranslator(): Translator {
 		$translator = new Translator( 'en' );
 		$translator->addLoader( 'array', new ArrayLoader() );
 		$translator->addResource(

--- a/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
@@ -21,7 +21,7 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 	private const STATUS_BOOKED = 'status-booked';
 	private const STATUS_UNCONFIRMED = 'status-unconfirmed';
 
-	public function testWhenPresenterRenders_itPassedParamsToTemplate() {
+	public function testWhenPresenterRenders_itPassedParamsToTemplate(): void {
 		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
 		$pageSelector = $this->getMockBuilder( SelectedConfirmationPage::class )->disableOriginalConstructor()->getMock();
 
@@ -72,7 +72,7 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 		return $piwikEvents;
 	}
 
-	public function testWhenPresenterPresents_itPassesMappedStatus() {
+	public function testWhenPresenterPresents_itPassesMappedStatus(): void {
 		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
 		$pageSelector = $this->getMockBuilder( SelectedConfirmationPage::class )->disableOriginalConstructor()->getMock();
 

--- a/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
@@ -21,7 +21,7 @@ class MembershipApplicationConfirmationHtmlPresenterTest extends \PHPUnit\Framew
 	private const STATUS_UNCONFIRMED = 'status-unconfirmed';
 
 	/** @dataProvider applicationStatusProvider */
-	public function testWhenPresenterPresents_itPassesParametersToTemplate( $isConfirmed, $expectedMappedStatus ): void {
+	public function testWhenPresenterPresents_itPassesParametersToTemplate( bool $isConfirmed, string $expectedMappedStatus ): void {
 		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
 		$twig->expects( $this->once() )
 			->method( 'render' )
@@ -41,7 +41,7 @@ class MembershipApplicationConfirmationHtmlPresenterTest extends \PHPUnit\Framew
 		);
 	}
 
-	public function applicationStatusProvider() {
+	public function applicationStatusProvider(): array {
 		return [
 			[ true, self::STATUS_BOOKED ],
 			[ false, self::STATUS_UNCONFIRMED ]

--- a/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/MembershipApplicationConfirmationHtmlPresenterTest.php
@@ -21,7 +21,7 @@ class MembershipApplicationConfirmationHtmlPresenterTest extends \PHPUnit\Framew
 	private const STATUS_UNCONFIRMED = 'status-unconfirmed';
 
 	/** @dataProvider applicationStatusProvider */
-	public function testWhenPresenterPresents_itPassesParametersToTemplate( $isConfirmed, $expectedMappedStatus ) {
+	public function testWhenPresenterPresents_itPassesParametersToTemplate( $isConfirmed, $expectedMappedStatus ): void {
 		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
 		$twig->expects( $this->once() )
 			->method( 'render' )

--- a/tests/Integration/Presentation/TwigEnvironmentConfiguratorTest.php
+++ b/tests/Integration/Presentation/TwigEnvironmentConfiguratorTest.php
@@ -25,7 +25,7 @@ class TwigEnvironmentConfiguratorTest extends TestCase {
 
 	private const LOCALE = 'de_DE';
 
-	public function testTwigInstanceUsesDollarPlaceholdersForVariables() {
+	public function testTwigInstanceUsesDollarPlaceholdersForVariables(): void {
 		$factory = TestEnvironment::newInstance( [
 			'twig' => [
 				'loaders' => [
@@ -42,7 +42,7 @@ class TwigEnvironmentConfiguratorTest extends TestCase {
 		);
 	}
 
-	public function testTwigInstancesTryAllLoadersUntilTemplateIsFound() {
+	public function testTwigInstancesTryAllLoadersUntilTemplateIsFound(): void {
 		$loaderException = new Twig_Error_Loader( 'not found' );
 		$firstLoader = $this->createMock( Twig_LoaderInterface::class );
 		$firstLoader->method( 'getSource' )->willThrowException( $loaderException );
@@ -74,7 +74,7 @@ class TwigEnvironmentConfiguratorTest extends TestCase {
 		return new Twig_Environment();
 	}
 
-	public function testWhenWebBasePathIsEmpty_templatedPathsReferToRootPath() {
+	public function testWhenWebBasePathIsEmpty_templatedPathsReferToRootPath(): void {
 		$factory = TestEnvironment::newInstance( [
 			'twig' => [
 				'loaders' => [
@@ -92,7 +92,7 @@ class TwigEnvironmentConfiguratorTest extends TestCase {
 		);
 	}
 
-	public function testWhenWebBasePathIsNotEmpty_templatedPathsReferToRootPath() {
+	public function testWhenWebBasePathIsNotEmpty_templatedPathsReferToRootPath(): void {
 		$factory = TestEnvironment::newInstance( [
 			'twig' => [
 				'loaders' => [
@@ -110,7 +110,7 @@ class TwigEnvironmentConfiguratorTest extends TestCase {
 		);
 	}
 
-	public function testFilePrefixerIsCalledInTemplate() {
+	public function testFilePrefixerIsCalledInTemplate(): void {
 		$factory = TestEnvironment::newInstance( [
 			'twig' => [
 				'loaders' => [

--- a/tests/Integration/UseCases/GetInTouch/GetInTouchUseCaseTest.php
+++ b/tests/Integration/UseCases/GetInTouch/GetInTouchUseCaseTest.php
@@ -10,6 +10,7 @@ use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\TemplateBasedMailerSpy;
 use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
 use WMDE\Fundraising\Frontend\Validation\ValidationResult;
+use WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchRequest;
 
 /**
  * @covers WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchUseCase
@@ -76,8 +77,8 @@ class GetInTouchUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function newRequest() {
-		return new \WMDE\Fundraising\Frontend\UseCases\GetInTouch\GetInTouchRequest(
+	private function newRequest(): GetInTouchRequest {
+		return new GetInTouchRequest(
 			self::INQUIRER_FIRST_NAME,
 			self::INQUIRER_LAST_NAME,
 			self::INQUIRER_EMAIL_ADDRESS,
@@ -86,7 +87,7 @@ class GetInTouchUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function newSucceedingValidator() {
+	private function newSucceedingValidator(): GetInTouchValidator {
 		$validator = $this->getMockBuilder( GetInTouchValidator::class )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Integration/UseCases/GetInTouch/GetInTouchUseCaseTest.php
+++ b/tests/Integration/UseCases/GetInTouch/GetInTouchUseCaseTest.php
@@ -33,7 +33,7 @@ class GetInTouchUseCaseTest extends \PHPUnit\Framework\TestCase {
 	/** @var TemplateBasedMailerSpy */
 	private $userMailer;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->validator = $this->newSucceedingValidator();
 		$this->operatorMailer = $this->createMock( OperatorMailer::class );
 		$this->userMailer = new TemplateBasedMailerSpy( $this );
@@ -47,7 +47,7 @@ class GetInTouchUseCaseTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenValidParameters_theyAreContainedInTheEmailToOperator() {
+	public function testGivenValidParameters_theyAreContainedInTheEmailToOperator(): void {
 		$this->operatorMailer->expects( $this->once() )
 			->method( 'sendMailToOperator' )
 			->with(
@@ -65,7 +65,7 @@ class GetInTouchUseCaseTest extends \PHPUnit\Framework\TestCase {
 		$useCase->processContactRequest( $this->newRequest() );
 	}
 
-	public function testGivenValidRequest_theUserIsNotified() {
+	public function testGivenValidRequest_theUserIsNotified(): void {
 		$useCase = $this->newGetInTouchUseCase();
 		$useCase->processContactRequest( $this->newRequest() );
 

--- a/tests/Integration/Validation/DonorValidatorTest.php
+++ b/tests/Integration/Validation/DonorValidatorTest.php
@@ -106,7 +106,7 @@ class DonorValidatorTest extends ValidatorTestCase {
 		return $address;
 	}
 
-	private function newDonorValidator() {
+	private function newDonorValidator(): DonorValidator {
 		return new DonorValidator(
 			new DonorNameValidator(),
 			new DonorAddressValidator(),

--- a/tests/Integration/Validation/DonorValidatorTest.php
+++ b/tests/Integration/Validation/DonorValidatorTest.php
@@ -24,7 +24,7 @@ class DonorValidatorTest extends ValidatorTestCase {
 
 	const VALID_EMAIL_ADDRESS = 'hank.scorpio@globex.com';
 
-	public function testGivenValidPersonalInfo_validationIsSuccessful() {
+	public function testGivenValidPersonalInfo_validationIsSuccessful(): void {
 		$personalInfo = new Donor(
 			$this->newCompanyName(),
 			$this->newPhysicalAddress(),
@@ -34,7 +34,7 @@ class DonorValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $this->newDonorValidator()->validate( $personalInfo )->isSuccessful() );
 	}
 
-	public function testGivenMissingEmail_validationFails() {
+	public function testGivenMissingEmail_validationFails(): void {
 		$personalInfo = new Donor(
 			$this->newCompanyName(),
 			$this->newPhysicalAddress(),
@@ -44,7 +44,7 @@ class DonorValidatorTest extends ValidatorTestCase {
 		$this->assertFalse( $this->newDonorValidator()->validate( $personalInfo )->isSuccessful() );
 	}
 
-	public function testGivenMissingName_validationFails() {
+	public function testGivenMissingName_validationFails(): void {
 		$personalInfo = new Donor(
 			DonorName::newCompanyName(),
 			$this->newPhysicalAddress(),
@@ -60,7 +60,7 @@ class DonorValidatorTest extends ValidatorTestCase {
 		);
 	}
 
-	public function testGivenMissingAddressFields_validationFails() {
+	public function testGivenMissingAddressFields_validationFails(): void {
 		$personalInfo = new Donor(
 			$this->newCompanyName(),
 			$this->newPhysicalAddressWithMissingData(),

--- a/tests/Integration/Validation/GetInTouchValidatorTest.php
+++ b/tests/Integration/Validation/GetInTouchValidatorTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Validation\GetInTouchValidator;
  */
 class GetInTouchValidatorTest extends ValidatorTestCase {
 
-	public function testNameFieldsAreOptional() {
+	public function testNameFieldsAreOptional(): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 		$validator = new GetInTouchValidator( $mailValidator );
 		$request = new GetInTouchRequest(
@@ -29,7 +29,7 @@ class GetInTouchValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $validator->validate( $request )->isSuccessful() );
 	}
 
-	public function testEmailAddressIsValidated() {
+	public function testEmailAddressIsValidated(): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 		$validator = new GetInTouchValidator( $mailValidator );
 		$request = new GetInTouchRequest(
@@ -43,7 +43,7 @@ class GetInTouchValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $validator->validate( $request ), 'email' );
 	}
 
-	public function testSubjectIsValidated() {
+	public function testSubjectIsValidated(): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 		$validator = new GetInTouchValidator( $mailValidator );
 		$request = new GetInTouchRequest(
@@ -57,7 +57,7 @@ class GetInTouchValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $validator->validate( $request ), 'subject' );
 	}
 
-	public function testMessageBodyIsValidated() {
+	public function testMessageBodyIsValidated(): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 		$validator = new GetInTouchValidator( $mailValidator );
 		$request = new GetInTouchRequest(

--- a/tests/Integration/Validation/SubscriptionValidatorTest.php
+++ b/tests/Integration/Validation/SubscriptionValidatorTest.php
@@ -24,14 +24,14 @@ use WMDE\Fundraising\Frontend\Validation\ValidationResult;
  */
 class SubscriptionValidatorTest extends ValidatorTestCase {
 
-	private function getMockTextPolicyValidator() {
+	private function getMockTextPolicyValidator(): TextPolicyValidator {
 		$mock = $this->createMock( TextPolicyValidator::class );
 		$mock->method( 'hasHarmlessContent' )
 			->willReturn( true );
 		return $mock;
 	}
 
-	private function getMockDuplicateValidator() {
+	private function getMockDuplicateValidator(): SubscriptionDuplicateValidator {
 		$mock = $this->getMockBuilder( SubscriptionDuplicateValidator::class )
 			->disableOriginalConstructor()->getMock();
 

--- a/tests/Integration/Validation/SubscriptionValidatorTest.php
+++ b/tests/Integration/Validation/SubscriptionValidatorTest.php
@@ -52,7 +52,7 @@ class SubscriptionValidatorTest extends ValidatorTestCase {
 		return $address;
 	}
 
-	public function testEmailIsValidated() {
+	public function testEmailIsValidated(): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 		$subscriptionValidator = new SubscriptionValidator(
 			$mailValidator,
@@ -66,7 +66,7 @@ class SubscriptionValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $subscriptionValidator->validate( $subscription ), 'email' );
 	}
 
-	public function testGivenBadWords_subscriptionIsStillValid() {
+	public function testGivenBadWords_subscriptionIsStillValid(): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 		$policyValidator = $this->createMock( TextPolicyValidator::class );
 		$policyValidator->method( 'hasHarmlessContent' )
@@ -83,7 +83,7 @@ class SubscriptionValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $subscriptionValidator->validate( $subscription )->isSuccessful() );
 	}
 
-	public function testGivenBadWords_needsModerationIsTrue() {
+	public function testGivenBadWords_needsModerationIsTrue(): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 		$policyValidator = $this->createMock( TextPolicyValidator::class );
 		$policyValidator->method( 'hasHarmlessContent' )
@@ -100,7 +100,7 @@ class SubscriptionValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $subscriptionValidator->needsModeration( $subscription ) );
 	}
 
-	public function testDuplicateSubscriptionIsValidated() {
+	public function testDuplicateSubscriptionIsValidated(): void {
 		$subscription = new Subscription();
 		$subscription->setAddress( $this->createAddress( 'Herr', 'Nyan', 'Cat' ) );
 		$subscription->setEmail( 'nyan@meow.com' );
@@ -122,7 +122,7 @@ class SubscriptionValidatorTest extends ValidatorTestCase {
 		);
 	}
 
-	public function testHonorificIsValidated() {
+	public function testHonorificIsValidated(): void {
 		$subscription = new Subscription();
 		$address = $this->createAddress( 'Herr', 'Nyan', 'Cat' );
 		$address->setTitle( 'Overlord' );

--- a/tests/System/McpCreditCardServiceTest.php
+++ b/tests/System/McpCreditCardServiceTest.php
@@ -30,7 +30,7 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 
 	private $customerId;
 
-	public function setUp() {
+	public function setUp(): void {
 		$config = TestEnvironment::newInstance( [] )->getConfig();
 		$this->accessKey = $config['creditcard']['access-key'];
 		$this->projectId = $config['creditcard']['project-id'];
@@ -67,17 +67,14 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 		return $result['sessionId'];
 	}
 
-	public function testGivenValidCustomerId_expirationDateIsRetrieved() {
+	public function testGivenValidCustomerId_expirationDateIsRetrieved(): void {
 		$service = new McpCreditCardService( $this->dispatcher, $this->accessKey, true );
 		$creditCardInfo = $service->getExpirationDate( $this->customerId );
 		$this->assertSame( (int)self::CARD_EXPIRY_MONTH, $creditCardInfo->getMonth() );
 		$this->assertSame( (int)self::CARD_EXPIRY_YEAR, $creditCardInfo->getYear() );
 	}
 
-	/**
-	 * @return IMcpCreditcardService_v1_5
-	 */
-	private function newDispatcher() {
+	private function newDispatcher(): IMcpCreditcardService_v1_5 {
 		return new TNvpServiceDispatcher(
 			'IMcpCreditcardService_v1_5',
 			'https://sipg.micropayment.de/public/creditcard/v1.5/nvp/'

--- a/tests/System/McpCreditCardServiceTest.php
+++ b/tests/System/McpCreditCardServiceTest.php
@@ -74,7 +74,7 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( (int)self::CARD_EXPIRY_YEAR, $creditCardInfo->getYear() );
 	}
 
-	private function newDispatcher(): IMcpCreditcardService_v1_5 {
+	private function newDispatcher(): TNvpServiceDispatcher {
 		return new TNvpServiceDispatcher(
 			'IMcpCreditcardService_v1_5',
 			'https://sipg.micropayment.de/public/creditcard/v1.5/nvp/'

--- a/tests/System/McpCreditCardServiceTest.php
+++ b/tests/System/McpCreditCardServiceTest.php
@@ -59,7 +59,7 @@ class McpCreditCardServiceTest extends \PHPUnit\Framework\TestCase {
 		$this->dispatcher->transactionPurchase( $this->accessKey, self::TEST_MODE, $sessionId, self::CARD_CVC2 );
 	}
 
-	private function createSession( $amountInCents, $currencyCode, $title, $payText, $localIpAddress ): string {
+	private function createSession( int $amountInCents, string $currencyCode, string $title, string $payText, string $localIpAddress ): string {
 		$result = $this->dispatcher->sessionCreate(
 			$this->accessKey, self::TEST_MODE, $this->customerId, null, $this->projectId, null, null, null, $amountInCents,
 			$currencyCode, $title, $payText, $localIpAddress, false

--- a/tests/System/PayPalNotificationVerifierTest.php
+++ b/tests/System/PayPalNotificationVerifierTest.php
@@ -45,7 +45,7 @@ class PayPalNotificationVerifierTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function newPostRequest() {
+	private function newPostRequest(): array {
 		return [
 			'mc_gross' => '5.00',
 			'protection_eligibility' => 'Eligible',

--- a/tests/System/PayPalNotificationVerifierTest.php
+++ b/tests/System/PayPalNotificationVerifierTest.php
@@ -18,19 +18,19 @@ class PayPalNotificationVerifierTest extends \PHPUnit\Framework\TestCase {
 	/** @var PayPalPaymentNotificationVerifier */
 	private $verifier;
 
-	public function setUp() {
+	public function setUp(): void {
 		$config = TestEnvironment::newInstance( [] )->getConfig();
 		$this->verifier = $this->newVerifier( $config['paypal-donation'] );
 	}
 
-	public function testWhenVerifyingInvalidRequest_externalServiceReturnsAnError() {
+	public function testWhenVerifyingInvalidRequest_externalServiceReturnsAnError(): void {
 		$this->expectException( PayPalPaymentNotificationVerifierException::class );
 		$this->expectExceptionMessageRegExp( '/did not confirm/' );
 
 		$this->verifier->verify( $this->newPostRequest() );
 	}
 
-	public function testWhenVerifyingValidRequest_externalServiceReturnsAnError() {
+	public function testWhenVerifyingValidRequest_externalServiceReturnsAnError(): void {
 		$this->expectException( PayPalPaymentNotificationVerifierException::class );
 		$this->expectExceptionMessageRegExp( '/did not confirm/' );
 

--- a/tests/System/TextPolicyValidatorTest.php
+++ b/tests/System/TextPolicyValidatorTest.php
@@ -17,7 +17,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider urlTestProvider
 	 */
-	public function testWhenGivenCommentHasURL_validatorReturnsFalse( $commentToTest ): void {
+	public function testWhenGivenCommentHasURL_validatorReturnsFalse( string $commentToTest ): void {
 		$this->skipIfNoInternet();
 
 		$textPolicyValidator = new TextPolicyValidator();
@@ -40,7 +40,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
-	public function urlTestProvider() {
+	public function urlTestProvider(): array {
 		return [
 			[ 'www.example.com' ],
 			[ 'http://www.example.com' ],
@@ -58,7 +58,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider harmlessTestProvider
 	 */
-	public function testWhenGivenHarmlessComment_validatorReturnsTrue( $commentToTest ): void {
+	public function testWhenGivenHarmlessComment_validatorReturnsTrue( string $commentToTest ): void {
 		$this->skipIfNoInternet();
 
 		$textPolicyValidator = new TextPolicyValidator();
@@ -69,7 +69,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		) );
 	}
 
-	public function harmlessTestProvider() {
+	public function harmlessTestProvider(): array {
 		return [
 			[ 'Wikipedia ist so super, meine Eltern sagen es ist eine toll Seite. Berlin ist auch Super.' ],
 			[ 'Ich mag Wikipedia. Aber meine Seite ist auch toll. Googelt mal nach Bunsenbrenner!!!1' ],
@@ -97,7 +97,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider insultingTestProvider
 	 */
-	public function testWhenGivenInsultingComment_validatorReturnsFalse( $commentToTest ): void {
+	public function testWhenGivenInsultingComment_validatorReturnsFalse( string $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertFalse( $textPolicyValidator->hasHarmlessContent(
@@ -106,7 +106,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		) );
 	}
 
-	public function insultingTestProvider() {
+	public function insultingTestProvider(): array {
 		return [
 			[ 'Alles Deppen!' ],
 			[ 'Heil Hitler!' ],
@@ -118,7 +118,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider whiteWordsInsultingTestProvider
 	 */
-	public function testWhenGivenInsultingCommentAndWhiteWords_validatorReturnsFalse( $commentToTest ): void {
+	public function testWhenGivenInsultingCommentAndWhiteWords_validatorReturnsFalse( string $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertFalse(
@@ -132,7 +132,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function whiteWordsInsultingTestProvider() {
+	public function whiteWordsInsultingTestProvider(): array {
 		return [
 			[ 'Ich heisse Deppendorf ihr Deppen und das ist auch gut so!' ],
 			[ 'Ihr Arschgeigen, ich wohne in Marsch und das ist auch gut so!' ],
@@ -143,7 +143,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider whiteWordsHarmlessTestProvider
 	 */
-	public function testWhenGivenHarmlessCommentAndWhiteWords_validatorReturnsTrue( $commentToTest ): void {
+	public function testWhenGivenHarmlessCommentAndWhiteWords_validatorReturnsTrue( string $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertTrue(
@@ -157,7 +157,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function whiteWordsHarmlessTestProvider() {
+	public function whiteWordsHarmlessTestProvider(): array {
 		return [
 			[ 'Wikipedia ist so super, meine Eltern sagen es ist eine toll Seite. Berlin ist auch Super.' ],
 			[ 'Ich heisse Deppendorf ihr und das ist auch gut so!' ],
@@ -169,7 +169,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider insultingTestProviderWithRegexChars
 	 */
-	public function testGivenBadWordMatchContainingRegexChars_validatorReturnsFalse( $commentToTest ): void {
+	public function testGivenBadWordMatchContainingRegexChars_validatorReturnsFalse( string $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertFalse(
@@ -183,7 +183,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function insultingTestProviderWithRegexChars() {
+	public function insultingTestProviderWithRegexChars(): array {
 		return [
 			[ 'Ich heisse Deppendorf (ihr Deppen und das ist auch gut so!' ],
 			[ 'Ihr [Arschgeigen], ich wohne in //Marsch// und das ist auch gut so!' ],
@@ -191,7 +191,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	private function getPreFilledTextPolicyValidator() {
+	private function getPreFilledTextPolicyValidator(): TextPolicyValidator {
 		$textPolicyValidator = new TextPolicyValidator();
 		$textPolicyValidator->addBadWordsFromArray(
 			[

--- a/tests/System/TextPolicyValidatorTest.php
+++ b/tests/System/TextPolicyValidatorTest.php
@@ -17,7 +17,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider urlTestProvider
 	 */
-	public function testWhenGivenCommentHasURL_validatorReturnsFalse( $commentToTest ) {
+	public function testWhenGivenCommentHasURL_validatorReturnsFalse( $commentToTest ): void {
 		$this->skipIfNoInternet();
 
 		$textPolicyValidator = new TextPolicyValidator();
@@ -28,7 +28,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		) );
 	}
 
-	private function skipIfNoInternet() {
+	private function skipIfNoInternet(): void {
 		static $isConnected = null;
 
 		if ( $isConnected === null ) {
@@ -58,7 +58,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider harmlessTestProvider
 	 */
-	public function testWhenGivenHarmlessComment_validatorReturnsTrue( $commentToTest ) {
+	public function testWhenGivenHarmlessComment_validatorReturnsTrue( $commentToTest ): void {
 		$this->skipIfNoInternet();
 
 		$textPolicyValidator = new TextPolicyValidator();
@@ -78,7 +78,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	public function testHamlessContentWithDns() {
+	public function testHamlessContentWithDns(): void {
 		$this->skipIfNoInternet();
 
 		if ( checkdnsrr( 'some-non-existing-domain-drfeszrfdaesr.sdferdyerdhgty', 'A' ) ) {
@@ -97,7 +97,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider insultingTestProvider
 	 */
-	public function testWhenGivenInsultingComment_validatorReturnsFalse( $commentToTest ) {
+	public function testWhenGivenInsultingComment_validatorReturnsFalse( $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertFalse( $textPolicyValidator->hasHarmlessContent(
@@ -118,7 +118,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider whiteWordsInsultingTestProvider
 	 */
-	public function testWhenGivenInsultingCommentAndWhiteWords_validatorReturnsFalse( $commentToTest ) {
+	public function testWhenGivenInsultingCommentAndWhiteWords_validatorReturnsFalse( $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertFalse(
@@ -143,7 +143,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider whiteWordsHarmlessTestProvider
 	 */
-	public function testWhenGivenHarmlessCommentAndWhiteWords_validatorReturnsTrue( $commentToTest ) {
+	public function testWhenGivenHarmlessCommentAndWhiteWords_validatorReturnsTrue( $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertTrue(
@@ -169,7 +169,7 @@ class TextPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider insultingTestProviderWithRegexChars
 	 */
-	public function testGivenBadWordMatchContainingRegexChars_validatorReturnsFalse( $commentToTest ) {
+	public function testGivenBadWordMatchContainingRegexChars_validatorReturnsFalse( $commentToTest ): void {
 		$textPolicyValidator = $this->getPreFilledTextPolicyValidator();
 
 		$this->assertFalse(

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -15,7 +15,7 @@ use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
  */
 class TestEnvironment {
 
-	public static function newInstance( array $config = [] ) {
+	public static function newInstance( array $config = [] ): self {
 		$instance = new self( $config );
 
 		$installer = $instance->factory->newInstaller();
@@ -38,7 +38,7 @@ class TestEnvironment {
 	}
 
 	/**
-	 * @var array
+	 * @var array[]
 	 */
 	private $config;
 
@@ -52,7 +52,7 @@ class TestEnvironment {
 		$this->factory = new FunFunFactory( $this->config );
 	}
 
-	private function getConfigFromFiles() {
+	private function getConfigFromFiles(): array {
 		$readerArguments = [
 			new SimpleFileFetcher(),
 			__DIR__ . '/../app/config/config.dist.json',
@@ -81,7 +81,7 @@ class TestEnvironment {
 		return file_get_contents( __DIR__ . '/Data/files/' . $fileName );
 	}
 
-	public static function getJsonTestData( string $fileName ) {
+	public static function getJsonTestData( string $fileName ): array {
 		return json_decode( self::getTestData( $fileName ), true );
 	}
 

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -38,7 +38,7 @@ class TestEnvironment {
 	}
 
 	/**
-	 * @var array[]
+	 * @var array
 	 */
 	private $config;
 

--- a/tests/Unit/Cli/SchemaLoaderTest.php
+++ b/tests/Unit/Cli/SchemaLoaderTest.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\Cli\ConfigValidation\SchemaLoader;
  */
 class SchemaLoaderTest extends \PHPUnit\Framework\TestCase {
 
-	public function testOnFileFetchingError_runtimeExceptionIsThrown() {
+	public function testOnFileFetchingError_runtimeExceptionIsThrown(): void {
 		$fileFetcher = $this->createMock( FileFetcher::class );
 		$fileFetcher->method( 'fetchFile' )->willThrowException( new \RuntimeException() );
 		$loader = new SchemaLoader( $fileFetcher );
@@ -21,7 +21,7 @@ class SchemaLoaderTest extends \PHPUnit\Framework\TestCase {
 		$loader->loadSchema( 'test.json' );
 	}
 
-	public function testGivenInvalidJson_validationExceptionIsThrown() {
+	public function testGivenInvalidJson_validationExceptionIsThrown(): void {
 		$fileFetcher = $this->createMock( FileFetcher::class );
 		$fileFetcher->method( 'fetchFile' )->willReturn( 'Not a valid JSON string' );
 		$loader = new SchemaLoader( $fileFetcher );
@@ -29,7 +29,7 @@ class SchemaLoaderTest extends \PHPUnit\Framework\TestCase {
 		$loader->loadSchema( 'test.json' );
 	}
 
-	public function testGivenJsonRootIsNotAnObject_validationExceptionIsThrown() {
+	public function testGivenJsonRootIsNotAnObject_validationExceptionIsThrown(): void {
 		$fileFetcher = $this->createMock( FileFetcher::class );
 		$fileFetcher->method( 'fetchFile' )->willReturn( '"A valid JSON string"' );
 		$loader = new SchemaLoader( $fileFetcher );
@@ -37,7 +37,7 @@ class SchemaLoaderTest extends \PHPUnit\Framework\TestCase {
 		$loader->loadSchema( 'test.json' );
 	}
 
-	public function testGivenValidJson_itIsReturnedAsObject() {
+	public function testGivenValidJson_itIsReturnedAsObject(): void {
 		$fileFetcher = $this->createMock( FileFetcher::class );
 		$fileFetcher->method( 'fetchFile' )->willReturn( '{"testProperty": "A valid JSON string"}' );
 		$loader = new SchemaLoader( $fileFetcher );

--- a/tests/Unit/EmailValidatorTest.php
+++ b/tests/Unit/EmailValidatorTest.php
@@ -32,7 +32,7 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider fullyValidEmailProvider
 	 */
-	public function testGivenValidMail_validationWithDomainNameCheckSucceeds( $validEmail ) {
+	public function testGivenValidMail_validationWithDomainNameCheckSucceeds( $validEmail ): void {
 		$mailValidator = new EmailValidator( $this->newStubDomainValidator() );
 
 		$this->assertTrue( $mailValidator->validate( $validEmail )->isSuccessful() );
@@ -52,7 +52,7 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider emailWithInvalidDomainProvider
 	 */
-	public function testGivenMailWithInvalidDomain_validationWithDomainNameCheckFails( $invalidEmail ) {
+	public function testGivenMailWithInvalidDomain_validationWithDomainNameCheckFails( $invalidEmail ): void {
 		$mailValidator = new EmailValidator( $this->newStubDomainValidator() );
 
 		$this->assertFalse( $mailValidator->validate( $invalidEmail )->isSuccessful() );
@@ -73,7 +73,7 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider emailWithInvalidFormatProvider
 	 */
-	public function testGivenMailWithInvalidFormat_validationWithoutDomainCheckFails( $invalidEmail ) {
+	public function testGivenMailWithInvalidFormat_validationWithoutDomainCheckFails( $invalidEmail ): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 
 		$this->assertFalse( $mailValidator->validate( $invalidEmail )->isSuccessful() );

--- a/tests/Unit/EmailValidatorTest.php
+++ b/tests/Unit/EmailValidatorTest.php
@@ -32,13 +32,13 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider fullyValidEmailProvider
 	 */
-	public function testGivenValidMail_validationWithDomainNameCheckSucceeds( $validEmail ): void {
+	public function testGivenValidMail_validationWithDomainNameCheckSucceeds( string $validEmail ): void {
 		$mailValidator = new EmailValidator( $this->newStubDomainValidator() );
 
 		$this->assertTrue( $mailValidator->validate( $validEmail )->isSuccessful() );
 	}
 
-	public function fullyValidEmailProvider() {
+	public function fullyValidEmailProvider(): array {
 		return [
 			[ 'christoph.fischer@wikimedia.de' ],
 			[ 'test@nick.berlin' ],
@@ -52,13 +52,13 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider emailWithInvalidDomainProvider
 	 */
-	public function testGivenMailWithInvalidDomain_validationWithDomainNameCheckFails( $invalidEmail ): void {
+	public function testGivenMailWithInvalidDomain_validationWithDomainNameCheckFails( string $invalidEmail ): void {
 		$mailValidator = new EmailValidator( $this->newStubDomainValidator() );
 
 		$this->assertFalse( $mailValidator->validate( $invalidEmail )->isSuccessful() );
 	}
 
-	public function emailWithInvalidDomainProvider() {
+	public function emailWithInvalidDomainProvider(): array {
 		return [
 			[ 'chrifi.asfsfas.de  ' ],
 			[ ' ' ],
@@ -73,13 +73,13 @@ class EmailValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider emailWithInvalidFormatProvider
 	 */
-	public function testGivenMailWithInvalidFormat_validationWithoutDomainCheckFails( $invalidEmail ): void {
+	public function testGivenMailWithInvalidFormat_validationWithoutDomainCheckFails( string $invalidEmail ): void {
 		$mailValidator = new EmailValidator( new NullDomainNameValidator() );
 
 		$this->assertFalse( $mailValidator->validate( $invalidEmail )->isSuccessful() );
 	}
 
-	public function emailWithInvalidFormatProvider() {
+	public function emailWithInvalidFormatProvider(): array {
 		return [
 			[ 'chrifi.asfsfas.de  ' ],
 			[ ' ' ],

--- a/tests/Unit/FreezableValueObjectTest.php
+++ b/tests/Unit/FreezableValueObjectTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\FrozenValueObject;
  */
 class FreezableValueObjectTest extends \PHPUnit\Framework\TestCase {
 
-	public function testCanSetAndGetValuesBeforeFreeze() {
+	public function testCanSetAndGetValuesBeforeFreeze(): void {
 		$object = new FrozenValueObject();
 
 		$object->setHeaderContent( 'header' );
@@ -28,7 +28,7 @@ class FreezableValueObjectTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'footer', $object->getFooterContent() );
 	}
 
-	public function testCanBeforeFreezeAndGetValuesAfter() {
+	public function testCanBeforeFreezeAndGetValuesAfter(): void {
 		$object = new FrozenValueObject();
 
 		$object->setHeaderContent( 'header' );
@@ -42,7 +42,7 @@ class FreezableValueObjectTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'footer', $object->getFooterContent() );
 	}
 
-	public function testWhenFreezing_settersCauseException() {
+	public function testWhenFreezing_settersCauseException(): void {
 		$object = new FrozenValueObject();
 
 		$object->setHeaderContent( 'header' );
@@ -56,7 +56,7 @@ class FreezableValueObjectTest extends \PHPUnit\Framework\TestCase {
 		$object->setHeaderContent( 'header' );
 	}
 
-	public function testWhenFreezingAndValueNotSet_settersCauseException() {
+	public function testWhenFreezingAndValueNotSet_settersCauseException(): void {
 		$object = new FrozenValueObject();
 
 		$object->freeze();
@@ -66,7 +66,7 @@ class FreezableValueObjectTest extends \PHPUnit\Framework\TestCase {
 		$object->setHeaderContent( 'header' );
 	}
 
-	public function testWhenNoValuesAreSet_assertNoNullFieldsThrowsException() {
+	public function testWhenNoValuesAreSet_assertNoNullFieldsThrowsException(): void {
 		$object = new FrozenValueObject();
 
 		$this->expectException( RuntimeException::class );
@@ -74,7 +74,7 @@ class FreezableValueObjectTest extends \PHPUnit\Framework\TestCase {
 		$object->assertNoNullFields();
 	}
 
-	public function testWhenSettingAllValues_assertNoNullFieldsDoesNothing() {
+	public function testWhenSettingAllValues_assertNoNullFieldsDoesNothing(): void {
 		$object = new FrozenValueObject();
 
 		$object->setHeaderContent( 'header' );

--- a/tests/Unit/Infrastructure/AmountParserTest.php
+++ b/tests/Unit/Infrastructure/AmountParserTest.php
@@ -28,7 +28,7 @@ class AmountParserTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function valueProvider() {
+	public function valueProvider(): array {
 		return [
 			[ 'de_DE', 29.5, '29,50' ],
 			[ 'de_DE', 0.1, '0,10' ],

--- a/tests/Unit/Infrastructure/AmountParserTest.php
+++ b/tests/Unit/Infrastructure/AmountParserTest.php
@@ -21,7 +21,7 @@ class AmountParserTest extends \PHPUnit\Framework\TestCase {
 	 * @param float $expectedValue
 	 * @param string $inputValue
 	 */
-	public function testGivenFormattedString_setAmountFromStringParsesIntoFloat( $locale, $expectedValue, $inputValue ) {
+	public function testGivenFormattedString_setAmountFromStringParsesIntoFloat( string $locale, float $expectedValue, string $inputValue ): void {
 		$this->assertSame(
 			$expectedValue,
 			( new AmountParser( $locale ) )->parseAsFloat( $inputValue )

--- a/tests/Unit/Infrastructure/BestEffortDonationEventLoggerTest.php
+++ b/tests/Unit/Infrastructure/BestEffortDonationEventLoggerTest.php
@@ -21,7 +21,7 @@ class BestEffortDonationEventLoggerTest extends \PHPUnit\Framework\TestCase {
 	const DONATION_ID = 1337;
 	const MESSAGE = 'a semi-important event has occured';
 
-	public function testLogDataIsPassed() {
+	public function testLogDataIsPassed(): void {
 		$eventLogger = new DonationEventLoggerSpy();
 		$bestEffortLogger = new BestEffortDonationEventLogger(
 			$eventLogger,
@@ -31,7 +31,7 @@ class BestEffortDonationEventLoggerTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 1, $eventLogger->getLogCalls() );
 	}
 
-	public function testWhenNoExceptionOccurs_nothingIsLogged() {
+	public function testWhenNoExceptionOccurs_nothingIsLogged(): void {
 		$eventLogger = new DonationEventLoggerSpy();
 		$logger = $this->getLogger();
 		$logger->expects( $this->never() )->method( $this->anything() );
@@ -42,7 +42,7 @@ class BestEffortDonationEventLoggerTest extends \PHPUnit\Framework\TestCase {
 		$bestEffortLogger->log( self::DONATION_ID, self::MESSAGE );
 	}
 
-	public function testWhenEventLoggerThrows_itIsLogged() {
+	public function testWhenEventLoggerThrows_itIsLogged(): void {
 		$eventLogger = $this->createMock( DonationEventLogger::class );
 		$eventLogger->method( 'log' )->will( $this->throwException( new DonationEventLogException( 'Fire Alarm!' ) ) );
 		$logger = $this->getLogger();

--- a/tests/Unit/Infrastructure/Cache/AuthorizedCachePurgerTest.php
+++ b/tests/Unit/Infrastructure/Cache/AuthorizedCachePurgerTest.php
@@ -19,7 +19,7 @@ class AuthorizedCachePurgerTest extends \PHPUnit\Framework\TestCase {
 	const CORRECT_SECRET = 'correct secret';
 	const WRONG_SECRET = 'wrong secret';
 
-	public function testWhenSecretMatches_purgeHappens() {
+	public function testWhenSecretMatches_purgeHappens(): void {
 		$cachePurger = $this->newCachePurger();
 		$cachePurger->expects( $this->once() )->method( 'purgeCache' );
 
@@ -35,7 +35,7 @@ class AuthorizedCachePurgerTest extends \PHPUnit\Framework\TestCase {
 		return $this->createMock( CachePurger::class );
 	}
 
-	public function testWhenSecretDoesNotMatch_purgeDoesNotHappen() {
+	public function testWhenSecretDoesNotMatch_purgeDoesNotHappen(): void {
 		$cachePurger = $this->newCachePurger();
 		$cachePurger->expects( $this->never() )->method( 'purgeCache' );
 
@@ -44,7 +44,7 @@ class AuthorizedCachePurgerTest extends \PHPUnit\Framework\TestCase {
 		$useCase->purgeCache( self::WRONG_SECRET );
 	}
 
-	public function testWhenPurgeHappens_successIsReturned() {
+	public function testWhenPurgeHappens_successIsReturned(): void {
 		$useCase = new AuthorizedCachePurger( $this->newCachePurger(), self::CORRECT_SECRET );
 
 		$this->assertSame(
@@ -53,7 +53,7 @@ class AuthorizedCachePurgerTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenSecretDoesNotMatch_accessDeniedIsReturned() {
+	public function testWhenSecretDoesNotMatch_accessDeniedIsReturned(): void {
 		$useCase = new AuthorizedCachePurger( $this->newCachePurger(), self::CORRECT_SECRET );
 
 		$this->assertSame(
@@ -62,7 +62,7 @@ class AuthorizedCachePurgerTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenCachePurgeThrowsException_errorIsReturned() {
+	public function testWhenCachePurgeThrowsException_errorIsReturned(): void {
 		$cachePurger = $this->newCachePurger();
 		$cachePurger->expects( $this->any() )
 			->method( 'purgeCache' )->willThrowException( new CachePurgingException( '' ) );

--- a/tests/Unit/Infrastructure/ConfigReaderTest.php
+++ b/tests/Unit/Infrastructure/ConfigReaderTest.php
@@ -26,7 +26,7 @@ class ConfigReaderTest extends \PHPUnit\Framework\TestCase {
 	private $distPath;
 	private $emptyPath;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->dir = vfsStream::setup( 'ConfigReaderTest' );
 
 		$this->distPath = vfsStream::newFile( 'config.dist.json' )
@@ -68,13 +68,13 @@ class ConfigReaderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testReadSingleConfigFile() {
+	public function testReadSingleConfigFile(): void {
 		$reader = new ConfigReader( new SimpleFileFetcher(), $this->distPath );
 
 		$this->assertEquals( $this->getDistConfig(), $reader->getConfig() );
 	}
 
-	public function testWhenReadingDistAndInstanceConfig_instanceGetsMergedIntoDist() {
+	public function testWhenReadingDistAndInstanceConfig_instanceGetsMergedIntoDist(): void {
 		$instancePath = vfsStream::newFile( 'config.json' )
 			->at( $this->dir )->withContent( $this->getInstanceConfigContents() )->url();
 
@@ -94,13 +94,13 @@ class ConfigReaderTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenInstanceFileIsEmpty_distConfigIsReturned() {
+	public function testWhenInstanceFileIsEmpty_distConfigIsReturned(): void {
 		$reader = new ConfigReader( new SimpleFileFetcher(), $this->distPath, $this->emptyPath );
 
 		$this->assertEquals( $this->getDistConfig(), $reader->getConfig() );
 	}
 
-	public function testWhenDistFileDoesNotExist_exceptionIsThrown() {
+	public function testWhenDistFileDoesNotExist_exceptionIsThrown(): void {
 		$reader = new ConfigReader( new SimpleFileFetcher(), $this->distPath . 'foo', $this->emptyPath );
 
 		$this->expectException( RuntimeException::class );
@@ -108,7 +108,7 @@ class ConfigReaderTest extends \PHPUnit\Framework\TestCase {
 		$reader->getConfig();
 	}
 
-	public function testWhenInstanceFileDoesNotExist_exceptionIsThrown() {
+	public function testWhenInstanceFileDoesNotExist_exceptionIsThrown(): void {
 		$reader = new \WMDE\Fundraising\Frontend\Infrastructure\ConfigReader( new SimpleFileFetcher(), $this->distPath, $this->emptyPath . 'foo' );
 
 		$this->expectException( RuntimeException::class );
@@ -116,7 +116,7 @@ class ConfigReaderTest extends \PHPUnit\Framework\TestCase {
 		$reader->getConfig();
 	}
 
-	public function testWhenConfigIsNotJson_exceptionIsThrown() {
+	public function testWhenConfigIsNotJson_exceptionIsThrown(): void {
 		$notJsonPath = vfsStream::newFile( 'not.json' )->at( $this->dir )->withContent( 'kittens' )->url();
 
 		$reader = new ConfigReader( new SimpleFileFetcher(), $notJsonPath );
@@ -126,7 +126,7 @@ class ConfigReaderTest extends \PHPUnit\Framework\TestCase {
 		$reader->getConfig();
 	}
 
-	public function testWhenConfigJsonIsNotArray_exceptionIsThrown() {
+	public function testWhenConfigJsonIsNotArray_exceptionIsThrown(): void {
 		$notArrayPath = vfsStream::newFile( 'not-array.json' )->at( $this->dir )->withContent( '42' )->url();
 
 		$reader = new \WMDE\Fundraising\Frontend\Infrastructure\ConfigReader( new SimpleFileFetcher(), $notArrayPath );

--- a/tests/Unit/Infrastructure/DonationConfirmationMailerTest.php
+++ b/tests/Unit/Infrastructure/DonationConfirmationMailerTest.php
@@ -21,7 +21,7 @@ class DonationConfirmationMailerTest extends \PHPUnit\Framework\TestCase {
 
 	const DONATION_ID = 42;
 
-	public function testMailerExtractsEmailFromDonation() {
+	public function testMailerExtractsEmailFromDonation(): void {
 		$mailer = new TemplateBasedMailerSpy( $this );
 
 		$donationMailer = new DonationConfirmationMailer( $mailer );
@@ -40,7 +40,7 @@ class DonationConfirmationMailerTest extends \PHPUnit\Framework\TestCase {
 		return $donation;
 	}
 
-	public function testMailerAssemblesTemplateData() {
+	public function testMailerAssemblesTemplateData(): void {
 		$mailer = new TemplateBasedMailerSpy( $this );
 
 		$donationMailer = new DonationConfirmationMailer( $mailer );

--- a/tests/Unit/Infrastructure/LoggingPaymentNotificationVerifierTest.php
+++ b/tests/Unit/Infrastructure/LoggingPaymentNotificationVerifierTest.php
@@ -18,7 +18,7 @@ use WMDE\PsrLogTestDoubles\LoggerSpy;
  */
 class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenVerifierThrowsException_loggingVerifierPassesItOn() {
+	public function testWhenVerifierThrowsException_loggingVerifierPassesItOn(): void {
 		$loggingVerifier = new LoggingPaymentNotificationVerifier(
 			$this->newThrowingVerifier(),
 			new LoggerSpy()
@@ -42,7 +42,7 @@ class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase
 		return $verifier;
 	}
 
-	public function testWhenVerifierThrowsException_itIsLogged() {
+	public function testWhenVerifierThrowsException_itIsLogged(): void {
 		$logger = new LoggerSpy();
 
 		$loggingVerifier = new LoggingPaymentNotificationVerifier(
@@ -59,7 +59,7 @@ class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase
 		$this->assertExceptionLoggedAsCritical( PayPalPaymentNotificationVerifierException::class, $logger );
 	}
 
-	private function assertExceptionLoggedAsCritical( string $expectedExceptionType, LoggerSpy $logger ) {
+	private function assertExceptionLoggedAsCritical( string $expectedExceptionType, LoggerSpy $logger ): void {
 		$this->assertNotEmpty( $logger->getLogCalls(), 'There should be at least one log call' );
 
 		$logCall = $logger->getLogCalls()->getFirstCall();
@@ -69,7 +69,7 @@ class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase
 		$this->assertInstanceOf( $expectedExceptionType, $logCall->getContext()['exception'] );
 	}
 
-	public function testGivenAnExceptionForUnsupportedPaymentMethod_itIsLoggedAsInfo() {
+	public function testGivenAnExceptionForUnsupportedPaymentMethod_itIsLoggedAsInfo(): void {
 		$logger = new LoggerSpy();
 
 		$statusException = new PayPalPaymentNotificationVerifierException(
@@ -90,7 +90,7 @@ class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase
 		$this->assertUnsupportedMethodWasLogged( 'Unknown', $logger );
 	}
 
-	private function assertUnsupportedMethodWasLogged( string $expectedMethodName, LoggerSpy $logger ) {
+	private function assertUnsupportedMethodWasLogged( string $expectedMethodName, LoggerSpy $logger ): void {
 		$this->assertNotEmpty( $logger->getLogCalls(), 'There should be at least one log call' );
 
 		$logCall = $logger->getLogCalls()->getFirstCall();
@@ -100,7 +100,7 @@ class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame( $expectedMethodName, $logCall->getContext()['payment_status'] );
 	}
 
-	public function testWhenVerifierThrowsException_requestIsLoggedAsDebugInfo() {
+	public function testWhenVerifierThrowsException_requestIsLoggedAsDebugInfo(): void {
 		$logger = new LoggerSpy();
 
 		$loggingVerifier = new LoggingPaymentNotificationVerifier(
@@ -117,7 +117,7 @@ class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase
 		$this->assertRequestLoggedAsDebugInfo( $logger );
 	}
 
-	private function assertRequestLoggedAsDebugInfo( LoggerSpy $logger ) {
+	private function assertRequestLoggedAsDebugInfo( LoggerSpy $logger ): void {
 		$this->assertGreaterThan( 1, count( $logger->getLogCalls() ), 'There should be at least two log calls' );
 
 		$logCall = $logger->getLogCalls()->getIterator()[1];
@@ -130,7 +130,7 @@ class LoggingPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase
 		);
 	}
 
-	public function testWhenVerifierSucceeds_nothingIsLogged() {
+	public function testWhenVerifierSucceeds_nothingIsLogged(): void {
 		$logger = new LoggerSpy();
 		$verifierMock = $this->getMockBuilder( PayPalPaymentNotificationVerifier::class )->disableOriginalConstructor()->getMock();
 		$verifier = new LoggingPaymentNotificationVerifier(

--- a/tests/Unit/Infrastructure/MessengerTest.php
+++ b/tests/Unit/Infrastructure/MessengerTest.php
@@ -33,7 +33,7 @@ class MessengerTest extends \PHPUnit\Framework\TestCase {
 			);
 	}
 
-	private function newMailTransport() {
+	private function newMailTransport(): Swift_NullTransport {
 		return $this->getMockBuilder( Swift_NullTransport::class )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/Unit/Infrastructure/MessengerTest.php
+++ b/tests/Unit/Infrastructure/MessengerTest.php
@@ -17,7 +17,7 @@ use WMDE\Fundraising\Frontend\MembershipContext\Domain\Model\EmailAddress;
  */
 class MessengerTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenSendReturnsZero_exceptionIsThrown() {
+	public function testWhenSendReturnsZero_exceptionIsThrown(): void {
 		$mailTransport = $this->newMailTransport();
 
 		$mailTransport->expects( $this->once() )
@@ -39,7 +39,7 @@ class MessengerTest extends \PHPUnit\Framework\TestCase {
 			->getMock();
 	}
 
-	public function testSendToAddressWithInternationalCharacters_doesNotCauseException() {
+	public function testSendToAddressWithInternationalCharacters_doesNotCauseException(): void {
 		$messenger = new Messenger(
 			$this->newMailTransport(),
 			new EmailAddress( 'hostmaster@thatoperator.com' )

--- a/tests/Unit/Infrastructure/PageViewTrackerTest.php
+++ b/tests/Unit/Infrastructure/PageViewTrackerTest.php
@@ -15,7 +15,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker;
  */
 class PageViewTrackerTest extends \PHPUnit\Framework\TestCase {
 
-	public function testTrackPaypalRedirection() {
+	public function testTrackPaypalRedirection(): void {
 		$tracker = new ServerSideTrackerSpy();
 		$pageViewTracker = new PageViewTracker( $tracker, 'http://awesome.url' );
 

--- a/tests/Unit/Infrastructure/PayPalPaymentNotificationVerifierTest.php
+++ b/tests/Unit/Infrastructure/PayPalPaymentNotificationVerifierTest.php
@@ -26,7 +26,7 @@ class PayPalPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase 
 	const CURRENCY_EUR = 'EUR';
 	const RECURRING_NO_PAYMENT = 'recurring_payment_suspended_due_to_max_failed_payment';
 
-	public function testReceiverAddressMismatches_verifierThrowsException() {
+	public function testReceiverAddressMismatches_verifierThrowsException(): void {
 		$this->expectException( PayPalPaymentNotificationVerifierException::class );
 
 		$this->newVerifier( new Client() )->verify( [
@@ -35,20 +35,20 @@ class PayPalPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase 
 		] );
 	}
 
-	public function testReceiverAddressNotGiven_verifierThrowsException() {
+	public function testReceiverAddressNotGiven_verifierThrowsException(): void {
 		$this->expectException( PayPalPaymentNotificationVerifierException::class );
 
 		$this->newVerifier( new Client() )->verify( [] );
 	}
 
-	public function testPaymentStatusNotGiven_verifierThrowsException() {
+	public function testPaymentStatusNotGiven_verifierThrowsException(): void {
 		$this->expectException( PayPalPaymentNotificationVerifierException::class );
 		$this->newVerifier( new Client() )->verify( [
 			'receiver_email' => self::VALID_ACCOUNT_EMAIL
 		] );
 	}
 
-	public function testPaymentStatusNotConfirmable_verifierThrowsException() {
+	public function testPaymentStatusNotConfirmable_verifierThrowsException(): void {
 		$this->expectException( PayPalPaymentNotificationVerifierException::class );
 		$this->newVerifier( new Client() )->verify( [
 			'receiver_email' => self::VALID_ACCOUNT_EMAIL,
@@ -56,7 +56,7 @@ class PayPalPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase 
 		] );
 	}
 
-	public function testReassuringReceivedDataSucceeds_verifierDoesNotThrowException() {
+	public function testReassuringReceivedDataSucceeds_verifierDoesNotThrowException(): void {
 		try {
 			$this->newVerifier( $this->newSucceedingClient() )->verify( $this->newRequest() );
 		} catch ( PayPalPaymentNotificationVerifierException $e ) {
@@ -64,13 +64,13 @@ class PayPalPaymentNotificationVerifierTest extends \PHPUnit\Framework\TestCase 
 		}
 	}
 
-	public function testReassuringReceivedDataFails_verifierThrowsException() {
+	public function testReassuringReceivedDataFails_verifierThrowsException(): void {
 		$this->expectException( PayPalPaymentNotificationVerifierException::class );
 		$verifier = $this->newVerifier( $this->newFailingClient() );
 		$verifier->verify( $this->newRequest() );
 	}
 
-	public function testGivenRecurringPaymentStatusMessage_currencyIsCheckedInDifferentField() {
+	public function testGivenRecurringPaymentStatusMessage_currencyIsCheckedInDifferentField(): void {
 		try {
 			$expectedParams = [
 				'cmd' => '_notify-validate',

--- a/tests/Unit/Infrastructure/PiwikEventsTest.php
+++ b/tests/Unit/Infrastructure/PiwikEventsTest.php
@@ -14,13 +14,13 @@ use WMDE\Fundraising\Frontend\Infrastructure\PiwikEvents;
  */
 class PiwikEventsTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenPassedAnUndefinedCustomVarId_exceptionIsThrown() {
+	public function testWhenPassedAnUndefinedCustomVarId_exceptionIsThrown(): void {
 		$piwikEvents = new PiwikEvents();
 		$this->expectException( \InvalidArgumentException::class );
 		$piwikEvents->triggerSetCustomVariable( 4095, 'an event has no definition', PiwikEvents::SCOPE_PAGE );
 	}
 
-	public function testWhenPassedValidCustomVarId_eventIsAdded() {
+	public function testWhenPassedValidCustomVarId_eventIsAdded(): void {
 		$piwikEvents = new PiwikEvents();
 		$piwikEvents->triggerSetCustomVariable(
 			PiwikEvents::CUSTOM_VARIABLE_PAYMENT_TYPE,
@@ -43,7 +43,7 @@ class PiwikEventsTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testWhenCallingTrackGoal_eventIsAdded() {
+	public function testWhenCallingTrackGoal_eventIsAdded(): void {
 		$piwikEvents = new PiwikEvents();
 		$piwikEvents->triggerTrackGoal( 4 );
 		$this->assertContains(

--- a/tests/Unit/Infrastructure/PiwikVariableCollectorTest.php
+++ b/tests/Unit/Infrastructure/PiwikVariableCollectorTest.php
@@ -27,7 +27,7 @@ class PiwikVariableCollectorTest extends \PHPUnit\Framework\TestCase {
 
 	/** @dataProvider sessionAndDonationDataProvider */
 	public function testVariableCollectorReturnsCorrectEvents( $initialAmount, $initialType, $initialInterval,
-															   $expectedResult ) {
+															   $expectedResult ): void {
 		$sessionData = $this->newSessionData( $initialAmount, $initialType, $initialInterval );
 		$donation = $this->newDonationMock( self::ACTUAL_AMOUNT, self::ACTUAL_TYPE, self::ACTUAL_INTERVAL );
 
@@ -74,7 +74,7 @@ class PiwikVariableCollectorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	private function assertCustomTrackingContainsEvents( array $expectedEvents, array $actualEvents ) {
+	private function assertCustomTrackingContainsEvents( array $expectedEvents, array $actualEvents ): void {
 		foreach ( $expectedEvents as $event ) {
 			$this->assertContains( $event, $actualEvents );
 		}

--- a/tests/Unit/Infrastructure/PiwikVariableCollectorTest.php
+++ b/tests/Unit/Infrastructure/PiwikVariableCollectorTest.php
@@ -26,8 +26,8 @@ class PiwikVariableCollectorTest extends \PHPUnit\Framework\TestCase {
 	const ACTUAL_INTERVAL = 3;
 
 	/** @dataProvider sessionAndDonationDataProvider */
-	public function testVariableCollectorReturnsCorrectEvents( $initialAmount, $initialType, $initialInterval,
-															   $expectedResult ): void {
+	public function testVariableCollectorReturnsCorrectEvents( ?string $initialAmount, ?string $initialType,
+																?string $initialInterval, array $expectedResult ): void {
 		$sessionData = $this->newSessionData( $initialAmount, $initialType, $initialInterval );
 		$donation = $this->newDonationMock( self::ACTUAL_AMOUNT, self::ACTUAL_TYPE, self::ACTUAL_INTERVAL );
 
@@ -35,7 +35,7 @@ class PiwikVariableCollectorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCustomTrackingContainsEvents( $expectedResult, $tracking->getEvents() );
 	}
 
-	public function sessionAndDonationDataProvider() {
+	public function sessionAndDonationDataProvider(): array {
 		return [
 			[
 				self::INITIAL_AMOUNT,
@@ -82,7 +82,7 @@ class PiwikVariableCollectorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( count( $expectedEvents ), $actualEvents );
 	}
 
-	private function newDonationMock( string $amount, string $paymentType, int $paymentInterval ) {
+	private function newDonationMock( string $amount, string $paymentType, int $paymentInterval ): Donation {
 		$amount = Euro::newFromString( $amount );
 
 		$donationMock = $this->getMockBuilder( Donation::class )->disableOriginalConstructor()->getMock();
@@ -92,7 +92,7 @@ class PiwikVariableCollectorTest extends \PHPUnit\Framework\TestCase {
 		return $donationMock;
 	}
 
-	private function newSessionData( $amount, $paymentType, $paymentInterval ) {
+	private function newSessionData( ?string $amount, ?string $paymentType, ?string $paymentInterval ): array {
 		return [
 			'paymentAmount' => $amount,
 			'paymentType' => $paymentType,

--- a/tests/Unit/Infrastructure/RandomTokenGeneratorTest.php
+++ b/tests/Unit/Infrastructure/RandomTokenGeneratorTest.php
@@ -14,26 +14,26 @@ use WMDE\Fundraising\Frontend\Infrastructure\RandomTokenGenerator;
  */
 class RandomTokenGeneratorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGenerateTokenReturnsHexString() {
+	public function testGenerateTokenReturnsHexString(): void {
 		$this->assertTrue( ctype_xdigit(
 			( new RandomTokenGenerator( 10, new \DateInterval( 'PT1H' ) ) )->generateToken()
 		) );
 	}
 
-	public function testGenerateTokenReturnsDifferentStringsOnSuccessiveCalls() {
+	public function testGenerateTokenReturnsDifferentStringsOnSuccessiveCalls(): void {
 		$generator = new RandomTokenGenerator( 10, new \DateInterval( 'PT1H' ) );
 
 		$this->assertNotSame( $generator->generateToken(), $generator->generateToken() );
 	}
 
-	public function testGenerateTokenReturnsDifferentStringsForInitialCalls() {
+	public function testGenerateTokenReturnsDifferentStringsForInitialCalls(): void {
 		$this->assertNotSame(
 			( new RandomTokenGenerator( 10, new \DateInterval( 'PT1H' ) ) )->generateToken(),
 			( new RandomTokenGenerator( 10, new \DateInterval( 'PT1H' ) ) )->generateToken()
 		);
 	}
 
-	public function testGenerateTokenExpiryAddsInterval() {
+	public function testGenerateTokenExpiryAddsInterval(): void {
 		$generator = new RandomTokenGenerator( 10, new \DateInterval( 'PT1H' ) );
 
 		$this->assertGreaterThan(

--- a/tests/Unit/Infrastructure/TrackingDataSelectorTest.php
+++ b/tests/Unit/Infrastructure/TrackingDataSelectorTest.php
@@ -20,7 +20,7 @@ class TrackingDataSelectorTest extends \PHPUnit\Framework\TestCase {
 	 * @param string $expectedResult
 	 * @param string[] $values
 	 */
-	public function testGetPreferredValueReturnsFirstSetElementOrEmptyString( $expectedResult, $values ) {
+	public function testGetPreferredValueReturnsFirstSetElementOrEmptyString( string $expectedResult, $values ): void {
 		$value = TrackingDataSelector::getFirstNonEmptyValue( $values );
 		$this->assertSame( $expectedResult, $value );
 	}
@@ -41,7 +41,7 @@ class TrackingDataSelectorTest extends \PHPUnit\Framework\TestCase {
 	 * @param $campaign
 	 * @param $keyword
 	 */
-	public function testConcatTrackingFromVarCouple( $expectedResult, $campaign, $keyword ) {
+	public function testConcatTrackingFromVarCouple( $expectedResult, $campaign, $keyword ): void {
 		$value = TrackingDataSelector::getFirstNonEmptyValue( [
 			'',
 			'',

--- a/tests/Unit/Infrastructure/TrackingDataSelectorTest.php
+++ b/tests/Unit/Infrastructure/TrackingDataSelectorTest.php
@@ -20,12 +20,12 @@ class TrackingDataSelectorTest extends \PHPUnit\Framework\TestCase {
 	 * @param string $expectedResult
 	 * @param string[] $values
 	 */
-	public function testGetPreferredValueReturnsFirstSetElementOrEmptyString( string $expectedResult, $values ): void {
+	public function testGetPreferredValueReturnsFirstSetElementOrEmptyString( string $expectedResult, array $values ): void {
 		$value = TrackingDataSelector::getFirstNonEmptyValue( $values );
 		$this->assertSame( $expectedResult, $value );
 	}
 
-	public function preferredValueProvider() {
+	public function preferredValueProvider(): array {
 		return [
 			[ 'chocolate', [ 'chocolate', 'hazelnuts', 'campaign/keyword' ] ],
 			[ 'hazelnuts', [ '', 'hazelnuts', 'campaign/keyword' ] ],
@@ -37,11 +37,11 @@ class TrackingDataSelectorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider trackingVarProvider
 	 *
-	 * @param $expectedResult
-	 * @param $campaign
-	 * @param $keyword
+	 * @param $expectedResult string
+	 * @param $campaign string
+	 * @param $keyword string
 	 */
-	public function testConcatTrackingFromVarCouple( $expectedResult, $campaign, $keyword ): void {
+	public function testConcatTrackingFromVarCouple( string $expectedResult, string $campaign, string $keyword ): void {
 		$value = TrackingDataSelector::getFirstNonEmptyValue( [
 			'',
 			'',
@@ -51,7 +51,7 @@ class TrackingDataSelectorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( $expectedResult, $value );
 	}
 
-	public function trackingVarProvider() {
+	public function trackingVarProvider(): array {
 		return [
 			[ 'campaign/keyword', 'campaign', 'keyword' ],
 			[ 'campaign/keyword', 'Campaign', 'Keyword' ],

--- a/tests/Unit/Infrastructure/WordListFileReaderTest.php
+++ b/tests/Unit/Infrastructure/WordListFileReaderTest.php
@@ -43,7 +43,7 @@ class WordListFileReaderTest extends TestCase {
 		$this->assertEquals( [ 'one', 'two', 'three', 'techno' ], $stringList->toArray() );
 	}
 
-	private function getFileFetcherWithContent( array $content ) {
+	private function getFileFetcherWithContent( array $content ): ErrorLoggingFileFetcher {
 		return new ErrorLoggingFileFetcher( new InMemoryFileFetcher( $content ), new NullLogger() );
 	}
 

--- a/tests/Unit/Infrastructure/WordListFileReaderTest.php
+++ b/tests/Unit/Infrastructure/WordListFileReaderTest.php
@@ -12,22 +12,22 @@ use WMDE\Fundraising\Frontend\Infrastructure\WordListFileReader;
 
 class WordListFileReaderTest extends TestCase {
 
-	public function testGivenEmptyString_anEmptyListIsReturned() {
+	public function testGivenEmptyString_anEmptyListIsReturned(): void {
 		$stringList = new WordListFileReader( $this->getFileFetcherWithContent( [ 'empty.txt' => '' ] ), 'empty.txt' );
 		$this->assertSame( [], $stringList->toArray() );
 	}
 
-	public function testGivenEmptyFilename_anEmptyListIsReturned() {
+	public function testGivenEmptyFilename_anEmptyListIsReturned(): void {
 		$stringList = new WordListFileReader( $this->getFileFetcherWithContent( [ 'empty.txt' => '' ] ), '' );
 		$this->assertSame( [], $stringList->toArray() );
 	}
 
-	public function testGivenMissingFile_fileFetchingExceptionIsCaught() {
+	public function testGivenMissingFile_fileFetchingExceptionIsCaught(): void {
 		$stringList = new WordListFileReader( $this->getFileFetcherWithContent( [] ), 'utopia.txt' );
 		$this->assertSame( [], $stringList->toArray() );
 	}
 
-	public function testGivenMultilineFile_eachLineIsReturned() {
+	public function testGivenMultilineFile_eachLineIsReturned(): void {
 		$stringList = new WordListFileReader(
 			$this->getFileFetcherWithContent( [ 'words.txt' => "one\ntwo\nthree\ntechno" ] ),
 			'words.txt'
@@ -35,7 +35,7 @@ class WordListFileReaderTest extends TestCase {
 		$this->assertSame( [ 'one', 'two', 'three', 'techno' ], $stringList->toArray() );
 	}
 
-	public function testGivenFileWithEmptyLinesAndTabs_whitespaceIsStripped() {
+	public function testGivenFileWithEmptyLinesAndTabs_whitespaceIsStripped(): void {
 		$stringList = new WordListFileReader(
 			$this->getFileFetcherWithContent( [ 'words.txt' => "one  \n\ttwo\n\t\tthree\n\n\t\t\ttechno\r\n" ] ),
 			'words.txt'

--- a/tests/Unit/Presentation/AmountFormatterTest.php
+++ b/tests/Unit/Presentation/AmountFormatterTest.php
@@ -15,31 +15,31 @@ use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
  */
 class AmountFormatterTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenGermanLocaleAndFractionalAmount_amountIsFormattedAsGermanString() {
+	public function testGivenGermanLocaleAndFractionalAmount_amountIsFormattedAsGermanString(): void {
 		$formatter = new AmountFormatter( 'de_DE' );
 		$euro = Euro::newFromCents( 2342 );
 		$this->assertEquals( '23,42', $formatter->format( $euro ) );
 	}
 
-	public function testGivenGermanLocaleAndIntegerAmount_amountIsFormattedAsGermanString() {
+	public function testGivenGermanLocaleAndIntegerAmount_amountIsFormattedAsGermanString(): void {
 		$formatter = new AmountFormatter( 'de_DE' );
 		$euro = Euro::newFromInt( 23 );
 		$this->assertEquals( '23,00', $formatter->format( $euro ) );
 	}
 
-	public function testGivenUSLocaleAndFractionalAmount_amountIsFormattedAsUSString() {
+	public function testGivenUSLocaleAndFractionalAmount_amountIsFormattedAsUSString(): void {
 		$formatter = new AmountFormatter( 'en_US' );
 		$euro = Euro::newFromCents( 2342 );
 		$this->assertEquals( '23.42', $formatter->format( $euro ) );
 	}
 
-	public function testGivenUSLocaleAndIntegerAmount_amountIsFormattedAsUSString() {
+	public function testGivenUSLocaleAndIntegerAmount_amountIsFormattedAsUSString(): void {
 		$formatter = new AmountFormatter( 'en_US' );
 		$euro = Euro::newFromInt( 23 );
 		$this->assertEquals( '23.00', $formatter->format( $euro ) );
 	}
 
-	public function testGivenUnknownLocale_exceptionIsThrown() {
+	public function testGivenUnknownLocale_exceptionIsThrown(): void {
 		$formatter = new AmountFormatter( 'foo_bar' );
 		$euro = Euro::newFromInt( 23 );
 

--- a/tests/Unit/Presentation/DonationConfirmationPageSelectorTest.php
+++ b/tests/Unit/Presentation/DonationConfirmationPageSelectorTest.php
@@ -32,7 +32,7 @@ class DonationConfirmationPageSelectorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertNotEmpty( $selector->selectPage()->getPageTitle() );
 	}
 
-	private function newCampaignConfig( array $templates ) {
+	private function newCampaignConfig( array $templates ): array {
 		return [
 			'default' => 'defaultConfirmationPage',
 			'campaigns' => [

--- a/tests/Unit/Presentation/DonationConfirmationPageSelectorTest.php
+++ b/tests/Unit/Presentation/DonationConfirmationPageSelectorTest.php
@@ -12,19 +12,19 @@ use WMDE\Fundraising\Frontend\Presentation\DonationConfirmationPageSelector;
  */
 class DonationConfirmationPageSelectorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenConfigIsEmpty_selectPageReturnsDefaultPageTitle() {
+	public function testWhenConfigIsEmpty_selectPageReturnsDefaultPageTitle(): void {
 		$selector = new DonationConfirmationPageSelector( $this->newCampaignConfig( [] ) );
 		$this->assertSame( '', $selector->selectPage()->getCampaignCode() );
 		$this->assertSame( 'defaultConfirmationPage', $selector->selectPage()->getPageTitle() );
 	}
 
-	public function testWhenConfigContainsOneElement_selectPageReturnsThatElement() {
+	public function testWhenConfigContainsOneElement_selectPageReturnsThatElement(): void {
 		$selector = new DonationConfirmationPageSelector( $this->newCampaignConfig( [ 'ThisIsJustATest.twig' ] ) );
 		$this->assertSame( 'example', $selector->selectPage()->getCampaignCode() );
 		$this->assertSame( 'ThisIsJustATest.twig', $selector->selectPage()->getPageTitle() );
 	}
 
-	public function testWhenConfigContainsSomeElements_selectPageReturnsOne() {
+	public function testWhenConfigContainsSomeElements_selectPageReturnsOne(): void {
 		$selector = new DonationConfirmationPageSelector(
 			$this->newCampaignConfig( [ 'ThisIsJustATest.twig', 'AnotherOne.twig' ] )
 		);

--- a/tests/Unit/Presentation/FilePrefixerTest.php
+++ b/tests/Unit/Presentation/FilePrefixerTest.php
@@ -8,17 +8,17 @@ use WMDE\Fundraising\Frontend\Presentation\FilePrefixer;
 
 class FilePrefixerTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenNoFilePrefixes_fileNameIsNotChanged() {
+	public function testGivenNoFilePrefixes_fileNameIsNotChanged(): void {
 		$prefixer = new FilePrefixer( '' );
 		$this->assertSame( 'wmde.js', $prefixer->prefixFile( 'wmde.js' ) );
 	}
 
-	public function testGivenPrefixes_prefixIsPrependedToFilename() {
+	public function testGivenPrefixes_prefixIsPrependedToFilename(): void {
 		$prefixer = new FilePrefixer( 'badcaffee' );
 		$this->assertSame( 'badcaffee.wmde.js', $prefixer->prefixFile( 'wmde.js' ) );
 	}
 
-	public function testGivenPrefixesWithPath_prefixIsPrependedToFilename() {
+	public function testGivenPrefixesWithPath_prefixIsPrependedToFilename(): void {
 		$prefixer = new FilePrefixer( 'badcaffee' );
 		$this->assertSame( 'res/js/badcaffee.wmde.js', $prefixer->prefixFile( 'res/js/wmde.js' ) );
 	}

--- a/tests/Unit/Presentation/GreetingGeneratorTest.php
+++ b/tests/Unit/Presentation/GreetingGeneratorTest.php
@@ -21,12 +21,12 @@ class GreetingGeneratorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider greetingProvider
 	 */
-	public function testGivenASalutation_specificGreetingIsGenerated( $salutation, $expected ): void {
+	public function testGivenASalutation_specificGreetingIsGenerated( string $salutation, string $expected ): void {
 		$generator = new GreetingGenerator();
 		$this->assertSame( $expected, $generator->createGreeting( 'Nyan', $salutation, '' ) );
 	}
 
-	public function greetingProvider() {
+	public function greetingProvider(): array {
 		return [
 			[ 'Herr', 'Sehr geehrter Herr Nyan,' ],
 			[ 'Frau', 'Sehr geehrte Frau Nyan,' ],
@@ -37,12 +37,12 @@ class GreetingGeneratorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider greetingTitleProvider
 	 */
-	public function testGivenATitle_itIsMentionInGreeting( $salutation, $title, $expected ): void {
+	public function testGivenATitle_itIsMentionInGreeting( string $salutation, string $title, string $expected ): void {
 		$generator = new GreetingGenerator();
 		$this->assertSame( $expected, $generator->createGreeting( 'Nyan', $salutation, $title ) );
 	}
 
-	public function greetingTitleProvider() {
+	public function greetingTitleProvider(): array {
 		return [
 			[ 'Herr', 'Dr.', 'Sehr geehrter Herr Dr. Nyan,' ],
 			[ 'Frau', 'Prof.', 'Sehr geehrte Frau Prof. Nyan,' ],

--- a/tests/Unit/Presentation/GreetingGeneratorTest.php
+++ b/tests/Unit/Presentation/GreetingGeneratorTest.php
@@ -8,12 +8,12 @@ use WMDE\Fundraising\Frontend\Presentation\GreetingGenerator;
 
 class GreetingGeneratorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenNoLastName_neutralGreetingIsGenerated() {
+	public function testGivenNoLastName_neutralGreetingIsGenerated(): void {
 		$generator = new GreetingGenerator();
 		$this->assertSame( 'Sehr geehrte Damen und Herren,', $generator->createGreeting( '', 'Herr', '' ) );
 	}
 
-	public function testGivenNoSalutation_neutralGreetingIsGenerated() {
+	public function testGivenNoSalutation_neutralGreetingIsGenerated(): void {
 		$generator = new GreetingGenerator();
 		$this->assertSame( 'Sehr geehrte Damen und Herren,', $generator->createGreeting( 'Nyan', '', '' ) );
 	}
@@ -21,7 +21,7 @@ class GreetingGeneratorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider greetingProvider
 	 */
-	public function testGivenASalutation_specificGreetingIsGenerated( $salutation, $expected ) {
+	public function testGivenASalutation_specificGreetingIsGenerated( $salutation, $expected ): void {
 		$generator = new GreetingGenerator();
 		$this->assertSame( $expected, $generator->createGreeting( 'Nyan', $salutation, '' ) );
 	}
@@ -37,7 +37,7 @@ class GreetingGeneratorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider greetingTitleProvider
 	 */
-	public function testGivenATitle_itIsMentionInGreeting( $salutation, $title, $expected ) {
+	public function testGivenATitle_itIsMentionInGreeting( $salutation, $title, $expected ): void {
 		$generator = new GreetingGenerator();
 		$this->assertSame( $expected, $generator->createGreeting( 'Nyan', $salutation, $title ) );
 	}

--- a/tests/Unit/Presentation/HonorificsTest.php
+++ b/tests/Unit/Presentation/HonorificsTest.php
@@ -14,7 +14,7 @@ use WMDE\Fundraising\Frontend\Presentation\Honorifics;
  */
 class HonorificsTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGetKeys_returnsOnlyKeys() {
+	public function testGetKeys_returnsOnlyKeys(): void {
 		$honorifics = new Honorifics( [ '' => 'None', 'Dr.' => 'Dr.' ] );
 		$this->assertSame( [ '', 'Dr.' ], $honorifics->getKeys() );
 	}

--- a/tests/Unit/Presentation/TemplateTestCampaignTest.php
+++ b/tests/Unit/Presentation/TemplateTestCampaignTest.php
@@ -15,7 +15,7 @@ use WMDE\Fundraising\Frontend\Presentation\TemplateTestCampaign;
  */
 class TemplateTestCampaignTest extends \PHPUnit\Framework\TestCase {
 
-	public function testConstructorSetsFields() {
+	public function testConstructorSetsFields(): void {
 		$campaign = new TemplateTestCampaign( [
 			'code' => 'FOO',
 			'active' => true,
@@ -48,7 +48,7 @@ class TemplateTestCampaignTest extends \PHPUnit\Framework\TestCase {
 		return new TemplateTestCampaign( array_merge( $campaignTemplate, $campaignData ) );
 	}
 
-	public function testHasStarted() {
+	public function testHasStarted(): void {
 		$startedCampaign = $this->newCampaign( [
 			'startDate' => '2015-01-01 08:00:00',
 			'endDate' => '2115-01-01 08:00:00',
@@ -62,7 +62,7 @@ class TemplateTestCampaignTest extends \PHPUnit\Framework\TestCase {
 
 	}
 
-	public function testHasEnded() {
+	public function testHasEnded(): void {
 		$finishedCampaign = $this->newCampaign( [
 			'startDate' => '2015-01-01 08:00:00',
 			'endDate' => '2015-09-01 08:00:00',
@@ -78,7 +78,7 @@ class TemplateTestCampaignTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider isRunningDataProvider
 	 */
-	public function testIsRunning( bool $expected, array $data ) {
+	public function testIsRunning( bool $expected, array $data ): void {
 		$campaign = $this->newCampaign( $data );
 		$this->assertSame( $expected, $campaign->isRunning() );
 	}

--- a/tests/Unit/Presentation/TemplateTestCampaignTest.php
+++ b/tests/Unit/Presentation/TemplateTestCampaignTest.php
@@ -34,7 +34,7 @@ class TemplateTestCampaignTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( [ 'bar', 'baz' ], $campaign->getTemplates() );
 	}
 
-	private function newCampaign( array $campaignData ) {
+	private function newCampaign( array $campaignData ): TemplateTestCampaign {
 		$campaignTemplate = [
 			'code' => 'FOO',
 			'active' => true,
@@ -83,7 +83,7 @@ class TemplateTestCampaignTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( $expected, $campaign->isRunning() );
 	}
 
-	public function isRunningDataProvider() {
+	public function isRunningDataProvider(): array {
 		return [
 			[
 				true,

--- a/tests/Unit/SimpleTransferCodeGeneratorTest.php
+++ b/tests/Unit/SimpleTransferCodeGeneratorTest.php
@@ -14,7 +14,7 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\SimpleTransferCodeGenerator;
  */
 class SimpleTransferCodeGeneratorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGenerateBankTransferCode_matchesRegex() {
+	public function testGenerateBankTransferCode_matchesRegex(): void {
 		$generator = new SimpleTransferCodeGenerator();
 		$this->assertRegExp( '/W-Q-[A-Z]{6}-[A-Z]/', $generator->generateTransferCode() );
 	}

--- a/tests/Unit/Validation/AllowedValuesValidatorTest.php
+++ b/tests/Unit/Validation/AllowedValuesValidatorTest.php
@@ -14,12 +14,12 @@ use WMDE\Fundraising\Frontend\Validation\AllowedValuesValidator;
  */
 class AllowedValuesValidatorTest extends ValidatorTestCase {
 
-	public function testGivenNoAllowedValues_constructionFails() {
+	public function testGivenNoAllowedValues_constructionFails(): void {
 		$this->expectException( \UnexpectedValueException::class );
 		new AllowedValuesValidator( [] );
 	}
 
-	public function testGivenAllowedValues_theyAreAccepted() {
+	public function testGivenAllowedValues_theyAreAccepted(): void {
 		$validator = new AllowedValuesValidator( ['kittens', 'unicorns'] );
 		$this->assertTrue( $validator->validate( 'kittens' )->isSuccessful() );
 		$this->assertTrue( $validator->validate( 'unicorns' )->isSuccessful() );
@@ -27,7 +27,7 @@ class AllowedValuesValidatorTest extends ValidatorTestCase {
 		$this->assertFalse( $validator->validate( 'dragons' )->isSuccessful() );
 	}
 
-	public function testAllowedValuesAreCheckedStrictly() {
+	public function testAllowedValuesAreCheckedStrictly(): void {
 		$validator = new AllowedValuesValidator( ['1', '2'] );
 		$this->assertTrue( $validator->validate( '1' )->isSuccessful() );
 		$this->assertFalse( $validator->validate( 1 )->isSuccessful() );

--- a/tests/Unit/Validation/AmountPolicyValidatorTest.php
+++ b/tests/Unit/Validation/AmountPolicyValidatorTest.php
@@ -25,7 +25,7 @@ class AmountPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	 * @param float $amount
 	 * @param int $interval
 	 */
-	public function testGivenAmountWithinLimits_validationSucceeds( float $amount, int $interval ) {
+	public function testGivenAmountWithinLimits_validationSucceeds( float $amount, int $interval ): void {
 		$this->assertTrue( $this->newAmountValidator()->validate( $amount, $interval )->isSuccessful() );
 	}
 
@@ -44,7 +44,7 @@ class AmountPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 	 * @param float $amount
 	 * @param int $interval
 	 */
-	public function testGivenAmountTooHigh_validationFails( float $amount, int $interval ) {
+	public function testGivenAmountTooHigh_validationFails( float $amount, int $interval ): void {
 		$this->assertFalse( $this->newAmountValidator()->validate( $amount, $interval )->isSuccessful() );
 	}
 

--- a/tests/Unit/Validation/AmountPolicyValidatorTest.php
+++ b/tests/Unit/Validation/AmountPolicyValidatorTest.php
@@ -29,7 +29,7 @@ class AmountPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $this->newAmountValidator()->validate( $amount, $interval )->isSuccessful() );
 	}
 
-	public function smallAmountProvider() {
+	public function smallAmountProvider(): array {
 		return [
 			[ 750.0, self::INTERVAL_ONCE ],
 			[ 20.0, self::INTERVAL_MONTHLY ],
@@ -48,7 +48,7 @@ class AmountPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertFalse( $this->newAmountValidator()->validate( $amount, $interval )->isSuccessful() );
 	}
 
-	public function offLimitAmountProvider() {
+	public function offLimitAmountProvider(): array {
 		return [
 			[ 1750.0, self::INTERVAL_ONCE ],
 			[ 101.0, self::INTERVAL_MONTHLY ],
@@ -58,7 +58,7 @@ class AmountPolicyValidatorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	private function newAmountValidator() {
+	private function newAmountValidator(): AmountPolicyValidator {
 		return new AmountPolicyValidator( 1000, 1000 );
 	}
 

--- a/tests/Unit/Validation/BankDataValidatorTest.php
+++ b/tests/Unit/Validation/BankDataValidatorTest.php
@@ -22,7 +22,7 @@ class BankDataValidatorTest extends ValidatorTestCase {
 	 * @dataProvider invalidBankDataProvider
 	 */
 	public function testFieldsMissing_validationFails( string $iban, string $bic, string $bankName,
-		string $bankCode, string $account ) {
+		string $bankCode, string $account ): void {
 
 		$bankDataValidator = $this->newBankDataValidator();
 		$bankData = $this->newBankData( $iban, $bic, $bankName, $bankCode, $account );
@@ -63,7 +63,7 @@ class BankDataValidatorTest extends ValidatorTestCase {
 		];
 	}
 
-	public function testAllRequiredFieldsGiven_validationSucceeds() {
+	public function testAllRequiredFieldsGiven_validationSucceeds(): void {
 		$bankDataValidator = $this->newBankDataValidator();
 		$bankData = $this->newBankData( 'DE00123456789012345678', 'SCROUSDBXXX', 'Scrooge Bank', '12345678', '1234567890' );
 		$this->assertTrue( $bankDataValidator->validate( $bankData )->isSuccessful() );

--- a/tests/Unit/Validation/BankDataValidatorTest.php
+++ b/tests/Unit/Validation/BankDataValidatorTest.php
@@ -29,7 +29,7 @@ class BankDataValidatorTest extends ValidatorTestCase {
 		$this->assertFalse( $bankDataValidator->validate( $bankData )->isSuccessful() );
 	}
 
-	public function invalidBankDataProvider() {
+	public function invalidBankDataProvider(): array {
 		return [
 			[
 				'DB00123456789012345678',
@@ -69,7 +69,7 @@ class BankDataValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $bankDataValidator->validate( $bankData )->isSuccessful() );
 	}
 
-	public function validBankDataProvider() {
+	public function validBankDataProvider(): array {
 		return [
 			[
 				'DB00123456789012345678',
@@ -97,7 +97,7 @@ class BankDataValidatorTest extends ValidatorTestCase {
 			->setAccount( $account );
 	}
 
-	private function newBankDataValidator() {
+	private function newBankDataValidator(): BankDataValidator {
 		$ibanValidatorMock = $this->getMockBuilder( IbanValidator::class )->disableOriginalConstructor()->getMock();
 		$ibanValidatorMock->method( 'validate' )
 			->willReturn( new ValidationResult() );

--- a/tests/Unit/Validation/DonorAddressValidatorTest.php
+++ b/tests/Unit/Validation/DonorAddressValidatorTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\Unit\Validation\ValidatorTestCase;
  */
 class DonorAddressValidatorTest extends ValidatorTestCase {
 
-	public function testGivenValidAddress_validatorReturnsTrue_andConstraintViolationsAreEmpty() {
+	public function testGivenValidAddress_validatorReturnsTrue_andConstraintViolationsAreEmpty(): void {
 		$validator = new DonorAddressValidator();
 		$physicalAddress = new DonorAddress();
 		$physicalAddress->setStreetAddress( 'Stiftstr. 50' );
@@ -28,12 +28,12 @@ class DonorAddressValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $validator->validate( $physicalAddress )->isSuccessful() );
 	}
 
-	public function testGivenEmptyAddress_validatorReturnsFalse() {
+	public function testGivenEmptyAddress_validatorReturnsFalse(): void {
 		$validator = new DonorAddressValidator();
 		$this->assertFalse( $validator->validate( new DonorAddress() )->isSuccessful() );
 	}
 
-	public function testGivenEmptyAddress_violationsContainsRequiredFieldNames() {
+	public function testGivenEmptyAddress_violationsContainsRequiredFieldNames(): void {
 		$validator = new DonorAddressValidator();
 		$result = $validator->validate( new DonorAddress() );
 

--- a/tests/Unit/Validation/DonorNameValidatorTest.php
+++ b/tests/Unit/Validation/DonorNameValidatorTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\Tests\Unit\Validation\ValidatorTestCase;
  */
 class DonorNameValidatorTest extends ValidatorTestCase {
 
-	public function testGivenValidPersonName_validationSucceeds() {
+	public function testGivenValidPersonName_validationSucceeds(): void {
 		$validator = new DonorNameValidator();
 		$personName = DonorName::newPrivatePersonName();
 		$personName->setSalutation( 'Mr.' );
@@ -27,7 +27,7 @@ class DonorNameValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $validator->validate( $personName )->isSuccessful() );
 	}
 
-	public function testGivenEmptyPersonName_validationFails() {
+	public function testGivenEmptyPersonName_validationFails(): void {
 		$validator = new DonorNameValidator();
 		$personName = DonorName::newPrivatePersonName();
 
@@ -37,7 +37,7 @@ class DonorNameValidatorTest extends ValidatorTestCase {
 		$this->assertConstraintWasViolated( $result, 'lastName' );
 	}
 
-	public function testGivenValidCompanyName_validationSucceeds() {
+	public function testGivenValidCompanyName_validationSucceeds(): void {
 		$validator = new DonorNameValidator();
 		$personName = DonorName::newCompanyName();
 		$personName->setCompanyName( 'Globex Corp.' );
@@ -45,7 +45,7 @@ class DonorNameValidatorTest extends ValidatorTestCase {
 		$this->assertTrue( $validator->validate( $personName )->isSuccessful() );
 	}
 
-	public function testGivenEmptyCompanyName_validationFails() {
+	public function testGivenEmptyCompanyName_validationFails(): void {
 		$validator = new DonorNameValidator();
 
 		$this->assertConstraintWasViolated(

--- a/tests/Unit/Validation/IbanValidatorTest.php
+++ b/tests/Unit/Validation/IbanValidatorTest.php
@@ -38,7 +38,7 @@ class IbanValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider validIbanProvider
 	 */
-	public function testGivenValidIban_validateReturnsTrue( string $iban ) {
+	public function testGivenValidIban_validateReturnsTrue( string $iban ): void {
 		$validator = $this->newValidator();
 		$this->assertTrue( $validator->validate( new Iban( $iban ) )->isSuccessful() );
 	}
@@ -58,7 +58,7 @@ class IbanValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider wellFormedInvalidIbanProvider
 	 */
-	public function testGivenWellFormedButInvalidIban_validateReturnsFalse( $iban ) {
+	public function testGivenWellFormedButInvalidIban_validateReturnsFalse( $iban ): void {
 		$validator = $this->newValidator();
 		$this->assertFalse( $validator->validate( new Iban( $iban ) )->isSuccessful() );
 	}
@@ -75,12 +75,12 @@ class IbanValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider notWellFormedIbanProvider
 	 */
-	public function testGivenNotWellFormedIban_validateReturnsFalse( $iban ) {
+	public function testGivenNotWellFormedIban_validateReturnsFalse( $iban ): void {
 		$validator = $this->newValidator();
 		$this->assertFalse( $validator->validate( new Iban( $iban ) )->isSuccessful() );
 	}
 
-	public function testGivenBannedIban_validateReturnsFalse() {
+	public function testGivenBannedIban_validateReturnsFalse(): void {
 		$validator = $this->newValidator( [ 'DE33100205000001194700' ] );
 		$this->assertFalse( $validator->validate( new Iban( 'DE33100205000001194700' ) )->isSuccessful() );
 	}

--- a/tests/Unit/Validation/IbanValidatorTest.php
+++ b/tests/Unit/Validation/IbanValidatorTest.php
@@ -19,11 +19,11 @@ use WMDE\Fundraising\Frontend\Validation\IbanValidator;
  */
 class IbanValidatorTest extends \PHPUnit\Framework\TestCase {
 
-	private function newValidator( array $bannedIbans = [] ) {
+	private function newValidator( array $bannedIbans = [] ): IbanValidator {
 		return new IbanValidator( new BankDataConverter( 'res/blz.lut2f' ), $bannedIbans );
 	}
 
-	public function validIbanProvider() {
+	public function validIbanProvider(): array {
 		return [
 			[ 'DE89370400440532013000' ],
 			[ 'AT611904300234573201' ],
@@ -43,7 +43,7 @@ class IbanValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $validator->validate( new Iban( $iban ) )->isSuccessful() );
 	}
 
-	public function wellFormedInvalidIbanProvider() {
+	public function wellFormedInvalidIbanProvider(): array {
 		return [
 			[ 'DE01234567890123456789' ],
 			[ 'AT012345678901234567' ],
@@ -58,12 +58,12 @@ class IbanValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider wellFormedInvalidIbanProvider
 	 */
-	public function testGivenWellFormedButInvalidIban_validateReturnsFalse( $iban ): void {
+	public function testGivenWellFormedButInvalidIban_validateReturnsFalse( string $iban ): void {
 		$validator = $this->newValidator();
 		$this->assertFalse( $validator->validate( new Iban( $iban ) )->isSuccessful() );
 	}
 
-	public function notWellFormedIbanProvider() {
+	public function notWellFormedIbanProvider(): array {
 		return [
 			[ 'DE0123456789012345678' ],
 			[ 'DE012345678901234567890' ],
@@ -75,7 +75,7 @@ class IbanValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider notWellFormedIbanProvider
 	 */
-	public function testGivenNotWellFormedIban_validateReturnsFalse( $iban ): void {
+	public function testGivenNotWellFormedIban_validateReturnsFalse( string $iban ): void {
 		$validator = $this->newValidator();
 		$this->assertFalse( $validator->validate( new Iban( $iban ) )->isSuccessful() );
 	}

--- a/tests/Unit/Validation/MembershipFeeValidatorTest.php
+++ b/tests/Unit/Validation/MembershipFeeValidatorTest.php
@@ -18,7 +18,7 @@ use WMDE\Fundraising\Frontend\Validation\MembershipFeeValidator;
  */
 class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenValidRequest_validationSucceeds() {
+	public function testGivenValidRequest_validationSucceeds(): void {
 		$validRequest = $this->newValidRequest();
 		$response = $this->newValidator()->validate(
 			$validRequest->getPaymentAmountInEuros(),
@@ -42,7 +42,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider invalidAmountProvider
 	 */
-	public function testGivenInvalidAmount_validationFails( string $amount, int $intervalInMonths, string $expectedViolation ) {
+	public function testGivenInvalidAmount_validationFails( string $amount, int $intervalInMonths, string $expectedViolation ): void {
 		$request = $this->newValidRequestWithPaymentAmount( $amount, $intervalInMonths );
 
 		$response = $this->newValidator()->validate(
@@ -80,7 +80,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider validAmountProvider
 	 */
-	public function testGivenValidAmount_validationSucceeds( string $amount, int $intervalInMonths ) {
+	public function testGivenValidAmount_validationSucceeds( string $amount, int $intervalInMonths ): void {
 		$request = $this->newValidRequestWithPaymentAmount( $amount, $intervalInMonths );
 
 		$this->assertTrue(
@@ -101,7 +101,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	public function testGivenValidCompanyAmount_validationSucceeds() {
+	public function testGivenValidCompanyAmount_validationSucceeds(): void {
 		$request = $this->newValidRequestWithPaymentAmount( '100.00', 12 );
 		$request->markApplicantAsCompany();
 
@@ -112,7 +112,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenInvalidCompanyAmount_validationFails() {
+	public function testGivenInvalidCompanyAmount_validationFails(): void {
 		$request = $this->newValidRequestWithPaymentAmount( '99.99', 12 );
 		$request->markApplicantAsCompany();
 

--- a/tests/Unit/Validation/MembershipFeeValidatorTest.php
+++ b/tests/Unit/Validation/MembershipFeeValidatorTest.php
@@ -31,7 +31,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $response->isSuccessful() );
 	}
 
-	private function newValidator() {
+	private function newValidator(): MembershipFeeValidator {
 		return new MembershipFeeValidator();
 	}
 
@@ -56,7 +56,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( $expectedViolation, $response->getViolationType( Result::SOURCE_PAYMENT_AMOUNT ) );
 	}
 
-	public function invalidAmountProvider() {
+	public function invalidAmountProvider(): array {
 		return [
 			'invalid: negative' => [ '-1.00', 3, Result::VIOLATION_NOT_MONEY ],
 			'invalid' => [ 'y u no btc', 3, Result::VIOLATION_NOT_MONEY ],
@@ -70,7 +70,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		];
 	}
 
-	private function newValidRequestWithPaymentAmount( string $amount, int $intervalInMonths ) {
+	private function newValidRequestWithPaymentAmount( string $amount, int $intervalInMonths ): ApplyForMembershipRequest {
 		$request = $this->newValidRequest();
 		$request->setPaymentAmountInEuros( $amount );
 		$request->setPaymentIntervalInMonths( $intervalInMonths );
@@ -90,7 +90,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function validAmountProvider() {
+	public function validAmountProvider(): array {
 		return [
 			'single payment' => [ '50.00', 12 ],
 			'just enough single payment' => [ '24.00', 12 ],
@@ -123,7 +123,7 @@ class MembershipFeeValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	private function getRequestAddressType( ApplyForMembershipRequest $request ) {
+	private function getRequestAddressType( ApplyForMembershipRequest $request ): string {
 		return $request->isCompanyApplication() ? 'firma' : 'person';
 	}
 

--- a/tests/Unit/Validation/PaymentDataValidatorTest.php
+++ b/tests/Unit/Validation/PaymentDataValidatorTest.php
@@ -20,74 +20,74 @@ class PaymentDataValidatorTest extends \PHPUnit\Framework\TestCase {
 	const MIN_DONATION_AMOUNT = 1;
 	const MAX_DONATION_AMOUNT = 100000;
 
-	public function testGivenAmountWithinLimits_validationSucceeds() {
+	public function testGivenAmountWithinLimits_validationSucceeds(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertTrue( $validator->validate( 50, 'UEB' )->isSuccessful() );
 	}
 
-	public function testGivenAmountTooLow_validationFails() {
+	public function testGivenAmountTooLow_validationFails(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( 0.2, 'UEB' )->isSuccessful() );
 	}
 
-	public function testGivenAmountTooHigh_validationFails() {
+	public function testGivenAmountTooHigh_validationFails(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( 100000, 'UEB' )->isSuccessful() );
 	}
 
-	public function testGivenAmountIsNotANumber_validationFails() {
+	public function testGivenAmountIsNotANumber_validationFails(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( 'much money', 'UEB' )->isSuccessful() );
 	}
 
-	public function testGivenPaymentTypeSpecificLimits_differentPaymentTypeUsesMainLimit() {
+	public function testGivenPaymentTypeSpecificLimits_differentPaymentTypeUsesMainLimit(): void {
 		$validator = new PaymentDataValidator( 1, 100000, [ 'UEB', 'BEZ', 'PPL' ], [ 'BEZ' => 100, 'PPL' => 200 ] );
 		$this->assertTrue( $validator->validate( 50, 'UEB' )->isSuccessful() );
 	}
 
-	public function testGivenPaymentWithTypeSpecificLimits_specificLimitIsUsed() {
+	public function testGivenPaymentWithTypeSpecificLimits_specificLimitIsUsed(): void {
 		$validator = new PaymentDataValidator( 10, 100000, [ 'UEB', 'BEZ', 'PPL' ], [ 'BEZ' => 50, 'UEB' => 100 ] );
 
 		$this->assertTrue( $validator->validate( 60, 'BEZ' )->isSuccessful() );
 		$this->assertFalse( $validator->validate( 40, 'BEZ' )->isSuccessful() );
 	}
 
-	public function testNumberEqualToBoundIsAllowed() {
+	public function testNumberEqualToBoundIsAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertTrue( $validator->validate( 1, 'UEB' )->isSuccessful() );
 	}
 
-	public function testStringNotationBelowLowerBoundIsNotAllowed() {
+	public function testStringNotationBelowLowerBoundIsNotAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( '0.1', 'UEB' )->isSuccessful() );
 	}
 
-	public function testStringNotationAboveLowerBoundIsAllowed() {
+	public function testStringNotationAboveLowerBoundIsAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertTrue( $validator->validate( '1.1', 'UEB' )->isSuccessful() );
 	}
 
-	public function testNumberEqualToUpperBoundIsNotAllowed() {
+	public function testNumberEqualToUpperBoundIsNotAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( 100000, 'UEB' )->isSuccessful() );
 	}
 
-	public function testStringNotationAboveUpperBoundIsNotAllowed() {
+	public function testStringNotationAboveUpperBoundIsNotAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( '123456.78', 'UEB' )->isSuccessful() );
 	}
 
-	public function testStringNotationBelowUpperBoundIsAllowed() {
+	public function testStringNotationBelowUpperBoundIsAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertTrue( $validator->validate( '99999.99', 'UEB' )->isSuccessful() );
 	}
 
-	public function testBinaryNotationIsNotAllowed() {
+	public function testBinaryNotationIsNotAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( '0b10100111001', 'UEB' )->isSuccessful() );
 	}
 
-	public function testUnknownPaymentMethodsAreNotAllowed() {
+	public function testUnknownPaymentMethodsAreNotAllowed(): void {
 		$validator = $this->newPaymentValidator();
 		$this->assertFalse( $validator->validate( 99, 'DOGE' )->isSuccessful() );
 	}
@@ -100,7 +100,7 @@ class PaymentDataValidatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testGivenEuroAmountWithinLimits_validationSucceeds() {
+	public function testGivenEuroAmountWithinLimits_validationSucceeds(): void {
 		$this->assertTrue(
 			$this->newPaymentValidator()->validate(
 				Euro::newFromInt( 50 ),

--- a/tests/Unit/Validation/SubscriptionDuplicateValidatorTest.php
+++ b/tests/Unit/Validation/SubscriptionDuplicateValidatorTest.php
@@ -16,7 +16,7 @@ use WMDE\Fundraising\Frontend\SubscriptionContext\Validation\SubscriptionDuplica
  */
 class SubscriptionDuplicateValidatorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testGivenSubscriptionCountOfZero_validationSucceeds() {
+	public function testGivenSubscriptionCountOfZero_validationSucceeds(): void {
 		$repository = $this->createMock( SubscriptionRepository::class );
 		$repository->method( 'countSimilar' )->willReturn( 0 );
 
@@ -26,7 +26,7 @@ class SubscriptionDuplicateValidatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue( $validator->validate( new Subscription() )->isSuccessful() );
 	}
 
-	public function testGivenSubscriptionCountGreaterThanZero_validationFails() {
+	public function testGivenSubscriptionCountGreaterThanZero_validationFails(): void {
 		$repository = $this->createMock( SubscriptionRepository::class );
 		$repository->method( 'countSimilar' )->willReturn( 1 );
 

--- a/tests/Unit/Validation/TemplateNameValidatorTest.php
+++ b/tests/Unit/Validation/TemplateNameValidatorTest.php
@@ -10,13 +10,13 @@ use WMDE\Fundraising\Frontend\Validation\TemplateNameValidator;
 
 class TemplateNameValidatorTest extends \PHPUnit\Framework\TestCase {
 
-	public function testWhenEnvironmentThrowsNoException_validationSuccceeds() {
+	public function testWhenEnvironmentThrowsNoException_validationSuccceeds(): void {
 		$twig = $this->getMockBuilder( Twig_Environment::class )->disableOriginalConstructor()->getMock();
 		$validator = new TemplateNameValidator( $twig );
 		$this->assertTrue( $validator->validate( 'Unicorns' )->isSuccessful() );
 	}
 
-	public function testWhenEnvironmentThrowsLoadException_validationFails() {
+	public function testWhenEnvironmentThrowsLoadException_validationFails(): void {
 		$twig = $this->getMockBuilder( Twig_Environment::class )->disableOriginalConstructor()->getMock();
 		$twig->method( 'loadTemplate' )->willThrowException( new Twig_Error_Loader( 'That template was not found' ) );
 		$validator = new TemplateNameValidator( $twig );

--- a/tests/Unit/Validation/ValidatorTestCase.php
+++ b/tests/Unit/Validation/ValidatorTestCase.php
@@ -13,7 +13,7 @@ use WMDE\Fundraising\Frontend\Validation\ValidationResult;
  */
 class ValidatorTestCase extends \PHPUnit\Framework\TestCase {
 
-	protected function assertConstraintWasViolated( ValidationResult $result, string $fieldName ) {
+	protected function assertConstraintWasViolated( ValidationResult $result, string $fieldName ): void {
 		$this->assertContainsOnlyInstancesOf( ConstraintViolation::class, $result->getViolations() );
 		$this->assertTrue( $result->hasViolations() );
 


### PR DESCRIPTION
* Using PHP type hints for parameters and return values instead of phpdoc 
* removing phpdoc in case it contains only information readily available from the actual hints
* making sure these rules are obeyed on every phpcs run

I like all but the last commit (246514b). What is your opinion how we should deal with cases where there is no clean/easy answer? I am in favor of ignoring these for the moment an fixing them when we touch them the next time.

Using trusty [slevomat sniffs](https://github.com/slevomat/coding-standard#slevomatcodingstandardtypehintstypehintdeclaration-).

[Custom configuration](https://github.com/wmde/FundraisingFrontend/compare/type-hint-doc?expand=1#diff-6b216d983cf0a62e9c648934c5687456R135)

Was 344 violations before changes.