### PR TITLE
T167882 Sofort notification + mail

### DIFF
--- a/app/MailTemplates.php
+++ b/app/MailTemplates.php
@@ -92,6 +92,13 @@ class MailTemplates {
 							'interval' => 0,
 						]
 					],
+					'sofort_unmoderated_non_recurring' => [
+						'donation' => [
+							'paymentType' => 'SUB',
+							'interval' => 0,
+							'status' => 'Z'
+						]
+					],
 					// PPL and MCP follow the same code path for recurring, no need to test each separately
 					'micropayment_unmoderated_recurring' => [
 						'donation' => [

--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -98,7 +98,8 @@ class AddDonationHandler {
 						$responseModel->getDonation()->getId(),
 						$responseModel->getDonation()->getPayment()->getPaymentMethod()->getBankTransferCode(),
 						$responseModel->getDonation()->getAmount(),
-						$responseModel->getAccessToken()
+						$responseModel->getAccessToken(),
+						$responseModel->getUpdateToken()
 					)
 				);
 				break;

--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -98,8 +98,8 @@ class AddDonationHandler {
 						$responseModel->getDonation()->getId(),
 						$responseModel->getDonation()->getPayment()->getPaymentMethod()->getBankTransferCode(),
 						$responseModel->getDonation()->getAmount(),
-						$responseModel->getAccessToken(),
-						$responseModel->getUpdateToken()
+						$responseModel->getUpdateToken(),
+						$responseModel->getAccessToken()
 					)
 				);
 				break;

--- a/app/RouteHandlers/SofortNotificationHandler.php
+++ b/app/RouteHandlers/SofortNotificationHandler.php
@@ -37,15 +37,17 @@ class SofortNotificationHandler {
 	}
 
 	private function newUseCaseRequestFromRequest( Request $request ): SofortNotificationRequest {
-		$usecaseRequest = new SofortNotificationRequest();
-		$usecaseRequest->setDonationId( $request->query->getInt( 'id' ) );
-		$usecaseRequest->setTransactionId( $request->request->get( 'transaction', '' ) );
+		$useCaseRequest = new SofortNotificationRequest();
+		$useCaseRequest->setDonationId( $request->query->getInt( 'id' ) );
+		$useCaseRequest->setTransactionId( $request->request->get( 'transaction', '' ) );
+
 		$time = DateTime::createFromFormat( DateTime::ATOM, $request->request->get( 'time', '' ) );
+
 		if ( $time instanceof DateTime ) {
-			$usecaseRequest->setTime( $time );
+			$useCaseRequest->setTime( $time );
 		}
 
-		return $usecaseRequest;
+		return $useCaseRequest;
 	}
 
 	private function logResponseIfNeeded( SofortNotificationResponse $response, Request $request ) {

--- a/app/RouteHandlers/SofortNotificationHandler.php
+++ b/app/RouteHandlers/SofortNotificationHandler.php
@@ -1,0 +1,87 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App\RouteHandlers;
+
+use Psr\Log\LogLevel;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use WMDE\Euro\Euro;
+use WMDE\Fundraising\Frontend\PaymentContext\ResponseModel\PaypalNotificationResponse;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+use WMDE\Fundraising\Frontend\Infrastructure\PayPalPaymentNotificationVerifierException;
+use WMDE\Fundraising\Frontend\PaymentContext\RequestModel\SofortPaymentNotificationRequest;
+use DateTime;
+
+class SofortNotificationHandler {
+
+	private $ffFactory;
+
+	public function __construct( FunFunFactory $ffFactory ) {
+		$this->ffFactory = $ffFactory;
+	}
+
+	public function handle( Request $request ): Response {
+		$post = $request->request;
+
+		try {
+			$this->ffFactory->getPayPalPaymentNotificationVerifier()->verify( $post->all() );
+		} catch ( PayPalPaymentNotificationVerifierException $e ) {
+			$this->ffFactory->getPaypalLogger()->log( LogLevel::ERROR, $e->getMessage(), [
+				'post_vars' => $request->request->all()
+			] );
+			return $this->createErrorResponse( $e );
+		}
+
+		$useCase = $this->ffFactory->newHandlePayPalPaymentNotificationUseCase( $this->getUpdateToken( $post ) );
+
+		$response = $useCase->handleNotification( $this->newUseCaseRequestFromPost( $post ) );
+		$this->logResponseIfNeeded( $response, $request );
+
+		return new Response( '', Response::HTTP_OK ); # PayPal expects an empty response
+	}
+
+	private function getUpdateToken( ParameterBag $postRequest ): string {
+		return $this->getValueFromCustomVars( $postRequest->get( 'custom', '' ), 'utoken' );
+	}
+
+	private function getValueFromCustomVars( string $customVars, string $key ): string {
+		$vars = json_decode( $customVars, true );
+		return !empty( $vars[$key] ) ? $vars[$key] : '';
+	}
+
+	private function newUseCaseRequestFromPost( ParameterBag $postRequest ): SofortPaymentNotificationRequest {
+		return ( new SofortPaymentNotificationRequest() )
+			->setTransactionId( $postRequest->get( 'transaction', '' ) )
+			->setTime( new DateTime( $postRequest->get( 'time', '' ) ) );
+	}
+
+	private function createErrorResponse( PayPalPaymentNotificationVerifierException $e ): Response {
+		switch ( $e->getCode() ) {
+			case PayPalPaymentNotificationVerifierException::ERROR_WRONG_RECEIVER:
+				return new Response( $e->getMessage(), Response::HTTP_FORBIDDEN );
+			case PayPalPaymentNotificationVerifierException::ERROR_VERIFICATION_FAILED:
+				return new Response( $e->getMessage(), Response::HTTP_FORBIDDEN );
+			case PayPalPaymentNotificationVerifierException::ERROR_UNSUPPORTED_CURRENCY:
+				return new Response( $e->getMessage(), Response::HTTP_NOT_ACCEPTABLE );
+			default:
+				return new Response( $e->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR );
+		}
+	}
+
+	private function logResponseIfNeeded( PaypalNotificationResponse $response, Request $request ) {
+		if ( $response->notificationWasHandled() ) {
+			return;
+		}
+
+		$context = $response->getContext();
+		$message = $context['message'] ?? 'Paypal request not handled';
+		$logLevel = $response->hasErrors() ? LogLevel::ERROR : LogLevel::INFO;
+		unset( $context['message'] );
+		$context['post_vars'] = $request->request->all();
+		$this->ffFactory->getPaypalLogger()->log( $logLevel, $message, $context );
+	}
+
+}

--- a/app/RouteHandlers/SofortNotificationHandler.php
+++ b/app/RouteHandlers/SofortNotificationHandler.php
@@ -28,12 +28,12 @@ class SofortNotificationHandler {
 		$this->logResponseIfNeeded( $response, $request );
 
 		if ( !$response->notificationWasHandled() ) {
-			return new Response( '', Response::HTTP_BAD_REQUEST );
+			return new Response( 'Bad request', Response::HTTP_BAD_REQUEST );
 		} elseif ( $response->hasErrors() ) {
-			return new Response( '', Response::HTTP_INTERNAL_SERVER_ERROR );
+			return new Response( 'Error', Response::HTTP_INTERNAL_SERVER_ERROR );
 		}
 
-		return new Response( '', Response::HTTP_OK );
+		return new Response( 'Ok', Response::HTTP_OK );
 	}
 
 	private function newUseCaseRequestFromRequest( Request $request ): SofortNotificationRequest {
@@ -54,10 +54,14 @@ class SofortNotificationHandler {
 		}
 
 		$context = $response->getContext();
-		$message = $context['message'] ?? 'Sofort request not handled';
+
 		$logLevel = $response->hasErrors() ? LogLevel::ERROR : LogLevel::INFO;
+
+		$message = $context['message'] ?? 'Sofort request not handled';
 		unset( $context['message'] );
-		$context['post_vars'] = array_merge( $request->query->all(), $request->request->all() );
+
+		$context['post_vars'] = $request->request->all();
+		$context['query_vars'] = $request->query->all();
 		$this->ffFactory->getSofortLogger()->log( $logLevel, $message, $context );
 	}
 

--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -122,7 +122,8 @@
 	"sofort": {
 		"config-key": "",
 		"return-url": "",
-		"cancel-url": ""
+		"cancel-url": "",
+		"notification-url": ""
 	},
 	"confirmation-pages": {
 		"default": "Donation_Confirmation.html.twig",

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -63,7 +63,8 @@
 	"sofort": {
 		"config-key": "fff:ggg:hhh:iii",
 		"return-url": "http://my.donation.app/show-donation-confirmation",
-		"cancel-url": "http://my.donation.app/donation/cancel"
+		"cancel-url": "http://my.donation.app/donation/cancel",
+		"notification-url": "http://my.donation.app/sofort-payment-notification"
 	},
 	"confirmation-pages": {
 		"default": "DonationConfirmation.twig",

--- a/app/config/config.test.json
+++ b/app/config/config.test.json
@@ -63,7 +63,7 @@
 	"sofort": {
 		"config-key": "fff:ggg:hhh:iii",
 		"return-url": "http://my.donation.app/show-donation-confirmation",
-		"cancel-url": "http://my.donation.app/donation/cancel",
+		"cancel-url": "http://my.donation.app/",
 		"notification-url": "http://my.donation.app/sofort-payment-notification"
 	},
 	"confirmation-pages": {

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -569,12 +569,17 @@
         },
         "return-url": {
           "type": "string",
-          "title": "Return URL",
+          "title": "Return URL - for after successful payment",
           "minLength": 1
         },
         "cancel-url": {
           "type": "string",
-          "title": "Cancel URL",
+          "title": "Cancel URL - for aborted payment",
+          "minLength": 1
+        },
+        "notification-url": {
+          "type": "string",
+          "title": "Notification URL - our endpoint for payment provider API calls",
           "minLength": 1
         }
       },

--- a/app/routes.php
+++ b/app/routes.php
@@ -19,6 +19,7 @@ use WMDE\Fundraising\Frontend\App\RouteHandlers\AddDonationHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\AddSubscriptionHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\ApplyForMembershipHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\PayPalNotificationHandler;
+use WMDE\Fundraising\Frontend\App\RouteHandlers\SofortNotificationHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\PayPalNotificationHandlerForMembershipFee;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\RouteRedirectionHandler;
 use WMDE\Fundraising\Frontend\App\RouteHandlers\ShowDonationConfirmationHandler;
@@ -458,6 +459,13 @@ $app->post(
 	'handle-paypal-payment-notification',
 	function ( Request $request ) use ( $ffFactory ) {
 		return ( new PayPalNotificationHandler( $ffFactory ) )->handle( $request );
+	}
+);
+
+$app->post(
+	'sofort-payment-notification',
+	function ( Request $request ) use ( $ffFactory ) {
+		return ( new SofortNotificationHandler( $ffFactory ) )->handle( $request );
 	}
 );
 

--- a/app/templates/Mail_Donation_Confirmation.txt.twig
+++ b/app/templates/Mail_Donation_Confirmation.txt.twig
@@ -18,7 +18,7 @@
 {$ 'recurringDonation'|transchoice( donation.interval, { '%interval%': donation.interval } ) $}
 {% endif %}
 
-{% elseif donation.paymentType == 'PPL' or donation.paymentType == 'MCP' or donation.paymentType == 'SUB' %}
+{% elseif donation.paymentType == 'PPL' or donation.paymentType == 'MCP' %}
 {$ mail_content('donation_confirmation/paymenttype_external', {
     'formatted_amount': formattedAmount,
     'payment_provider': donation.paymentType|trans({}, 'paymentTypes')
@@ -31,6 +31,13 @@
 {$ mail_content('donation_confirmation/paymenttype_banktransfer', {
     'formatted_amount': formattedAmount,
     'bank_transfer_code': donation.bankTransferCode
+}) $}
+
+{% elseif donation.paymentType == 'SUB' %}
+{$ mail_content('donation_confirmation/paymenttype_sofort', {
+	'formatted_amount': formattedAmount,
+	'payment_provider': donation.paymentType|trans({}, 'paymentTypes'),
+	'payment_status': donation.status|trans({}, 'paymentStatus')
 }) $}
 
 {% endif %}

--- a/composer.lock
+++ b/composer.lock
@@ -5928,7 +5928,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/test"
             },
-            "time": "2017-07-19T00:10:29+00:00"
+            "time": "2017-07-19 00:10:29"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/composer.lock
+++ b/composer.lock
@@ -5891,12 +5891,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content.git",
-                "reference": "2b1eda75ad73a2b34fc00acabd5376300ace6320"
+                "reference": "87d1fd9d920eca5275c39a67af2acc575a82e32d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/2b1eda75ad73a2b34fc00acabd5376300ace6320",
-                "reference": "2b1eda75ad73a2b34fc00acabd5376300ace6320",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/87d1fd9d920eca5275c39a67af2acc575a82e32d",
+                "reference": "87d1fd9d920eca5275c39a67af2acc575a82e32d",
                 "shasum": ""
             },
             "require-dev": {
@@ -5928,7 +5928,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/test"
             },
-            "time": "2017-07-19 00:10:29"
+            "time": "2017-07-17T16:14:30+00:00"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/composer.lock
+++ b/composer.lock
@@ -5928,7 +5928,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/test"
             },
-            "time": "2017-07-19 00:10:29"
+            "time": "2017-07-19T00:10:29+00:00"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/composer.lock
+++ b/composer.lock
@@ -5891,12 +5891,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content.git",
-                "reference": "87d1fd9d920eca5275c39a67af2acc575a82e32d"
+                "reference": "2b1eda75ad73a2b34fc00acabd5376300ace6320"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/87d1fd9d920eca5275c39a67af2acc575a82e32d",
-                "reference": "87d1fd9d920eca5275c39a67af2acc575a82e32d",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/2b1eda75ad73a2b34fc00acabd5376300ace6320",
+                "reference": "2b1eda75ad73a2b34fc00acabd5376300ace6320",
                 "shasum": ""
             },
             "require-dev": {
@@ -5928,7 +5928,7 @@
             "support": {
                 "source": "https://github.com/wmde/fundraising-frontend-content/tree/test"
             },
-            "time": "2017-07-17T16:14:30+00:00"
+            "time": "2017-07-19T00:10:29+00:00"
         },
         {
             "name": "wmde/psr-log-test-doubles",

--- a/contexts/DonationContext/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\DonationContext\UseCases\SofortPaymentNotification;
 
+use DateTime;
 use RuntimeException;
 use WMDE\Fundraising\Frontend\DonationContext\Authorization\DonationAuthorizer;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;
@@ -55,8 +56,12 @@ class SofortPaymentNotificationUseCase {
 		if ( $paymentMethod->isConfirmedPayment() ) {
 			return $this->createUnhandledResponse( 'Duplicate notification' );
 		}
+		$confirmedTime = $request->getTime();
+		if ( !( $confirmedTime instanceof DateTime ) ) {
+			return $this->createUnhandledResponse( 'Bad notification time' );
+		}
 
-		$paymentMethod->setConfirmedAt( $request->getTime() );
+		$paymentMethod->setConfirmedAt( $confirmedTime );
 
 		try {
 			$this->repository->storeDonation( $donation );

--- a/contexts/DonationContext/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
+++ b/contexts/DonationContext/src/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCase.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\DonationContext\UseCases\SofortPaymentNotification;
+
+use WMDE\Fundraising\Frontend\DonationContext\Authorization\DonationAuthorizer;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\DonationRepository;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\GetDonationException;
+use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\StoreDonationException;
+use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationConfirmationMailer;
+use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationEventLogger;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\SofortPayment;
+use WMDE\Fundraising\Frontend\PaymentContext\ResponseModel\SofortNotificationResponse;
+use WMDE\Fundraising\Frontend\PaymentContext\RequestModel\SofortNotificationRequest;
+
+class SofortPaymentNotificationUseCase {
+
+	private $repository;
+	private $authorizationService;
+	private $mailer;
+	private $donationEventLogger;
+
+	public function __construct( DonationRepository $repository, DonationAuthorizer $authorizationService,
+								 DonationConfirmationMailer $mailer, DonationEventLogger $donationEventLogger ) {
+		$this->repository = $repository;
+		$this->authorizationService = $authorizationService;
+		$this->mailer = $mailer;
+		$this->donationEventLogger = $donationEventLogger;
+	}
+
+	public function handleNotification( SofortNotificationRequest $request ): SofortNotificationResponse {
+
+		try {
+			$donation = $this->repository->getDonationById( $request->getDonationId() );
+		} catch ( GetDonationException $ex ) {
+			return $this->createErrorResponse( $ex );
+		}
+
+		if ( $donation === null ) {
+			return $this->createErrorResponse( new \Exception( 'Donation not found' ) );
+		}
+
+		return $this->handleRequestForDonation( $request, $donation );
+	}
+
+	private function handleRequestForDonation( SofortNotificationRequest $request, Donation $donation ): SofortNotificationResponse {
+		$paymentMethod = $donation->getPayment()->getPaymentMethod();
+
+		if ( !( $paymentMethod instanceof SofortPayment ) ) {
+			return $this->createUnhandledResponse( 'Trying to handle notification for non-sofort donation' );
+		}
+		if ( !$this->authorizationService->systemCanModifyDonation( $request->getDonationId() ) ) {
+			return $this->createUnhandledResponse( 'Wrong access code for donation' );
+		}
+
+		$paymentMethod->setConfirmedAt( $request->getTime() );
+
+		// todo ?
+		//$donation->confirmBooked();
+
+		try {
+			$this->repository->storeDonation( $donation );
+		}
+		catch ( StoreDonationException $ex ) {
+			return $this->createErrorResponse( $ex );
+		}
+
+		$this->sendConfirmationEmailFor( $donation );
+		$this->donationEventLogger->log( $donation->getId(), 'sofort_handler: booked' );
+
+		return SofortNotificationResponse::newSuccessResponse();
+	}
+
+	private function createUnhandledResponse( string $reason ): SofortNotificationResponse {
+		return SofortNotificationResponse::newUnhandledResponse( [
+			'message' => $reason
+		] );
+	}
+
+	private function sendConfirmationEmailFor( Donation $donation ): void {
+		if ( $donation->getDonor() !== null ) {
+			try {
+				$this->mailer->sendConfirmationMailFor( $donation );
+			} catch ( \RuntimeException $ex ) {
+				// no need to re-throw or return false, this is not a fatal error, only a minor inconvenience
+			}
+		}
+	}
+
+	private function createErrorResponse( \Exception $ex ): SofortNotificationResponse {
+		return SofortNotificationResponse::newFailureResponse( [
+			'message' => $ex->getMessage(),
+			'stackTrace' => $ex->getTraceAsString()
+		] );
+	}
+
+}

--- a/contexts/DonationContext/tests/Data/ValidDonation.php
+++ b/contexts/DonationContext/tests/Data/ValidDonation.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Data;
 
+use DateTime;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\Donation;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Model\DonationComment;
@@ -71,6 +72,8 @@ class ValidDonation {
 	public const COMMENT_IS_PUBLIC = true;
 	public const COMMENT_AUTHOR_DISPLAY_NAME = 'Such a tomato';
 
+	public const SOFORT_DONATION_CONFIRMED_AT = '-1 hour';
+
 	public static function newBankTransferDonation(): Donation {
 		return ( new self() )->createDonation(
 			new BankTransferPayment( self::PAYMENT_BANK_TRANSFER_CODE ),
@@ -112,6 +115,15 @@ class ValidDonation {
 	public static function newIncompleteSofortDonation(): Donation {
 		return ( new self() )->createDonation(
 			new SofortPayment( self::PAYMENT_BANK_TRANSFER_CODE ),
+			Donation::STATUS_PROMISE
+		);
+	}
+
+	public static function newCompletedSofortDonation(): Donation {
+		$payment = new SofortPayment( self::PAYMENT_BANK_TRANSFER_CODE );
+		$payment->setConfirmedAt( new DateTime( self::SOFORT_DONATION_CONFIRMED_AT ) );
+		return ( new self() )->createDonation(
+			$payment,
 			Donation::STATUS_PROMISE
 		);
 	}

--- a/contexts/DonationContext/tests/Data/ValidDonation.php
+++ b/contexts/DonationContext/tests/Data/ValidDonation.php
@@ -109,6 +109,13 @@ class ValidDonation {
 		);
 	}
 
+	public static function newIncompleteSofortDonation(): Donation {
+		return ( new self() )->createDonation(
+			new SofortPayment( self::PAYMENT_BANK_TRANSFER_CODE ),
+			Donation::STATUS_PROMISE
+		);
+	}
+
 	public static function newIncompleteAnonymousPayPalDonation(): Donation {
 		return ( new self() )->createAnonymousDonation(
 			new PayPalPayment( new PayPalData() ),

--- a/contexts/DonationContext/tests/Data/ValidSofortNotificationRequest.php
+++ b/contexts/DonationContext/tests/Data/ValidSofortNotificationRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Data;
+
+use DateTime;
+use WMDE\Fundraising\Frontend\PaymentContext\RequestModel\SofortNotificationRequest;
+
+class ValidSofortNotificationRequest {
+
+	public static function newInstantPayment( int $internalDonationId = 1 ): SofortNotificationRequest {
+		$request = new SofortNotificationRequest();
+		$request->setDonationId( $internalDonationId );
+		$request->setTime( new DateTime() );
+		$request->setTransactionId( 'fff-ggg-hhh' );
+
+		return $request;
+	}
+}

--- a/contexts/DonationContext/tests/Integration/DonationEventLoggerAsserter.php
+++ b/contexts/DonationContext/tests/Integration/DonationEventLoggerAsserter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Integration;
+
+use PHPUnit\Framework\Assert;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\DonationEventLoggerSpy;
+
+trait DonationEventLoggerAsserter {
+	public function assertEventLogContainsExpression( DonationEventLoggerSpy $eventLoggerSpy, int $donationId, string $expr ): void {
+		Assert::assertCount(
+			1,
+			array_filter( $eventLoggerSpy->getLogCalls(), function( $call ) use ( $donationId, $expr ) {
+				return $call[0] == $donationId && preg_match( $expr, $call[1] );
+			} ),
+			'Failed to assert that donation event log contained "' . $expr . '" for donation id '. $donationId
+		);
+	}
+}

--- a/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Integration\UseCases\CreditCardPaymentNotification;
 
 use Psr\Log\NullLogger;
+use PHPUnit\Framework\TestCase;
 use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\DonationContext\DataAccess\DoctrineDonationRepository;
 use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationConfirmationMailer;
@@ -14,6 +15,7 @@ use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\DonationRepositoryS
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\FailingDonationAuthorizer;
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\FakeDonationRepository;
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\SucceedingDonationAuthorizer;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Integration\DonationEventLoggerAsserter;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardNotificationUseCase;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardPaymentHandlerException;
 use WMDE\Fundraising\Frontend\MembershipContext\Tests\Data\ValidCreditCardNotificationRequest;
@@ -22,12 +24,14 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\FakeCreditCardService;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\ThrowingEntityManager;
 
 /**
- * @covers WMDE\Fundraising\Frontend\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardNotificationUseCase
+ * @covers \WMDE\Fundraising\Frontend\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardNotificationUseCase
  *
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
+class CreditCardNotificationUseCaseTest extends TestCase {
+
+	use DonationEventLoggerAsserter;
 
 	/** @var DoctrineDonationRepository|FakeDonationRepository|DonationRepositorySpy */
 	private $repository;
@@ -170,14 +174,6 @@ class CreditCardNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
 		} catch ( \Exception $e ) {
 			$this->fail();
 		}
-	}
-
-	private function assertEventLogContainsExpression( DonationEventLoggerSpy $eventLoggerSpy, int $donationId, string $expr ): void {
-		$foundCalls = array_filter( $eventLoggerSpy->getLogCalls(), function( $call ) use ( $donationId, $expr ) {
-			return $call[0] == $donationId && preg_match( $expr, $call[1] );
-		} );
-		$assertMsg = 'Failed to assert that donation event log log contained "' . $expr . '" for donation id '.$donationId;
-		$this->assertCount( 1, $foundCalls, $assertMsg );
 	}
 
 	/**

--- a/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/CreditCardPaymentNotification/CreditCardNotificationUseCaseTest.php
@@ -102,8 +102,8 @@ class CreditCardNotificationUseCaseTest extends TestCase {
 		$this->repository->storeDonation( $donation );
 
 		$this->mailer->expects( $this->once() )
-			->method( 'sendConfirmationMailFor' );
-			// TODO: assert that the correct values are passed to the mailer
+			->method( 'sendConfirmationMailFor' )
+			->with( $donation );
 
 		$useCase = $this->newCreditCardNotificationUseCase();
 

--- a/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
@@ -123,8 +123,8 @@ class HandlePayPalPaymentNotificationUseCaseTest extends TestCase {
 
 		$mailer = $this->getMailer();
 		$mailer->expects( $this->once() )
-			->method( 'sendConfirmationMailFor' );
-			// TODO: assert that the correct values are passed to the mailer
+			->method( 'sendConfirmationMailFor' )
+			->with( $donation );
 
 		$useCase = new HandlePayPalPaymentNotificationUseCase(
 			$fakeRepository,

--- a/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/HandlePayPalPaymentNotification/HandlePayPalPaymentNotificationUseCaseTest.php
@@ -15,19 +15,23 @@ use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\DonationRepositoryS
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\FailingDonationAuthorizer;
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\FakeDonationRepository;
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\SucceedingDonationAuthorizer;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Integration\DonationEventLoggerAsserter;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\HandlePayPalPaymentNotification\HandlePayPalPaymentNotificationUseCase;
 use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\PayPalData;
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Data\ValidDonation;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\ThrowingEntityManager;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @covers WMDE\Fundraising\Frontend\DonationContext\UseCases\HandlePayPalPaymentNotification\HandlePayPalPaymentNotificationUseCase
+ * @covers \WMDE\Fundraising\Frontend\DonationContext\UseCases\HandlePayPalPaymentNotification\HandlePayPalPaymentNotificationUseCase
  *
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >
  */
-class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\TestCase {
+class HandlePayPalPaymentNotificationUseCaseTest extends TestCase {
+
+	use DonationEventLoggerAsserter;
 
 	public function testWhenRepositoryThrowsException_errorResponseIsReturned(): void {
 		$useCase = new HandlePayPalPaymentNotificationUseCase(
@@ -443,14 +447,6 @@ class HandlePayPalPaymentNotificationUseCaseTest extends \PHPUnit\Framework\Test
 		/** @var PayPalData $paypalData */
 		$paypalData = $payment->getPaymentMethod()->getPaypalData();
 		$this->assertSame( ValidPayPalNotificationRequest::PAYER_ADDRESS_NAME, $paypalData->getAddressName() );
-	}
-
-	private function assertEventLogContainsExpression( DonationEventLoggerSpy $eventLoggerSpy, int $donationId, string $expr ): void {
-		$foundCalls = array_filter( $eventLoggerSpy->getLogCalls(), function( $call ) use ( $donationId, $expr ) {
-			return $call[0] == $donationId && preg_match( $expr, $call[1] );
-		} );
-		$assertMsg = 'Failed to assert that donation event log log contained "' . $expr . '" for donation id '.$donationId;
-		$this->assertCount( 1, $foundCalls, $assertMsg );
 	}
 
 	/**

--- a/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Integration\UseCases\SofortPaymentNotification;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \WMDE\Fundraising\Frontend\DonationContext\UseCases\SofortPaymentNotification\SofortPaymentNotificationUseCase
+ */
+class SofortPaymentNotificationUseCaseTest extends TestCase {
+
+	public function testWhenRepositoryThrowsException_errorResponseIsReturned(): void {
+
+	}
+
+	public function testWhenAuthorizationFails_unhandledResponseIsReturned(): void {
+
+	}
+
+	public function testWhenAuthorizationSucceeds_successResponseIsReturned(): void {
+
+	}
+
+	public function testWhenAuthorizationSucceeds_donationIsStored(): void {
+
+	}
+
+	public function testWhenAuthorizationSucceeds_bookingEventIsLogged(): void {
+
+	}
+
+	public function testWhenPaymentTypeIsNonSofort_unhandledResponseIsReturned(): void {
+
+	}
+
+	public function testWhenAuthorizationSucceeds_confirmationMailIsSent(): void {
+
+	}
+
+	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent(): void {
+
+	}
+
+	public function testWhenSendingConfirmationMailFails_handlerReturnsTrue(): void {
+
+	}
+
+	public function testGivenExistingTransactionIdForBookedDonation_handlerReturnsFalse(): void {
+
+	}
+
+	public function testWhenNotificationIsForNonExistingDonation_newDonationIsCreated(): void {
+
+	}
+
+	public function testWhenNotificationIsForNonExistingDonation_confirmationMailIsSent(): void {
+
+	}
+
+	public function testWhenNotificationIsForNonExistingDonation_bookingEventIsLogged(): void {
+
+	}
+}

--- a/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
@@ -26,7 +26,7 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 	public function testWhenRepositoryThrowsException_errorResponseIsReturned(): void {
 		$useCase = new SofortPaymentNotificationUseCase(
 			new DoctrineDonationRepository( ThrowingEntityManager::newInstance( $this ) ),
-			new FailingDonationAuthorizer(),
+			new SucceedingDonationAuthorizer(),
 			$this->getMailer()
 		);
 
@@ -47,7 +47,7 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 	public function testWhenNotificationIsForNonExistingDonation_unhandledResponseIsReturned(): void {
 		$useCase = new SofortPaymentNotificationUseCase(
 			new FakeDonationRepository(),
-			new FailingDonationAuthorizer(),
+			new SucceedingDonationAuthorizer(),
 			$this->getMailer()
 		);
 

--- a/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
@@ -173,13 +173,10 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( ValidDonation::newCompletedSofortDonation() );
 
-		$eventLogger = new DonationEventLoggerSpy();
-
 		$useCase = new SofortPaymentNotificationUseCase(
 			$fakeRepository,
 			new SucceedingDonationAuthorizer(),
-			$this->getMailer(),
-			$eventLogger
+			$this->getMailer()
 		);
 
 		$request = ValidSofortNotificationRequest::newInstantPayment();
@@ -195,13 +192,10 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 		$fakeRepository = new FakeDonationRepository();
 		$fakeRepository->storeDonation( ValidDonation::newIncompleteSofortDonation() );
 
-		$eventLogger = new DonationEventLoggerSpy();
-
 		$useCase = new SofortPaymentNotificationUseCase(
 			$fakeRepository,
 			new SucceedingDonationAuthorizer(),
-			$this->getMailer(),
-			$eventLogger
+			$this->getMailer()
 		);
 
 		$request = new SofortNotificationRequest();

--- a/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
@@ -134,14 +134,7 @@ class SofortPaymentNotificationUseCaseTest extends TestCase {
 		$mailer
 			->expects( $this->once() )
 			->method( 'sendConfirmationMailFor' )
-			->with( $this->callback( function ( Donation $value ) use ( $donation ) {
-				$this->assertSame( $donation->getId(), $value->getId() );
-				$this->assertEquals( $donation->getDonor(), $value->getDonor() );
-				$this->assertEquals( $donation->getPayment()->getAmount(), $value->getPayment()->getAmount() );
-				$this->assertSame( $donation->getPayment()->getIntervalInMonths(), $value->getPayment()->getIntervalInMonths() );
-				$this->assertSame( $donation->getPaymentType(), $value->getPaymentType() );
-				return true;
-			} ) );
+			->with( $donation );
 
 		$useCase = new SofortPaymentNotificationUseCase(
 			$fakeRepository,

--- a/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
+++ b/contexts/DonationContext/tests/Integration/UseCases/SofortPaymentNotification/SofortPaymentNotificationUseCaseTest.php
@@ -5,61 +5,197 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\DonationContext\Tests\Integration\UseCases\SofortPaymentNotification;
 
 use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\Entities\Donation;
+use WMDE\Fundraising\Frontend\DonationContext\DataAccess\DoctrineDonationRepository;
+use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationConfirmationMailer;
+use WMDE\Fundraising\Frontend\DonationContext\Infrastructure\DonationEventLogger;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\DonationEventLoggerSpy;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\DonationRepositorySpy;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\FailingDonationAuthorizer;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\FakeDonationRepository;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Fixtures\SucceedingDonationAuthorizer;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Integration\DonationEventLoggerAsserter;
+use WMDE\Fundraising\Frontend\DonationContext\UseCases\SofortPaymentNotification\SofortPaymentNotificationUseCase;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\ThrowingEntityManager;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Data\ValidDonation;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Data\ValidSofortNotificationRequest;
 
 /**
  * @covers \WMDE\Fundraising\Frontend\DonationContext\UseCases\SofortPaymentNotification\SofortPaymentNotificationUseCase
  */
 class SofortPaymentNotificationUseCaseTest extends TestCase {
 
-	public function testWhenRepositoryThrowsException_errorResponseIsReturned(): void {
+	use DonationEventLoggerAsserter;
 
+	public function testWhenRepositoryThrowsException_errorResponseIsReturned(): void {
+		$useCase = new SofortPaymentNotificationUseCase(
+			new DoctrineDonationRepository( ThrowingEntityManager::newInstance( $this ) ),
+			new FailingDonationAuthorizer(),
+			$this->getMailer(),
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$reponse = $useCase->handleNotification( $request );
+		$this->assertFalse( $reponse->notificationWasHandled() );
+		$this->assertTrue( $reponse->hasErrors() );
+	}
+
+	public function testWhenNotificationIsForNonExistingDonation_unhandledResponseIsReturned(): void {
+		$useCase = new SofortPaymentNotificationUseCase(
+			new FakeDonationRepository(),
+			new FailingDonationAuthorizer(),
+			$this->getMailer(),
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment( 4711 );
+
+		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
 	public function testWhenAuthorizationFails_unhandledResponseIsReturned(): void {
+		$fakeRepository = new FakeDonationRepository();
+		$fakeRepository->storeDonation( ValidDonation::newIncompleteSofortDonation() );
 
+		$useCase = new SofortPaymentNotificationUseCase(
+			$fakeRepository,
+			new FailingDonationAuthorizer(),
+			$this->getMailer(),
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
 	public function testWhenAuthorizationSucceeds_successResponseIsReturned(): void {
+		$fakeRepository = new FakeDonationRepository();
+		$fakeRepository->storeDonation( ValidDonation::newIncompleteSofortDonation() );
 
+		$useCase = new SofortPaymentNotificationUseCase(
+			$fakeRepository,
+			new SucceedingDonationAuthorizer(),
+			$this->getMailer(),
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
 	public function testWhenAuthorizationSucceeds_donationIsStored(): void {
+		$repositorySpy = new DonationRepositorySpy( ValidDonation::newIncompleteSofortDonation() );
 
+		$useCase = new SofortPaymentNotificationUseCase(
+			$repositorySpy,
+			new SucceedingDonationAuthorizer(),
+			$this->getMailer(),
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
+		$this->assertCount( 1, $repositorySpy->getStoreDonationCalls() );
 	}
 
-	public function testWhenAuthorizationSucceeds_bookingEventIsLogged(): void {
+	public function testWhenAuthorizationSucceeds_donationIsStillPromised(): void {
+		$donation = ValidDonation::newIncompleteSofortDonation();
+		$repository = new FakeDonationRepository( $donation );
 
+		$useCase = new SofortPaymentNotificationUseCase(
+			$repository,
+			new SucceedingDonationAuthorizer(),
+			$this->getMailer(),
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
+		$this->assertSame( Donation::STATUS_PROMISE, $repository->getDonationById( $donation->getId() )->getStatus() );
+	}
+
+
+	public function testWhenAuthorizationSucceeds_bookingEventIsLogged(): void {
+		$donation = ValidDonation::newIncompleteSofortDonation();
+		$repositorySpy = new DonationRepositorySpy( $donation );
+
+		$eventLogger = new DonationEventLoggerSpy();
+
+		$useCase = new SofortPaymentNotificationUseCase(
+			$repositorySpy,
+			new SucceedingDonationAuthorizer(),
+			$this->getMailer(),
+			$eventLogger
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
+		$this->assertEventLogContainsExpression( $eventLogger, $donation->getId(), '/booked/' );
 	}
 
 	public function testWhenPaymentTypeIsNonSofort_unhandledResponseIsReturned(): void {
+		$fakeRepository = new FakeDonationRepository();
+		$fakeRepository->storeDonation( ValidDonation::newDirectDebitDonation() );
 
+		$useCase = new SofortPaymentNotificationUseCase(
+			$fakeRepository,
+			new SucceedingDonationAuthorizer(),
+			$this->getMailer(),
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$this->assertFalse( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
 	public function testWhenAuthorizationSucceeds_confirmationMailIsSent(): void {
-
-	}
-
-	public function testWhenAuthorizationSucceedsForAnonymousDonation_confirmationMailIsNotSent(): void {
-
+		$this->markTestIncomplete( 'Do we send mail on notification or when creating the donation? Given notification means little.' );
 	}
 
 	public function testWhenSendingConfirmationMailFails_handlerReturnsTrue(): void {
+		$fakeRepository = new FakeDonationRepository();
+		$fakeRepository->storeDonation( ValidDonation::newIncompleteSofortDonation() );
 
+		$mailer = $this->getMailer();
+		$mailer->expects( $this->once() )
+			->method( 'sendConfirmationMailFor' )
+			->willThrowException( new \RuntimeException( 'Oh noes!' ) );
+
+		$useCase = new SofortPaymentNotificationUseCase(
+			$fakeRepository,
+			new SucceedingDonationAuthorizer(),
+			$mailer,
+			$this->getEventLogger()
+		);
+
+		$request = ValidSofortNotificationRequest::newInstantPayment();
+
+		$this->assertTrue( $useCase->handleNotification( $request )->notificationWasHandled() );
 	}
 
 	public function testGivenExistingTransactionIdForBookedDonation_handlerReturnsFalse(): void {
-
+		$this->markTestIncomplete( 'What do we do if donation payment has "createdAt" information already?' );
 	}
 
-	public function testWhenNotificationIsForNonExistingDonation_newDonationIsCreated(): void {
-
+	/**
+	 * @return DonationConfirmationMailer|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getMailer(): DonationConfirmationMailer {
+		return $this->getMockBuilder( DonationConfirmationMailer::class )->disableOriginalConstructor()->getMock();
 	}
 
-	public function testWhenNotificationIsForNonExistingDonation_confirmationMailIsSent(): void {
-
-	}
-
-	public function testWhenNotificationIsForNonExistingDonation_bookingEventIsLogged(): void {
-
+	/**
+	 * @return DonationEventLogger|\PHPUnit_Framework_MockObject_MockObject
+	 */
+	private function getEventLogger(): DonationEventLogger {
+		return $this->createMock( DonationEventLogger::class );
 	}
 }

--- a/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
@@ -36,4 +36,8 @@ class SofortPayment implements PaymentMethod {
 	public function setConfirmedAt( ?DateTime $confirmedAt ): void {
 		$this->confirmedAt = $confirmedAt;
 	}
+
+	public function isConfirmedPayment(): bool {
+		return !is_null( $this->getConfirmedAt() );
+	}
 }

--- a/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
+++ b/contexts/PaymentContext/src/Domain/Model/SofortPayment.php
@@ -4,9 +4,18 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\PaymentContext\Domain\Model;
 
+use DateTime;
+
 class SofortPayment implements PaymentMethod {
 
-	private $bankTransferCode;
+	/**
+	 * @var string
+	 */
+	private $bankTransferCode = '';
+	/**
+	 * @var DateTime|null
+	 */
+	private $confirmedAt;
 
 	public function __construct( string $bankTransferCode ) {
 		$this->bankTransferCode = $bankTransferCode;
@@ -18,5 +27,13 @@ class SofortPayment implements PaymentMethod {
 
 	public function getBankTransferCode(): string {
 		return $this->bankTransferCode;
+	}
+
+	public function getConfirmedAt(): ?DateTime {
+		return $this->confirmedAt;
+	}
+
+	public function setConfirmedAt( ?DateTime $confirmedAt ): void {
+		$this->confirmedAt = $confirmedAt;
 	}
 }

--- a/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/Sofort.php
+++ b/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/Sofort.php
@@ -36,11 +36,11 @@ class Sofort {
 	 * @param int $internalItemId Internal (WMDE-use only) Id of the item to pay
 	 * @param string $externalItemId External (3rd parties may use to reference the item with this) Id of the item to pay
 	 * @param Euro $amount The amount of money to pay
-	 * @param string $accessToken A token to use to return to the payment process after completing the 3rd party process
 	 * @param string $updateToken A token to use to invoke our API to change payment details at a later point in time
+	 * @param string $accessToken A token to use to return to the payment process after completing the 3rd party process
 	 * @return string
 	 */
-	public function generateUrl( int $internalItemId, string $externalItemId, Euro $amount, string $accessToken, string $updateToken ): string {
+	public function generateUrl( int $internalItemId, string $externalItemId, Euro $amount, string $updateToken, string $accessToken ): string {
 		$request = new Request();
 		$request->setAmount( $amount );
 		$request->setCurrencyCode( self::CURRENCY );

--- a/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/Sofort.php
+++ b/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/Sofort.php
@@ -36,10 +36,11 @@ class Sofort {
 	 * @param int $internalItemId Internal (WMDE-use only) Id of the item to pay
 	 * @param string $externalItemId External (3rd parties may use to reference the item with this) Id of the item to pay
 	 * @param Euro $amount The amount of money to pay
-	 * @param string $accessToken A token to return to the payment process after completing the 3rd party process
+	 * @param string $accessToken A token to use to return to the payment process after completing the 3rd party process
+	 * @param string $updateToken A token to use to invoke our API to change payment details at a later point in time
 	 * @return string
 	 */
-	public function generateUrl( int $internalItemId, string $externalItemId, Euro $amount, string $accessToken ): string {
+	public function generateUrl( int $internalItemId, string $externalItemId, Euro $amount, string $accessToken, string $updateToken ): string {
 		$request = new Request();
 		$request->setAmount( $amount );
 		$request->setCurrencyCode( self::CURRENCY );
@@ -51,8 +52,12 @@ class Sofort {
 			] )
 		);
 		$request->setAbortUrl( $this->config->getCancelUrl() );
-		// @todo To use in T167882
-		$request->setNotificationUrl( '' );
+		$request->setNotificationUrl(
+			$this->config->getNotificationUrl() . '?' . http_build_query( [
+				'id' => $internalItemId,
+				'updateToken' => $updateToken
+			] )
+		);
 
 		try {
 			$response = $this->client->get( $request );

--- a/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/SofortConfig.php
+++ b/contexts/PaymentContext/src/Domain/PaymentUrlGenerator/SofortConfig.php
@@ -18,11 +18,16 @@ class SofortConfig {
 	 * @var string
 	 */
 	private $cancelUrl;
+	/**
+	 * @var string
+	 */
+	private $notificationUrl;
 
-	public function __construct( string $reasonText, string $returnUrl, string $cancelUrl ) {
+	public function __construct( string $reasonText, string $returnUrl, string $cancelUrl, string $notificationUrl ) {
 		$this->reasonText = $reasonText;
 		$this->returnUrl = $returnUrl;
 		$this->cancelUrl = $cancelUrl;
+		$this->notificationUrl = $notificationUrl;
 	}
 
 	public function getReasonText(): string {
@@ -35,5 +40,9 @@ class SofortConfig {
 
 	public function getCancelUrl(): string {
 		return $this->cancelUrl;
+	}
+
+	public function getNotificationUrl(): string {
+		return $this->notificationUrl;
 	}
 }

--- a/contexts/PaymentContext/src/RequestModel/SofortNotificationRequest.php
+++ b/contexts/PaymentContext/src/RequestModel/SofortNotificationRequest.php
@@ -21,7 +21,7 @@ class SofortNotificationRequest {
 	 */
 	private $time;
 
-	public function getDonationId(): int {
+	public function getDonationId(): ?int {
 		return $this->donationId;
 	}
 
@@ -30,7 +30,7 @@ class SofortNotificationRequest {
 		return $this;
 	}
 
-	public function getTransactionId(): string {
+	public function getTransactionId(): ?string {
 		return $this->transactionId;
 	}
 
@@ -39,7 +39,7 @@ class SofortNotificationRequest {
 		return $this;
 	}
 
-	public function getTime(): DateTime {
+	public function getTime(): ?DateTime {
 		return $this->time;
 	}
 

--- a/contexts/PaymentContext/src/RequestModel/SofortNotificationRequest.php
+++ b/contexts/PaymentContext/src/RequestModel/SofortNotificationRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\PaymentContext\RequestModel;
+
+use DateTime;
+
+class SofortNotificationRequest {
+
+	/**
+	 * @var int
+	 */
+	private $donationId;
+	/**
+	 * @var string
+	 */
+	private $transactionId;
+	/**
+	 * @var DateTime
+	 */
+	private $time;
+
+	public function getDonationId(): int {
+		return $this->donationId;
+	}
+
+	public function setDonationId( int $donationId ): self {
+		$this->donationId = $donationId;
+		return $this;
+	}
+
+	public function getTransactionId(): string {
+		return $this->transactionId;
+	}
+
+	public function setTransactionId( string $transactionId ): self {
+		$this->transactionId = $transactionId;
+		return $this;
+	}
+
+	public function getTime(): DateTime {
+		return $this->time;
+	}
+
+	public function setTime( DateTime $time ): self {
+		$this->time = $time;
+		return $this;
+	}
+}

--- a/contexts/PaymentContext/src/ResponseModel/SofortNotificationResponse.php
+++ b/contexts/PaymentContext/src/ResponseModel/SofortNotificationResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\PaymentContext\ResponseModel;
+
+class SofortNotificationResponse {
+
+	private $wasHandled;
+	private $notificationFailed;
+	private $handlingContext;
+
+	private function __construct( bool $notificationWasHandled, bool $isError, array $handlingContext = [] ) {
+		$this->wasHandled = $notificationWasHandled;
+		$this->notificationFailed = $isError;
+		$this->handlingContext = $handlingContext;
+	}
+
+	public static function newSuccessResponse(): self {
+		return new self( true, false );
+	}
+
+	public static function newUnhandledResponse( array $context ): self {
+		return new self( false, false, $context );
+	}
+
+	public static function newFailureResponse( array $context ): self {
+		return new self( false, true, $context );
+	}
+
+	public function notificationWasHandled(): bool {
+		return $this->wasHandled;
+	}
+
+	public function hasErrors(): bool {
+		return $this->notificationFailed;
+	}
+
+	public function getContext(): array {
+		return $this->handlingContext;
+	}
+
+}

--- a/contexts/PaymentContext/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -10,12 +10,27 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\SofortPayment;
 
 class SofortPaymentTest extends TestCase {
 
-	public function testAccessors(): void {
+	public function testInitialProperties(): void {
 		$sofortPayment = new SofortPayment( 'lorem' );
 		$this->assertSame( 'SUB', $sofortPayment->getType() );
 		$this->assertSame( 'lorem', $sofortPayment->getBankTransferCode() );
 		$this->assertNull( $sofortPayment->getConfirmedAt() );
+	}
+
+	public function testConfirmedAcceptsDateTime(): void {
+		$sofortPayment = new SofortPayment( 'lorem' );
 		$sofortPayment->setConfirmedAt( new DateTime( '2001-12-24T17:30:00Z' ) );
 		$this->assertEquals( new DateTime( '2001-12-24T17:30:00Z' ), $sofortPayment->getConfirmedAt() );
+	}
+
+	public function testIsConfirmedPayment_newPaymentIsNotConfirmed(): void {
+		$sofortPayment = new SofortPayment( 'ipsum' );
+		$this->assertFalse( $sofortPayment->isConfirmedPayment() );
+	}
+
+	public function testIsConfirmedPayment_settingPaymentDateConfirmsPayment(): void {
+		$sofortPayment = new SofortPayment( 'ipsum' );
+		$sofortPayment->setConfirmedAt( new DateTime( 'now' ) );
+		$this->assertTrue( $sofortPayment->isConfirmedPayment() );
 	}
 }

--- a/contexts/PaymentContext/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\PaymentContext\Domain\Model;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use WMDE\Fundraising\Frontend\PaymentContext\Domain\Model\SofortPayment;
+
+class SofortPaymentTest extends TestCase {
+
+	public function testAccessors(): void {
+		$sofortPayment = new SofortPayment( 'lorem' );
+		$this->assertSame( 'SUB', $sofortPayment->getType() );
+		$this->assertSame( 'lorem', $sofortPayment->getBankTransferCode() );
+		$this->assertNull( $sofortPayment->getConfirmedAt() );
+		$sofortPayment->setConfirmedAt( new DateTime( '2001-12-24T17:30:00Z' ) );
+		$this->assertEquals( new DateTime( '2001-12-24T17:30:00Z' ), $sofortPayment->getConfirmedAt() );
+	}
+}

--- a/contexts/PaymentContext/tests/Unit/Domain/Model/SofortPaymentTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/Model/SofortPaymentTest.php
@@ -2,7 +2,7 @@
 
 declare( strict_types = 1 );
 
-namespace WMDE\Fundraising\Frontend\Tests\Unit\PaymentContext\Domain\Model;
+namespace WMDE\Fundraising\Frontend\PaymentContext\Tests\Unit\Domain\Model;
 
 use DateTime;
 use PHPUnit\Framework\TestCase;

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/SofortTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/SofortTest.php
@@ -50,7 +50,7 @@ class SofortTest extends TestCase {
 		$urlGenerator = new SofortUrlGenerator( $config, $client );
 		$this->assertSame(
 			'https://awsomepaymentprovider.tld/784trhhrf4',
-			$urlGenerator->generateUrl( 44, 'wx529836', $amount, 'letmein', 'makesandwich' )
+			$urlGenerator->generateUrl( 44, 'wx529836', $amount, 'makesandwich', 'letmein' )
 		);
 	}
 
@@ -75,6 +75,6 @@ class SofortTest extends TestCase {
 		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( 'Could not generate Sofort URL: boo boo' );
 
-		$urlGenerator->generateUrl( 23, 'dq529837', Euro::newFromCents( 300 ), 'letmein', 'makesandwich' );
+		$urlGenerator->generateUrl( 23, 'dq529837', Euro::newFromCents( 300 ), 'makesandwich', 'letmein' );
 	}
 }

--- a/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/SofortTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/PaymentUrlGenerator/SofortTest.php
@@ -19,7 +19,12 @@ use WMDE\Fundraising\Frontend\PaymentContext\Domain\PaymentUrlGenerator\Sofort a
 class SofortTest extends TestCase {
 
 	public function testWhenClientReturnsSuccessResponseAUrlIsReturned(): void {
-		$config = new SofortUrlConfig( 'Donation', 'https://us.org/yes', 'https://us.org/no' );
+		$config = new SofortUrlConfig(
+			'Donation',
+			'https://us.org/yes',
+			'https://us.org/no',
+			'https://us.org/callback'
+		);
 
 		$amount = Euro::newFromCents( 600 );
 
@@ -29,7 +34,7 @@ class SofortTest extends TestCase {
 		$request->setReasons( [ 'Donation', 'wx529836' ] );
 		$request->setSuccessUrl( 'https://us.org/yes?id=44&accessToken=letmein' );
 		$request->setAbortUrl( 'https://us.org/no' );
-		$request->setNotificationUrl( '' );
+		$request->setNotificationUrl( 'https://us.org/callback?id=44&updateToken=makesandwich' );
 
 		$response = new Response();
 		$response->setTransactionId( '500m1l35' );
@@ -45,12 +50,17 @@ class SofortTest extends TestCase {
 		$urlGenerator = new SofortUrlGenerator( $config, $client );
 		$this->assertSame(
 			'https://awsomepaymentprovider.tld/784trhhrf4',
-			$urlGenerator->generateUrl( 44, 'wx529836', $amount, 'letmein' )
+			$urlGenerator->generateUrl( 44, 'wx529836', $amount, 'letmein', 'makesandwich' )
 		);
 	}
 
 	public function testWhenApiReturnsErrorAnExceptionWithApiErrorMessageIsThrown(): void {
-		$config = new SofortUrlConfig( 'Your purchase', 'https://irreleva.nt', 'http://irreleva.nt' );
+		$config = new SofortUrlConfig(
+			'Your purchase',
+			'https://irreleva.nt/y',
+			'https://irreleva.nt/n',
+			'https://irreleva.nt/api'
+		);
 
 		$client = $this->createMock( Client::class );
 
@@ -65,6 +75,6 @@ class SofortTest extends TestCase {
 		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( 'Could not generate Sofort URL: boo boo' );
 
-		$urlGenerator->generateUrl( 23, 'dq529837', Euro::newFromCents( 300 ), 'letmein' );
+		$urlGenerator->generateUrl( 23, 'dq529837', Euro::newFromCents( 300 ), 'letmein', 'makesandwich' );
 	}
 }

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1168,8 +1168,7 @@ class FunFunFactory {
 		return new SofortPaymentNotificationUseCase(
 			$this->getDonationRepository(),
 			$this->newDonationAuthorizer( $updateToken ),
-			$this->newDonationConfirmationMailer(),
-			$this->newDonationEventLogger()
+			$this->newDonationConfirmationMailer()
 		);
 	}
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -70,6 +70,7 @@ use WMDE\Fundraising\Frontend\DonationContext\UseCases\AddDonation\ReferrerGener
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\CancelDonation\CancelDonationUseCase;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardNotificationUseCase;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\HandlePayPalPaymentNotification\HandlePayPalPaymentNotificationUseCase;
+use WMDE\Fundraising\Frontend\DonationContext\UseCases\SofortPaymentNotification\SofortPaymentNotificationUseCase;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\ListComments\ListCommentsUseCase;
 use WMDE\Fundraising\Frontend\DonationContext\UseCases\ShowDonationConfirmation\ShowDonationConfirmationUseCase;
 use WMDE\Fundraising\Frontend\DonationContext\Validation\DonorAddressValidator;
@@ -193,6 +194,10 @@ class FunFunFactory {
 		};
 
 		$pimple['paypal_logger'] = function() {
+			return new NullLogger();
+		};
+
+		$pimple['sofort_logger'] = function() {
 			return new NullLogger();
 		};
 
@@ -596,6 +601,10 @@ class FunFunFactory {
 
 	public function getPaypalLogger(): LoggerInterface {
 		return $this->pimple['paypal_logger'];
+	}
+
+	public function getSofortLogger(): LoggerInterface {
+		return $this->pimple['sofort_logger'];
 	}
 
 	private function getVarPath(): string {
@@ -1155,6 +1164,15 @@ class FunFunFactory {
 		} ) );
 	}
 
+	public function newHandleSofortPaymentNotificationUseCase( string $updateToken ): SofortPaymentNotificationUseCase {
+		return new SofortPaymentNotificationUseCase(
+			$this->getDonationRepository(),
+			$this->newDonationAuthorizer( $updateToken ),
+			$this->newDonationConfirmationMailer(),
+			$this->newDonationEventLogger()
+		);
+	}
+
 	public function newHandlePayPalPaymentNotificationUseCase( string $updateToken ): HandlePayPalPaymentNotificationUseCase {
 		return new HandlePayPalPaymentNotificationUseCase(
 			$this->getDonationRepository(),
@@ -1353,6 +1371,10 @@ class FunFunFactory {
 
 	public function setPaypalLogger( LoggerInterface $logger ): void {
 		$this->pimple['paypal_logger'] = $logger;
+	}
+
+	public function setSofortLogger( LoggerInterface $logger ): void {
+		$this->pimple['sofort_logger'] = $logger;
 	}
 
 	public function getProfilerDataCollector(): ProfilerDataCollector {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -936,7 +936,8 @@ class FunFunFactory {
 			new SofortConfig(
 				$this->getTranslator()->trans( 'item_name_donation', [], 'messages' ),
 				$config['return-url'],
-				$config['cancel-url']
+				$config['cancel-url'],
+				$config['notification-url']
 			),
 			$this->getSofortClient()
 		);

--- a/tests/Data/GeneratedMailTemplates/Mail_Donation_Confirmation.sofort_unmoderated_non_recurring.txt
+++ b/tests/Data/GeneratedMailTemplates/Mail_Donation_Confirmation.sofort_unmoderated_non_recurring.txt
@@ -1,0 +1,24 @@
+
+Sehr geehrte Frau 姜,
+
+donation_confirmation/intro
+
+donation_confirmation/paymenttype_sofort
+
+donation_confirmation/support
+
+donation_confirmation/greetings
+
+name_head_of_suborganization
+title_head_of_suborganization
+
+---------------------------------------------------------------------------
+wikimedia_vision
+<https://spenden.wikimedia.de/>
+---------------------------------------------------------------------------
+
+address_of_suborganization
+
+tax_id_suborganization_verbose
+
+donation_confirmation/number

--- a/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
@@ -5,19 +5,25 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge\Routes;
 
 use DateTime;
+use Psr\Log\LogLevel;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Client;
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Data\ValidDonation;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\FixedTokenGenerator;
+use WMDE\PsrLogTestDoubles\LoggerSpy;
 
 class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
+
+	private const TOKEN_VALID = 'my-secret_token';
+	private const TOKEN_INVALID = 'fffffggggg';
 
 	public function testGivenWrongPaymentType_applicationRefuses(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator(
-				'my-secret_token',
+				self::TOKEN_VALID,
 				new DateTime( '2039-12-31 23:59:59Z' )
 			) );
 
@@ -26,21 +32,22 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 
 			$client->request(
 				Request::METHOD_POST,
-				'/sofort-payment-notification?id=1&updateToken=my-secret_token',
+				'/sofort-payment-notification?id=1&updateToken=' . self::TOKEN_VALID,
 				[
 					'transaction' => '99999-53245-5483-4891',
 					'time' => '2010-04-14T19:01:08+02:00'
 				]
 			);
 
-			$this->assertSame( 400, $client->getResponse()->getStatusCode() );
+			$this->assertSame( 'Bad request', $client->getResponse()->getContent() );
+			$this->assertSame( Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode() );
 		} );
 	}
 
 	public function testGivenWrongToken_applicationRefuses(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator(
-				'my_secret_token',
+				self::TOKEN_VALID,
 				new DateTime( '2039-12-31 23:59:59Z' )
 			) );
 
@@ -49,21 +56,22 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 
 			$client->request(
 				Request::METHOD_POST,
-				'/sofort-payment-notification?id=1&updateToken=some_bogous',
+				'/sofort-payment-notification?id=1&updateToken=' . self::TOKEN_INVALID,
 				[
 					'transaction' => '99999-53245-5483-4891',
 					'time' => '2010-04-14T19:01:08+02:00'
 				]
 			);
 
-			$this->assertSame( 400, $client->getResponse()->getStatusCode() );
+			$this->assertSame( 'Bad request', $client->getResponse()->getContent() );
+			$this->assertSame( Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode() );
 		} );
 	}
 
 	public function testGivenBadTimeFormat_applicationRefuses(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator(
-				'my_secret_token',
+				self::TOKEN_VALID,
 				new DateTime( '2039-12-31 23:59:59Z' )
 			) );
 
@@ -72,21 +80,22 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 
 			$client->request(
 				Request::METHOD_POST,
-				'/sofort-payment-notification?id=1&updateToken=some_bogous',
+				'/sofort-payment-notification?id=1&updateToken=' . self::TOKEN_INVALID,
 				[
 					'transaction' => '99999-53245-5483-4891',
 					'time' => 'now'
 				]
 			);
 
-			$this->assertSame( 400, $client->getResponse()->getStatusCode() );
+			$this->assertSame( 'Bad request', $client->getResponse()->getContent() );
+			$this->assertSame( Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode() );
 		} );
 	}
 
 	public function testGivenValidRequest_applicationIndicatesSuccess(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
 			$factory->setTokenGenerator( new FixedTokenGenerator(
-				'my_secret-token',
+				self::TOKEN_VALID,
 				new DateTime( '2039-12-31 23:59:59Z' )
 			) );
 
@@ -95,17 +104,108 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 
 			$client->request(
 				Request::METHOD_POST,
-				'/sofort-payment-notification?id=1&updateToken=my_secret-token',
+				'/sofort-payment-notification?id=1&updateToken=' . self::TOKEN_VALID,
 				[
 					'transaction' => '99999-53245-5483-4891',
 					'time' => '2010-04-14T19:01:08+02:00'
 				]
 			);
 
-			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+			$this->assertSame( 'Ok', $client->getResponse()->getContent() );
+			$this->assertSame( Response::HTTP_OK, $client->getResponse()->getStatusCode() );
 
 			$donation = $repo->getDonationById( 1 );
 			$this->assertEquals( new DateTime( '2010-04-14T19:01:08+02:00' ), $donation->getPaymentMethod()->getConfirmedAt() );
+		} );
+	}
+
+	public function testGivenAlreadyConfirmedPayment_requestDataIsLogged(): void {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+
+			$logger = new LoggerSpy();
+			$factory->setSofortLogger( $logger );
+
+			$factory->setTokenGenerator( new FixedTokenGenerator(
+				self::TOKEN_VALID,
+				\DateTime::createFromFormat( 'Y-m-d H:i:s', '2039-12-31 23:59:59' )
+			) );
+
+			$repo = $factory->getDonationRepository();
+			$repo->storeDonation( ValidDonation::newCompletedSofortDonation() );	// creates donation w/ id=1
+
+			$client->request(
+				Request::METHOD_POST,
+				'/sofort-payment-notification?id=1&updateToken=' . self::TOKEN_VALID,
+				[
+					'transaction' => '99999-53245-5483-4891',
+					'time' => '2010-04-14T19:01:08+02:00'
+				]
+			);
+
+			$this->assertSame( 'Bad request', $client->getResponse()->getContent() );
+			$this->assertSame( Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode() );
+
+			$this->assertSame(
+				[ 'Duplicate notification' ],
+				$logger->getLogCalls()->getMessages()
+			);
+
+			$this->assertSame(
+				'99999-53245-5483-4891',
+				$logger->getLogCalls()->getFirstCall()->getContext()['post_vars']['transaction']
+			);
+
+			$this->assertSame(
+				'1',
+				$logger->getLogCalls()->getFirstCall()->getContext()['query_vars']['id']
+			);
+
+			$this->assertSame( LogLevel::INFO, $logger->getLogCalls()->getFirstCall()->getLevel() );
+		} );
+	}
+
+	public function testGivenUnknowDonation_requestDataIsLogged(): void {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+
+			$logger = new LoggerSpy();
+			$factory->setSofortLogger( $logger );
+
+			$factory->setTokenGenerator( new FixedTokenGenerator(
+				self::TOKEN_VALID,
+				\DateTime::createFromFormat( 'Y-m-d H:i:s', '2039-12-31 23:59:59' )
+			) );
+
+			$repo = $factory->getDonationRepository();
+			$repo->storeDonation( ValidDonation::newCompletedSofortDonation() );	// creates donation w/ id=1
+
+			$client->request(
+				Request::METHOD_POST,
+				'/sofort-payment-notification?id=2&updateToken=' . self::TOKEN_VALID,
+				[
+					'transaction' => '99999-53245-5483-4893',
+					'time' => '2010-04-14T19:01:08+02:00'
+				]
+			);
+
+			$this->assertSame( 'Bad request', $client->getResponse()->getContent() );
+			$this->assertSame( Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode() );
+
+			$this->assertSame(
+				[ 'Donation not found' ],
+				$logger->getLogCalls()->getMessages()
+			);
+
+			$this->assertSame(
+				'99999-53245-5483-4893',
+				$logger->getLogCalls()->getFirstCall()->getContext()['post_vars']['transaction']
+			);
+
+			$this->assertSame(
+				'2',
+				$logger->getLogCalls()->getFirstCall()->getContext()['query_vars']['id']
+			);
+
+			$this->assertSame( LogLevel::ERROR, $logger->getLogCalls()->getFirstCall()->getLevel() );
 		} );
 	}
 }

--- a/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge\Routes;
+
+use DateTime;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Client;
+use WMDE\Fundraising\Frontend\DonationContext\Tests\Data\ValidDonation;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
+use WMDE\Fundraising\Frontend\Tests\Fixtures\FixedTokenGenerator;
+
+class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
+
+	public function testGivenWrongPaymentType_applicationRefuses(): void {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$factory->setTokenGenerator( new FixedTokenGenerator(
+				'my-secret_token',
+				new DateTime( '2039-12-31 23:59:59Z' )
+			) );
+
+			$repo = $factory->getDonationRepository();
+			$repo->storeDonation( ValidDonation::newIncompletePayPalDonation() );	// creates donation w/ id=1
+
+			$client->request(
+				Request::METHOD_POST,
+				'/sofort-payment-notification?id=1&updateToken=my-secret_token',
+				[
+					'transaction' => '99999-53245-5483-4891',
+					'time' => '2010-04-14T19:01:08+02:00'
+				]
+			);
+
+			$this->assertSame( 400, $client->getResponse()->getStatusCode() );
+		} );
+	}
+
+	public function testGivenWrongToken_applicationRefuses(): void {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$factory->setTokenGenerator( new FixedTokenGenerator(
+				'my_secret_token',
+				new DateTime( '2039-12-31 23:59:59Z' )
+			) );
+
+			$repo = $factory->getDonationRepository();
+			$repo->storeDonation( ValidDonation::newIncompleteSofortDonation() );	// creates donation w/ id=1
+
+			$client->request(
+				Request::METHOD_POST,
+				'/sofort-payment-notification?id=1&updateToken=some_bogous',
+				[
+					'transaction' => '99999-53245-5483-4891',
+					'time' => '2010-04-14T19:01:08+02:00'
+				]
+			);
+
+			$this->assertSame( 400, $client->getResponse()->getStatusCode() );
+		} );
+	}
+
+	public function testGivenBadTimeFormat_applicationRefuses(): void {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$factory->setTokenGenerator( new FixedTokenGenerator(
+				'my_secret_token',
+				new DateTime( '2039-12-31 23:59:59Z' )
+			) );
+
+			$repo = $factory->getDonationRepository();
+			$repo->storeDonation( ValidDonation::newIncompleteSofortDonation() );	// creates donation w/ id=1
+
+			$client->request(
+				Request::METHOD_POST,
+				'/sofort-payment-notification?id=1&updateToken=some_bogous',
+				[
+					'transaction' => '99999-53245-5483-4891',
+					'time' => 'now'
+				]
+			);
+
+			$this->assertSame( 400, $client->getResponse()->getStatusCode() );
+		} );
+	}
+
+	public function testGivenValidRequest_applicationIndicatesSuccess(): void {
+		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ) {
+			$factory->setTokenGenerator( new FixedTokenGenerator(
+				'my_secret-token',
+				new DateTime( '2039-12-31 23:59:59Z' )
+			) );
+
+			$repo = $factory->getDonationRepository();
+			$repo->storeDonation( ValidDonation::newIncompleteSofortDonation() );	// creates donation w/ id=1
+
+			$client->request(
+				Request::METHOD_POST,
+				'/sofort-payment-notification?id=1&updateToken=my_secret-token',
+				[
+					'transaction' => '99999-53245-5483-4891',
+					'time' => '2010-04-14T19:01:08+02:00'
+				]
+			);
+
+			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
+
+			$donation = $repo->getDonationById( 1 );
+			$this->assertEquals( new DateTime( '2010-04-14T19:01:08+02:00' ), $donation->getPaymentMethod()->getConfirmedAt() );
+		} );
+	}
+}

--- a/web/index.php
+++ b/web/index.php
@@ -64,6 +64,17 @@ $ffFactory->setPaypalLogger( call_user_func( function() use ( $ffFactory ) {
 	return $logger;
 } ) );
 
+$ffFactory->setSofortLogger( call_user_func( function() use ( $ffFactory ) {
+	$logger = new Logger( 'sofort' );
+
+	$streamHandler = new StreamHandler( $ffFactory->getLoggingPath() . '/sofort.log' );
+
+	$streamHandler->setFormatter( new JsonFormatter() );
+	$logger->pushHandler( $streamHandler );
+
+	return $logger;
+} ) );
+
 /**
  * @var \Silex\Application $app
  */


### PR DESCRIPTION
* created endpoint for sofort payment notifications
* created sofort donation confirmation mail, triggered on sofort payment notification
* pimped FakeDonationRepository so that objects stored inside of them are identical before & after
  * asserting donation passed to mailer in case of credit card & paypal, too
* abstracted `assertEventLogContainsExpression` into trait (not used for sofort in the end, but kept)

Need to roll this to test (with www-reachable endpoint) to test integration with actual payment provider.