### PR TITLE
Payment delay in embedded membership form

### DIFF
--- a/app/RouteHandlers/ShowDonationConfirmationHandler.php
+++ b/app/RouteHandlers/ShowDonationConfirmationHandler.php
@@ -44,7 +44,8 @@ class ShowDonationConfirmationHandler {
 				$responseModel->getDonation(),
 				$responseModel->getUpdateToken(),
 				$selectedConfirmationPage,
-				PiwikVariableCollector::newForDonation( $sessionTrackingData, $responseModel->getDonation() )
+				PiwikVariableCollector::newForDonation( $sessionTrackingData, $responseModel->getDonation() ),
+				$this->ffFactory->getPaymentDelayInDays()
 			)
 		);
 

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -28,14 +28,17 @@ class DonationConfirmationHtmlPresenter {
 	}
 
 	public function present( Donation $donation, string $updateToken, SelectedConfirmationPage $selectedPage,
-							 PiwikEvents $piwikEvents ): string {
+							 PiwikEvents $piwikEvents, int $membershipFeePaymentDelay ): string {
 		return $this->template->render(
-			$this->getConfirmationPageArguments( $donation, $updateToken, $selectedPage, $piwikEvents )
+			$this->getConfirmationPageArguments(
+				$donation, $updateToken, $selectedPage, $piwikEvents, $membershipFeePaymentDelay
+			)
 		);
 	}
 
 	private function getConfirmationPageArguments( Donation $donation, string $updateToken,
-												   SelectedConfirmationPage $selectedPage, PiwikEvents $piwikEvents ): array {
+												   SelectedConfirmationPage $selectedPage, PiwikEvents $piwikEvents,
+												   int $membershipFeePaymentDelay ): array {
 
 		return [
 			'main_template' => $selectedPage->getPageTitle(),
@@ -57,7 +60,8 @@ class DonationConfirmationHtmlPresenter {
 			'person' => $this->getPersonArguments( $donation ),
 			'bankData' => $this->getBankDataArguments( $donation->getPaymentMethod() ),
 			'initialFormValues' => $this->getInitialMembershipFormValues( $donation ),
-			'piwikEvents' => $piwikEvents->getEvents()
+			'piwikEvents' => $piwikEvents->getEvents(),
+			'delay_in_days' => $membershipFeePaymentDelay
 		];
 	}
 

--- a/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
@@ -20,6 +20,7 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 
 	private const STATUS_BOOKED = 'status-booked';
 	private const STATUS_UNCONFIRMED = 'status-unconfirmed';
+	private const MEMBERSHIP_FEE_PAYMENT_DELAY = 42;
 
 	public function testWhenPresenterRenders_itPassedParamsToTemplate(): void {
 		$twig = $this->getMockBuilder( TwigTemplate::class )->disableOriginalConstructor()->getMock();
@@ -34,7 +35,8 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 			ValidDonation::newBookedAnonymousPayPalDonation(),
 			'update_token',
 			$pageSelector,
-			$this->newPiwikEvents()
+			$this->newPiwikEvents(),
+			self::MEMBERSHIP_FEE_PAYMENT_DELAY
 		);
 	}
 
@@ -60,7 +62,8 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 			'piwikEvents' => [
 				[ 'setCustomVariable', 1, 'Payment', 'some value', PiwikEvents::SCOPE_VISIT ],
 				[ 'trackGoal', 4095 ]
-			]
+			],
+			'delay_in_days' => 42
 		];
 	}
 
@@ -85,7 +88,8 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 			ValidDonation::newIncompleteAnonymousPayPalDonation(),
 			'update_token',
 			$pageSelector,
-			$this->newPiwikEvents()
+			$this->newPiwikEvents(),
+			self::MEMBERSHIP_FEE_PAYMENT_DELAY
 		);
 	}
 


### PR DESCRIPTION
This PR fixes that the payment delay for membership fees is not known to the membership form that is embedded in the donation confirmation page.