### PR TITLE
T176227 Payment type layout follow-up

### DIFF
--- a/skins/10h16/_styles/styles.css
+++ b/skins/10h16/_styles/styles.css
@@ -531,9 +531,8 @@ main { padding-top: 40px; padding-bottom: 100px; background: #f6f6f6; display: b
 }
 
 .payment-type-list.three-col li {
-    min-width: 30%;
+    min-width: 33.3%;
 }
-
 
 .slide-sepa label, .slide-non-sepa label { width: 175px; }
 

--- a/skins/10h16/templates/payment_type_list.twig
+++ b/skins/10h16/templates/payment_type_list.twig
@@ -3,6 +3,7 @@
 	formId
 	checkedPaymentType (optional)
 #}
+{% spaceless %}
 <ul class="clearfix payment-type-list {% if paymentTypes|length % 4 == 1 %}three-col{% else %}four-col{% endif %}">
 {% for paymentType in paymentTypes %}
 	<li
@@ -26,3 +27,4 @@
 	</li>
 {% endfor %}
 </ul>
+{% endspaceless %}


### PR DESCRIPTION
Saved some pixels that make "Sofortüberweisung" label almost fit (Firefox Ubuntu strangefont).

Follow-up for #960

@gbirke Can you verfiy this does not wrap in Safari? IE10, FF, chromium work out.