### PR TITLE
Improve moving of mail templates

### DIFF
--- a/app/UrlGenerator.php
+++ b/app/UrlGenerator.php
@@ -1,0 +1,19 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App;
+
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use WMDE\Fundraising\Frontend\Infrastructure\UrlGenerator as UrlGeneratorInterface;
+
+class UrlGenerator implements UrlGeneratorInterface {
+	private $routingExtension;
+
+	public function __construct( RoutingExtension $routingExtension ) {
+		$this->routingExtension = $routingExtension;
+	}
+
+	public function generateUrl( string $name, array $parameters = [] ): string {
+		return $this->routingExtension->getUrl( $name, $parameters );
+	}
+}

--- a/build/vagrant/config.prod.json
+++ b/build/vagrant/config.prod.json
@@ -20,6 +20,14 @@
 			}
 		}
 	},
+	"mailer-twig": {
+		"enable-cache": false,
+		"loaders": {
+			"filesystem": {
+				"template-dir": "app/mail_templates"
+			}
+		}
+	},
 	"i18n-base-path": "vendor/wmde/fundraising-frontend-content/i18n",
 	"text-policies": {
 		"fields": {

--- a/cli/RenderMailTemplatesCommand.php
+++ b/cli/RenderMailTemplatesCommand.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Cli;
 
 use FileFetcher\SimpleFileFetcher;
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,6 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Twig_Environment;
 use Twig_Error;
+use WMDE\Fundraising\Frontend\App\UrlGenerator;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\ConfigReader;
 use WMDE\Fundraising\Frontend\App\MailTemplates;
@@ -56,7 +58,7 @@ class RenderMailTemplatesCommand extends Command {
 
 		$app->flush();
 
-		$ffFactory->setSkinTwigEnvironment( $app['twig'] );
+		$ffFactory->setUrlGenerator( new UrlGenerator( $app['twig']->getExtension( RoutingExtension::class ) ) );
 
 		$mailTemplates = new MailTemplates( $ffFactory );
 		$testData = $mailTemplates->get();
@@ -72,7 +74,7 @@ class RenderMailTemplatesCommand extends Command {
 			$outputPath .= '/';
 		}
 
-		$this->renderTemplates( $testData, $ffFactory->getSkinTwig(), $outputPath, $output );
+		$this->renderTemplates( $testData, $ffFactory->getMailerTwig(), $outputPath, $output );
 	}
 
 	private function getDefaultConfig(): array {

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -343,11 +343,7 @@ class FunFunFactory {
 				$twigFactory->newTranslationExtension( $this->getTranslator() ),
 				new Twig_Extensions_Extension_Intl(),
 			];
-			$filters = [
-				$twigFactory->newFilePrefixFilter(
-					$this->getFilePrefixer()
-				)
-			];
+			$filters = [];
 			$functions = [
 				new Twig_SimpleFunction(
 					'mail_content',

--- a/web/index.dev.php
+++ b/web/index.dev.php
@@ -18,7 +18,7 @@ use Monolog\Handler\BufferHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
-use WMDE\Fundraising\Frontend\Infrastructure\UrlGenerator;
+use WMDE\Fundraising\Frontend\App\UrlGenerator;
 
 /**
  * @var \WMDE\Fundraising\Frontend\Factories\FunFunFactory $ffFactory
@@ -118,18 +118,6 @@ $app['twig.loader.filesystem'] = $app->extend(
 
 $ffFactory->setSkinTwigEnvironment( $app['twig'] );
 
-$ffFactory->setUrlGenerator(
-	new class( $app['twig']->getExtension( RoutingExtension::class ) ) implements UrlGenerator {
-		private $routingExtension;
-
-		public function __construct( RoutingExtension $routingExtension ) {
-			$this->routingExtension = $routingExtension;
-		}
-
-		public function generateUrl( string $name, array $parameters = [] ): string {
-			return $this->routingExtension->getUrl( $name, $parameters );
-		}
-	}
-);
+$ffFactory->setUrlGenerator( new UrlGenerator( $app['twig']->getExtension( RoutingExtension::class ) ) );
 
 $app->run();

--- a/web/index.php
+++ b/web/index.php
@@ -10,9 +10,9 @@ use Monolog\Handler\FingersCrossedHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use WMDE\Fundraising\Frontend\App\UrlGenerator;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\ConfigReader;
-use WMDE\Fundraising\Frontend\Infrastructure\UrlGenerator;
 
 /**
  * @var FunFunFactory $ffFactory
@@ -84,18 +84,6 @@ $app = require __DIR__ . '/../app/bootstrap.php';
 
 $ffFactory->setSkinTwigEnvironment( $app['twig'] );
 
-$ffFactory->setUrlGenerator(
-	new class( $app['twig']->getExtension( RoutingExtension::class ) ) implements UrlGenerator {
-		private $routingExtension;
-
-		public function __construct( RoutingExtension $routingExtension ) {
-			$this->routingExtension = $routingExtension;
-		}
-
-		public function generateUrl( string $name, array $parameters = [] ): string {
-			return $this->routingExtension->getUrl( $name, $parameters );
-		}
-	}
-);
+$ffFactory->setUrlGenerator( new UrlGenerator( $app['twig']->getExtension( RoutingExtension::class ) ) );
 
 $app->run();


### PR DESCRIPTION
Use correct templating environment in RenderMailTemplatesCommand.
Remove unneccessary filter from mail templating environment (mail
templates don't link to asset files that need to be prefixed).
Replace anonymous UrlGenerator class with standalone one since it's used
in 3 places now.
Add new config settings to vagrant environment.