### PR TITLE
Ignore jQuery in Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -15,5 +15,6 @@ tools:
 filter:
     excluded_paths:
         - 'vendor/*'
-        - 'web/res/js/lib/*'
+        - 'web/skins/*'
+        - 'skins/10h16/_js/lib/*'
         - 'node_modules/*'


### PR DESCRIPTION
The minified jQuery source was moved and showed up erronously in
scrutinizer.

Also, ignore compiled web skin assets.