### PR TITLE
phpunit @expectException annotation typo (unused hence undetected)

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -144,7 +144,7 @@
             <property name="usefulAnnotations" type="array" value="
 				@see,
 				@throws,
-				@expectException,
+				@expectedException,
 				@expectedExceptionMessage,
 				@dataProvider,
 				@slowThreshold,


### PR DESCRIPTION
Fix [typo](https://phpunit.de/manual/current/en/appendixes.annotations.html#appendixes.annotations.expectedException) in phpunit annotation.