### PR TITLE
Add delay-in-days to default configs

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -107,7 +107,8 @@
 		"notify-url": "",
 		"return-url": "",
 		"cancel-url": "",
-		"item-name": ""
+		"item-name": "",
+		"delay-in-days": 90
 	},
 	"creditcard": {
 		"access-key": "",

--- a/build/vagrant/config.prod.json
+++ b/build/vagrant/config.prod.json
@@ -56,7 +56,8 @@
 		"notify-url": "http://localhost:31337/handle-paypal-membership-fee-notification",
 		"return-url": "http://localhost:31337/show-membership-confirmation",
 		"cancel-url": "http://localhost:31337/",
-		"item-name": "Test-Mitgliedschaft bei Wikimedia"
+		"item-name": "Test-Mitgliedschaft bei Wikimedia",
+		"delay-in-days": 90
 	},
 	"creditcard": {
 		"access-key": "",


### PR DESCRIPTION
Make the value for `delay-in-days` visible in the default configuration
files. If it's missing and not added in the local prod config,
membership application on local dev machines will blow up.