### PR TITLE
do not use payment delay in templates

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -409,7 +409,7 @@ $app->post(
 $app->get(
 	'apply-for-membership',
 	function( Request $request ) use ( $ffFactory ) {
-		$params = [ 'delay_in_days' => $ffFactory->getPaymentDelayInDays() ];
+		$params = [];
 
 		if ( $request->query->get('type' ) === 'sustaining' ) {
 			$params['showMembershipTypeOption'] = false ;

--- a/app/templates/Membership_Application_Form.html.twig
+++ b/app/templates/Membership_Application_Form.html.twig
@@ -258,7 +258,7 @@
 
 						<div class="notice-ppl-recurrent">
 							<p>
-								{$ 'notice_membership_paypal'|trans({'%delay_in_days%': delay_in_days}) $}
+								{$ 'notice_membership_paypal'|trans $}
 							</p>
 							<p>
 								{$ 'notice_recurring_paypal'|trans $}

--- a/contexts/MembershipContext/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
+++ b/contexts/MembershipContext/tests/Integration/UseCases/ApplyForMembership/ApplyForMembershipUseCaseTest.php
@@ -41,7 +41,6 @@ class ApplyForMembershipUseCaseTest extends \PHPUnit\Framework\TestCase {
 	const ACCESS_TOKEN = 'Gimmeh all the access';
 	const UPDATE_TOKEN = 'Lemme change all the stuff';
 	const FIRST_PAYMENT_DATE = '2017-08-07';
-	const PAYMENT_DELAY_IN_DAYS = 42;
 
 	/**
 	 * @var ApplicationRepository


### PR DESCRIPTION
As stated in [phab:T162438](https://phabricator.wikimedia.org/T162438), we can get rid of passing `delay_in_days` to the membership application form presenter.