### PR TITLE
T176227 Fix layout of payment type options

### DIFF
--- a/skins/10h16/_styles/styles.css
+++ b/skins/10h16/_styles/styles.css
@@ -503,7 +503,6 @@ main { padding-top: 40px; padding-bottom: 100px; background: #f6f6f6; display: b
 #country { width: 350px; }
 #personal-data .anonymous-payment-select { margin-right: 4px; }
 
-#donation-payment label { width: 175px; }
 #donation-payment #card-number { width: 180px; }
 #donation-payment #first-name,
 #donation-payment #last-name { width: 220px; }
@@ -519,6 +518,22 @@ main { padding-top: 40px; padding-bottom: 100px; background: #f6f6f6; display: b
 #donation-payment button[type="submit"] { margin-left: 10px; vertical-align: bottom; }
 #donation-payment .hosted-by { font-size: 0.6em; color: #b2b2b2; margin-bottom: 15px; }
 #donation-payment .hosted-by a { text-decoration: underline; color: #b2b2b2; }
+
+.payment-type-list li {
+    box-sizing: border-box;
+    display: inline-block;
+    padding-right: 15px;
+    margin-bottom: 15px;
+}
+
+.payment-type-list.four-col li {
+    min-width: 20%;
+}
+
+.payment-type-list.three-col li {
+    min-width: 30%;
+}
+
 
 .slide-sepa label, .slide-non-sepa label { width: 175px; }
 

--- a/skins/10h16/templates/payment_type_list.twig
+++ b/skins/10h16/templates/payment_type_list.twig
@@ -3,7 +3,7 @@
 	formId
 	checkedPaymentType (optional)
 #}
-<ul class="horizontal clearfix payment-type-list">
+<ul class="clearfix payment-type-list {% if paymentTypes|length % 4 == 1 %}three-col{% else %}four-col{% endif %}">
 {% for paymentType in paymentTypes %}
 	<li
 	{% if loop.first %}


### PR DESCRIPTION
Align payments horizontally in three or four columns, depending how many
payment types there are.

ATTENTION: "Sofortüberweisung" does not fit the column layout (neither 3
or 4). It only works if it comes as the last option.