### PR TITLE
Made ChecksumGenerator insensitive just in case

### DIFF
--- a/contexts/PaymentContext/src/Domain/ChecksumGenerator.php
+++ b/contexts/PaymentContext/src/Domain/ChecksumGenerator.php
@@ -11,8 +11,6 @@ class ChecksumGenerator {
 
 	private $checksumCharacters;
 
-	private $cleanupPattern;
-
 	/**
 	 * @param array $checksumCharacters Characters that can be used for the checksum
 	 */
@@ -24,7 +22,6 @@ class ChecksumGenerator {
 		}
 
 		$this->checksumCharacters = $checksumCharacters;
-		$this->cleanupPattern = '/[^' . implode( '', $checksumCharacters ) . ']/';
 	}
 
 	/**
@@ -39,7 +36,7 @@ class ChecksumGenerator {
 	}
 
 	private function normalizeString( string $string ): string {
-		return strtoupper( preg_replace( $this->cleanupPattern, '', $string ) );
+		return strtoupper( str_replace( [ '-', '_', ' ' ], [ '', '', '' ], $string ) );
 	}
 
 }

--- a/contexts/PaymentContext/tests/Unit/Domain/ChecksumGeneratorTest.php
+++ b/contexts/PaymentContext/tests/Unit/Domain/ChecksumGeneratorTest.php
@@ -22,37 +22,60 @@ class ChecksumGeneratorTest extends TestCase {
 	public function testCanGenerateChecksumWithTwoCharacters(): void {
 		$generator = new ChecksumGenerator( [ 'a', 'b' ] );
 
-		$this->assertSame( 'a', $generator->createChecksum( 'bbbb' ) );
-		$this->assertSame( 'b', $generator->createChecksum( 'abab' ) );
-	}
-
-	public function testIgnoresCharsNotInRepertoire(): void {
-		$generator = new ChecksumGenerator( [ 'a', 'b' ] );
-
-		$this->assertSame( 'a', $generator->createChecksum( 'cat' ) );
-		$this->assertSame( 'a', $generator->createChecksum( 'rat' ) );
-		$this->assertSame( 'a', $generator->createChecksum( 'c-a-t' ) );
+		$this->assertSame( 'b', $generator->createChecksum( 'aaaa' ) );
+		$this->assertSame( 'b', $generator->createChecksum( 'aaaaa' ) );
 	}
 
 	public function testCanGenerateChecksumWithManyCharacters(): void {
 		$generator = new ChecksumGenerator( str_split( 'ACDEFKLMNPRSTWXYZ349' ) );
 
-		$this->assertSame( 'F', $generator->createChecksum( 'AAAA-AAAA-' ) );
-		$this->assertSame( '4', $generator->createChecksum( 'ABCD-EFGH-' ) );
-		$this->assertSame( 'K', $generator->createChecksum( 'QAQA-QAQA-' ) );
-		$this->assertSame( '9', $generator->createChecksum( 'AAAAXXXX-' ) );
+		$this->assertSame( 'X', $generator->createChecksum( 'AAAU' ) );
+		$this->assertSame( 'K', $generator->createChecksum( 'AAAA' ) );
+		$this->assertSame( 'C', $generator->createChecksum( 'QAQA' ) );
+		$this->assertSame( 'D', $generator->createChecksum( 'ABCD' ) );
+	}
+
+	public function testIgnoresDashesUnderscoresAndSpaces(): void {
+		$generator = new ChecksumGenerator( str_split( 'ACDEFKLMNPRSTWXYZ349' ) );
+
+		$checksum = $generator->createChecksum( 'CAT' );
+
+		$this->assertSame( $checksum, $generator->createChecksum( 'C-AT-' ) );
+		$this->assertSame( $checksum, $generator->createChecksum( '_CAT_' ) );
+		$this->assertSame( $checksum, $generator->createChecksum( 'C A T' ) );
+	}
+
+	public function testLowerAndMixedCaseProduceConsistentChecksum(): void {
+		$generator = new ChecksumGenerator( str_split( 'ACDEFKLMNPRSTWXYZ349' ) );
+
+		$this->assertSame( 'X', $generator->createChecksum( 'AAAU' ) );
+		$this->assertSame( 'X', $generator->createChecksum( 'aAAU' ) );
+
+		$this->assertSame( 'K', $generator->createChecksum( 'aAaa' ) );
+		$this->assertSame( 'K', $generator->createChecksum( 'aaaa' ) );
+
+		$this->assertSame( 'C', $generator->createChecksum( 'QaQa' ) );
+		$this->assertSame( 'C', $generator->createChecksum( 'qaqa' ) );
+
+		$this->assertSame( 'D', $generator->createChecksum( 'xxxx' ) );
+		$this->assertSame( 'D', $generator->createChecksum( 'XXXX' ) );
 	}
 
 	public function testChecksumIsOneOfTheExpectedCharacters(): void {
 		$characters = [ 'A', 'B', 'C' ];
 		$generator = new ChecksumGenerator( $characters );
 
+		//$distribution = ['A' => 0, 'B' => 0, 'C' => 0];
+
 		foreach ( $this->getRandomStrings() as $string ) {
+			//$distribution[$generator->createChecksum( $string )]++;
 			$this->assertContains(
 				$generator->createChecksum( $string ),
 				$characters
 			);
 		}
+
+		//var_dump($distribution);exit;
 	}
 
 	public function getRandomStrings(): iterable {


### PR DESCRIPTION
1) Made ChecksumGenerator insensitive just in case

2) Replaced broken regex with less mawgial replace. Even if the regex was not broken, it would allow for https://github.com/wmde/FundraisingFrontend/pull/940#issuecomment-330871351. With this PR the code just does https://github.com/wmde/FundraisingFrontend/pull/940#issuecomment-331111153

3) Made tests more focused (ie tests about capitalization no longer include ignored characters as well)

Based on https://github.com/wmde/FundraisingFrontend/pull/964, for https://phabricator.wikimedia.org/T170266, following up to https://github.com/wmde/FundraisingFrontend/pull/940