### PR TITLE
add another paragraph to paypal payment notice

### DIFF
--- a/app/templates/Membership_Application_Form.html.twig
+++ b/app/templates/Membership_Application_Form.html.twig
@@ -257,7 +257,12 @@
 						</ul>
 
 						<div class="notice-ppl-recurrent">
-							{$ 'notice_membership_paypal'|trans({'%delay_in_days%': delay_in_days}) $}
+							<p>
+								{$ 'notice_membership_paypal'|trans({'%delay_in_days%': delay_in_days}) $}
+							</p>
+							<p>
+								{$ 'notice_recurring_paypal'|trans $}
+							</p>
 						</div>
 
 						<hr />


### PR DESCRIPTION
This PR for [phab:T162438](https://phabricator.wikimedia.org/T162438) uses the message that is introduced in wmde/fundraising-frontend-content#26.