### PR TITLE
T167882 Sofort notification followup

### DIFF
--- a/app/RouteHandlers/SofortNotificationHandler.php
+++ b/app/RouteHandlers/SofortNotificationHandler.php
@@ -58,26 +58,15 @@ class SofortNotificationHandler {
 	}
 
 	private function newUseCaseRequest(): SofortNotificationRequest {
-		$time = $this->getTimeFromRequest();
+		$useCaseRequest = SofortNotificationRequest::fromRawRequest( $this->request->getContent() );
 
-		if ( $time === false ) {
-			throw new UnexpectedValueException( 'Invalid notification time' );
+		if ( !( $useCaseRequest instanceof SofortNotificationRequest ) ) {
+			throw new UnexpectedValueException( 'Invalid notification request' );
 		}
 
-		$useCaseRequest = new SofortNotificationRequest();
-
-		$useCaseRequest->setTime( $time );
 		$useCaseRequest->setDonationId( $this->request->query->getInt( 'id' ) );
-		$useCaseRequest->setTransactionId( $this->request->request->get( 'transaction', '' ) );
 
 		return $useCaseRequest;
-	}
-
-	/**
-	 * @return bool|DateTime
-	 */
-	private function getTimeFromRequest() {
-		return DateTime::createFromFormat( DateTime::ATOM, $this->request->request->get( 'time', '' ) );
 	}
 
 	private function logResponseIfNeeded( SofortNotificationResponse $response ): void {
@@ -95,7 +84,7 @@ class SofortNotificationHandler {
 		$message = $context['message'] ?? 'Sofort request not handled';
 		unset( $context['message'] );
 
-		$context['post_vars'] = $this->request->request->all();
+		$context['request_content'] = $this->request->getContent();
 		$context['query_vars'] = $this->request->query->all();
 		$this->ffFactory->getSofortLogger()->log( $logLevel, $message, $context );
 	}

--- a/contexts/PaymentContext/src/RequestModel/SofortNotificationRequest.php
+++ b/contexts/PaymentContext/src/RequestModel/SofortNotificationRequest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\PaymentContext\RequestModel;
 
+use Sofort\SofortLib\Notification as VendorNotification;
 use DateTime;
 
 class SofortNotificationRequest {
@@ -46,5 +47,26 @@ class SofortNotificationRequest {
 	public function setTime( DateTime $time ): self {
 		$this->time = $time;
 		return $this;
+	}
+
+	public static function fromRawRequest( string $content ): ?self {
+		$vendorNotification = new VendorNotification();
+		$result = $vendorNotification->getNotification( $content );
+
+		if ( $result === false ) {
+			return null;
+		}
+
+		$time = DateTime::createFromFormat( DateTime::ATOM, $vendorNotification->getTime() );
+
+		if ( $time === false ) {
+			return null;
+		}
+
+		$notification = new self();
+		$notification->setTime( $time );
+		$notification->setTransactionId( $vendorNotification->getTransactionId() );
+
+		return $notification;
 	}
 }

--- a/contexts/PaymentContext/tests/Unit/RequestModel/SofortNotificationRequestTest.php
+++ b/contexts/PaymentContext/tests/Unit/RequestModel/SofortNotificationRequestTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\PaymentContext\Tests\Unit\RequestModel;
+
+use WMDE\Fundraising\Frontend\PaymentContext\RequestModel\SofortNotificationRequest;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class SofortNotificationRequestTest extends TestCase {
+
+	public function testValidRequest_requestIsConstructed(): void {
+		$content = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+			. '<status_notification><transaction>555-777</transaction>'
+			. '<time>2010-04-14T19:01:08+02:00</time>'
+			. '</status_notification>';
+		$request = SofortNotificationRequest::fromRawRequest( $content );
+
+		$this->assertInstanceOf( SofortNotificationRequest::class, $request );
+		$this->assertSame( '555-777', $request->getTransactionId() );
+		$this->assertEquals( new DateTime( '2010-04-14T19:01:08+02:00' ), $request->getTime() );
+		$this->assertNull( $request->getDonationId(), 'Donation id is not part of the vendor raw request.' );
+	}
+
+	public function testAbsurdRequest_nullIsReturned(): void {
+		$request = SofortNotificationRequest::fromRawRequest( 'fff' );
+
+		$this->assertNull( $request );
+	}
+
+	public function testMissingTransactionIdRequest_nullIsReturned(): void {
+		$content = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+			. '<status_notification>'
+			. '<time>2013-06-25T11:04:03+05:00</time>'
+			. '</status_notification>';
+		$request = SofortNotificationRequest::fromRawRequest( $content );
+
+		$this->assertNull( $request );
+	}
+
+	public function testInValidTimeRequest_nullIsReturned(): void {
+		$content = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+			. '<status_notification><transaction>555-777</transaction>'
+			. '<time>now</time>'
+			. '</status_notification>';
+		$request = SofortNotificationRequest::fromRawRequest( $content );
+
+		$this->assertNull( $request );
+	}
+}

--- a/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
@@ -31,10 +31,10 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$client->request(
 				Request::METHOD_POST,
 				'/sofort-payment-notification?id=' . $donation->getId() . '&updateToken=' . self::VALID_TOKEN,
-				[
-					'transaction' => self::VALID_TRANSACTION_ID,
-					'time' => self::VALID_TRANSACTION_TIME
-				]
+				[],
+				[],
+				[],
+				$this->buildRawRequestBody( self::VALID_TRANSACTION_ID, self::VALID_TRANSACTION_TIME )
 			);
 
 			$this->assertIsBadRequestResponse( $client->getResponse() );
@@ -68,10 +68,10 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$client->request(
 				Request::METHOD_POST,
 				'/sofort-payment-notification?id=' . $donation->getId() . '&updateToken=' . self::INVALID_TOKEN,
-				[
-					'transaction' => self::VALID_TRANSACTION_ID,
-					'time' => self::VALID_TRANSACTION_TIME
-				]
+				[],
+				[],
+				[],
+				$this->buildRawRequestBody( self::VALID_TRANSACTION_ID, self::VALID_TRANSACTION_TIME )
 			);
 
 			$this->assertIsBadRequestResponse( $client->getResponse() );
@@ -86,10 +86,10 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$client->request(
 				Request::METHOD_POST,
 				'/sofort-payment-notification?id=' . $donation->getId() . '&updateToken=' . self::VALID_TOKEN,
-				[
-					'transaction' => self::VALID_TRANSACTION_ID,
-					'time' => 'now'
-				]
+				[],
+				[],
+				[],
+				$this->buildRawRequestBody( self::VALID_TRANSACTION_ID, 'now' )
 			);
 
 			$this->assertIsBadRequestResponse( $client->getResponse() );
@@ -104,10 +104,10 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$client->request(
 				Request::METHOD_POST,
 				'/sofort-payment-notification?id=' . $donation->getId() . '&updateToken=' . self::VALID_TOKEN,
-				[
-					'transaction' => self::VALID_TRANSACTION_ID,
-					'time' => self::VALID_TRANSACTION_TIME
-				]
+				[],
+				[],
+				[],
+				$this->buildRawRequestBody( self::VALID_TRANSACTION_ID, self::VALID_TRANSACTION_TIME )
 			);
 
 			$this->assertSame( 'Ok', $client->getResponse()->getContent() );
@@ -130,10 +130,10 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$client->request(
 				Request::METHOD_POST,
 				'/sofort-payment-notification?id=' . $donation->getId() . '&updateToken=' . self::VALID_TOKEN,
-				[
-					'transaction' => self::VALID_TRANSACTION_ID,
-					'time' => self::VALID_TRANSACTION_TIME
-				]
+				[],
+				[],
+				[],
+				$this->buildRawRequestBody( self::VALID_TRANSACTION_ID, self::VALID_TRANSACTION_TIME )
 			);
 
 			$this->assertIsBadRequestResponse( $client->getResponse() );
@@ -151,9 +151,9 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 	}
 
 	private function assertRequestVarsAreLogged( LoggerSpy $logger ): void {
-		$this->assertSame(
-			self::VALID_TRANSACTION_ID,
-			$logger->getLogCalls()->getFirstCall()->getContext()['post_vars']['transaction']
+		$this->assertContains(
+			'<transaction>' . self::VALID_TRANSACTION_ID . '</transaction>',
+			$logger->getLogCalls()->getFirstCall()->getContext()['request_content']
 		);
 
 		$this->assertEquals(
@@ -177,10 +177,10 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$client->request(
 				Request::METHOD_POST,
 				'/sofort-payment-notification?id=' . ( $donation->getId() + 1 ) . '&updateToken=' . self::VALID_TOKEN,
-				[
-					'transaction' => self::VALID_TRANSACTION_ID,
-					'time' => self::VALID_TRANSACTION_TIME
-				]
+				[],
+				[],
+				[],
+				$this->buildRawRequestBody( self::VALID_TRANSACTION_ID, self::VALID_TRANSACTION_TIME )
 			);
 
 			$this->assertIsErrorResponse( $client->getResponse() );
@@ -206,10 +206,10 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$client->request(
 				Request::METHOD_POST,
 				'/sofort-payment-notification?id=' . $donation->getId() . '&updateToken=' . self::VALID_TOKEN,
-				[
-					'transaction' => self::VALID_TRANSACTION_ID,
-					'time' => 'now'
-				]
+				[],
+				[],
+				[],
+				$this->buildRawRequestBody( self::VALID_TRANSACTION_ID, 'now' )
 			);
 
 			$this->assertIsBadRequestResponse( $client->getResponse() );
@@ -217,6 +217,13 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			$this->assertRequestVarsAreLogged( $logger );
 			$this->assertLogLevel( $logger, LogLevel::ERROR );
 		} );
+	}
+
+	private function buildRawRequestBody( string $transactionId, string $time ): string {
+		return "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+			. "<status_notification><transaction>$transactionId</transaction>"
+			. "<time>$time</time>"
+			. "</status_notification>";
 	}
 
 }

--- a/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/SofortPaymentNotificationRouteTest.php
@@ -213,7 +213,7 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$this->assertIsBadRequestResponse( $client->getResponse() );
-			$this->assertErrorCauseIsLogged( $logger, 'Invalid notification time' );
+			$this->assertErrorCauseIsLogged( $logger, 'Invalid notification request' );
 			$this->assertRequestVarsAreLogged( $logger );
 			$this->assertLogLevel( $logger, LogLevel::ERROR );
 		} );
@@ -223,7 +223,7 @@ class SofortPaymentNotificationRouteTest extends WebRouteTestCase {
 		return "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
 			. "<status_notification><transaction>$transactionId</transaction>"
 			. "<time>$time</time>"
-			. "</status_notification>";
+			. '</status_notification>';
 	}
 
 }


### PR DESCRIPTION
Discovered that the data received [is an XML](https://phabricator.wikimedia.org/T167882#3493855) clob that needs special treatment, so
* use 3rd party class to handle incoming notification requests
* dumping request body instead of POST to log in case of invalid requests

If you do not have strong objections, we should first try (can't do on dev) on test and then polish.