### PR TITLE
make cookies (optionally) configurable

### DIFF
--- a/app/RouteHandlers/ApplyForMembershipHandler.php
+++ b/app/RouteHandlers/ApplyForMembershipHandler.php
@@ -5,11 +5,9 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\App\RouteHandlers;
 
 use Silex\Application;
-use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
-use WMDE\Fundraising\Frontend\Infrastructure\ConfigurableCookie;
 use WMDE\Fundraising\Frontend\MembershipContext\Tracking\MembershipApplicationTrackingInfo;
 use WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipRequest;
 use WMDE\Fundraising\Frontend\MembershipContext\UseCases\ApplyForMembership\ApplyForMembershipResponse;

--- a/app/config/schema.json
+++ b/app/config/schema.json
@@ -781,7 +781,7 @@
     },
     "cookie": {
       "type": "object",
-      "title": "Configuration values for cookies",
+      "title": "Default Configuration values for cookies",
       "properties": {
         "expiration": {
           "type": "integer",
@@ -855,6 +855,7 @@
     "confirmation-pages",
     "piwik",
     "translation",
-    "payment-types"
+    "payment-types",
+    "cookie"
   ]
 }

--- a/src/Infrastructure/CookieBuilder.php
+++ b/src/Infrastructure/CookieBuilder.php
@@ -20,8 +20,7 @@ class CookieBuilder {
 	private $raw;
 	private $sameSite;
 
-	public function __construct( int $expire = 0, string $path = '', string $domain = null, bool $secure = false,
-								 bool $httpOnly = false, bool $raw = false, string $sameSite = null ) {
+	public function __construct( int $expire, string $path, ?string $domain, bool $secure, bool $httpOnly, bool $raw, ?string $sameSite ) {
 		$this->expire = $expire;
 		$this->path = $path;
 		$this->domain = $domain;
@@ -31,17 +30,18 @@ class CookieBuilder {
 		$this->sameSite = $sameSite;
 	}
 
-	public function newCookie( string $name, string $value ): Cookie {
+	public function newCookie( string $name, string $value, ?int $expire = null, ?string $path = null, ?string $domain = null,
+								?bool $raw = false, ?string $sameSite = null ): Cookie {
 		return new Cookie(
 			$name,
 			$value,
-			$this->expire,
-			$this->path,
-			$this->domain,
+			$expire ?? $this->expire,
+			$path ?? $this->path,
+			$domain ?? $this->domain,
 			$this->secure,
 			$this->httpOnly,
-			$this->raw,
-			$this->sameSite
+			$raw ?? $this->raw,
+			$sameSite ?? $this->sameSite
 		);
 	}
 

--- a/tests/Unit/Infrastructure/CookieBuilderTest.php
+++ b/tests/Unit/Infrastructure/CookieBuilderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use Symfony\Component\HttpFoundation\Cookie;
+use WMDE\Fundraising\Frontend\Infrastructure\CookieBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\CookieBuilder
+ */
+class CookieBuilderTest extends TestCase {
+
+	public function testNewCookieUsingDefaults(): void {
+		$builder = new CookieBuilder( 0, '/', null, true, true, false, null );
+		$cookie = $builder->newCookie( 'a', 'b' );
+		$this->assertInstanceOf( Cookie::class, $cookie );
+		$this->assertSame( 'a', $cookie->getName() );
+		$this->assertSame( 'b', $cookie->getValue() );
+		$this->assertSame( 0, $cookie->getExpiresTime() );
+		$this->assertSame( '/', $cookie->getPath() );
+		$this->assertNull( $cookie->getDomain() );
+		$this->assertTrue( $cookie->isHttpOnly() );
+		$this->assertTrue( $cookie->isSecure() );
+		$this->assertFalse( $cookie->isRaw() );
+		$this->assertNull( $cookie->getSameSite() );
+	}
+
+	public function testNewCookieOverriding(): void {
+		$builder = new CookieBuilder( 0, '/', null, true, true, false, null );
+		$cookie = $builder->newCookie( 'a', 'b', 500, '/here', 'sub.domain.com', true, 'strict' );
+		$this->assertInstanceOf( Cookie::class, $cookie );
+		$this->assertSame( 'a', $cookie->getName() );
+		$this->assertSame( 'b', $cookie->getValue() );
+		$this->assertSame( 500, $cookie->getExpiresTime() );
+		$this->assertSame( '/here', $cookie->getPath() );
+		$this->assertSame( 'sub.domain.com', $cookie->getDomain() );
+		$this->assertTrue( $cookie->isHttpOnly() );
+		$this->assertTrue( $cookie->isSecure() );
+		$this->assertTrue( $cookie->isRaw() );
+		$this->assertSame( 'strict', $cookie->getSameSite() );
+	}
+
+}


### PR DESCRIPTION
Followup for #952 to make important (non-security-relevant) cookie options - e.g. expiration time - configurable individually for every cookie.

I don't see much benefit in the way this is done (share much of @gbirke's thoughts from the other PR), just want to make it work for T172892 (2 week cookie expiration time).