### PR TITLE
Make checksum 32-bit safe

### DIFF
--- a/contexts/PaymentContext/src/Domain/ChecksumGenerator.php
+++ b/contexts/PaymentContext/src/Domain/ChecksumGenerator.php
@@ -33,9 +33,16 @@ class ChecksumGenerator {
 	 * @return string The checksum as a single character present in the constructors array argument
 	 */
 	public function createChecksum( string $string ): string {
-		$checksum = hexdec( substr( md5( $this->normalizeString( $string ) ), 0, 8 ) );
+		$checksum = substr( md5( $this->normalizeString( $string ) ), 0, 8 );
+		if(PHP_INT_SIZE > 4) {
+			return $this->checksumCharacters[hexdec( $checksum ) % count( $this->checksumCharacters )];
+		} else {
+			return $this->checksumCharacters[(int) fmod(
+				(float) base_convert( $checksum, 16, 10 ),
+				count( $this->checksumCharacters )
+			)];
+		}
 
-		return $this->checksumCharacters[$checksum % count( $this->checksumCharacters )];
 	}
 
 	private function normalizeString( string $string ): string {


### PR DESCRIPTION
Previous implementation failed on 32 bit systems, now it works.