### PR TITLE
Code style changes and minor refactoring in PaymentTypesSettings

### DIFF
--- a/src/Presentation/PaymentTypesSettings.php
+++ b/src/Presentation/PaymentTypesSettings.php
@@ -61,7 +61,6 @@ class PaymentTypesSettings {
 	}
 
 	/**
-	 * @param string $settingName
 	 * @return string[]
 	 */
 	private function getPaymentTypesWhereSettingIsTrue( string $settingName ): array {

--- a/src/Presentation/PaymentTypesSettings.php
+++ b/src/Presentation/PaymentTypesSettings.php
@@ -15,12 +15,12 @@ use InvalidArgumentException;
  *
  * [
  *   'BEZ' => [
- *     PaymentTypesSettings::PURPOSE_DONATION => true,
- *     PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+ *     PaymentTypesSettings::ENABLE_DONATIONS => true,
+ *     PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
  *   ],
  *   'UEB' => [
- *     PaymentTypesSettings::PURPOSE_DONATION => true,
- *     PaymentTypesSettings::PURPOSE_MEMBERSHIP => false
+ *     PaymentTypesSettings::ENABLE_DONATIONS => true,
+ *     PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => false
  *   ]
  * ]
  */

--- a/src/Presentation/PaymentTypesSettings.php
+++ b/src/Presentation/PaymentTypesSettings.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 
 /**
  * Class PaymentTypesSettings
+ *
  * @package WMDE\Fundraising\Frontend\Presentation
  *
  * Takes a config like the following and provides read and write interface
@@ -25,8 +26,8 @@ use InvalidArgumentException;
  */
 class PaymentTypesSettings {
 
-	public const PURPOSE_DONATION = 'donation-enabled';
-	public const PURPOSE_MEMBERSHIP = 'membership-enabled';
+	public const ENABLE_DONATIONS = 'donation-enabled';
+	public const ENABLE_MEMBERSHIP_APPLICATIONS = 'membership-enabled';
 
 	private $settings = [];
 
@@ -38,34 +39,40 @@ class PaymentTypesSettings {
 	 * @return string[]
 	 */
 	public function getEnabledForDonation(): array {
-		return $this->getEnabledTypes( self::PURPOSE_DONATION );
+		return $this->getPaymentTypesWhereSettingIsTrue( self::ENABLE_DONATIONS );
 	}
 
 	/**
 	 * @return string[]
 	 */
 	public function getEnabledForMembershipApplication(): array {
-		return $this->getEnabledTypes( self::PURPOSE_MEMBERSHIP );
+		return $this->getPaymentTypesWhereSettingIsTrue( self::ENABLE_MEMBERSHIP_APPLICATIONS );
 	}
 
-	public function updateSetting( string $paymentType, string $purpose, bool $value ): void {
+	public function setSettingToFalse( string $paymentType, string $settingName ): void {
 		if ( !array_key_exists( $paymentType, $this->settings ) ) {
 			throw new InvalidArgumentException( "Can not update setting of unknown paymentType '$paymentType'." );
 		}
-		if ( !array_key_exists( $purpose, $this->settings[$paymentType] ) ) {
-			throw new InvalidArgumentException( "Can not update setting of unknown purpose '$purpose'." );
+		if ( !array_key_exists( $settingName, $this->settings[$paymentType] ) ) {
+			throw new InvalidArgumentException( "Can not update setting of unknown purpose '$settingName'." );
 		}
 
-		$this->settings[$paymentType][$purpose] = $value;
+		$this->settings[$paymentType][$settingName] = false;
 	}
 
 	/**
+	 * @param string $settingName
 	 * @return string[]
 	 */
-	private function getEnabledTypes( string $purpose ): array {
-		return array_keys( array_filter( $this->settings, function ( $config ) use ( $purpose ) {
-			return ( $config[$purpose] ?? false ) === true;
-		} ) );
+	private function getPaymentTypesWhereSettingIsTrue( string $settingName ): array {
+		return array_keys(
+			array_filter(
+				$this->settings,
+				function ( $config ) use ( $settingName ) {
+					return ( $config[$settingName] ?? false ) === true;
+				}
+			)
+		);
 	}
 }
 

--- a/src/Presentation/SofortToggleServiceProvider.php
+++ b/src/Presentation/SofortToggleServiceProvider.php
@@ -26,7 +26,7 @@ class SofortToggleServiceProvider implements ServiceProviderInterface, BootableP
 	public function boot( Application $app ): void {
 		$app->before( function( Request $request ): void {
 			if ( $request->query->get( self::QUERY_PARAM_NAME ) === '0' ) {
-				$this->paymentTypesSettings->updateSetting( 'SUB', PaymentTypesSettings::PURPOSE_DONATION, false );
+				$this->paymentTypesSettings->setSettingToFalse( 'SUB', PaymentTypesSettings::ENABLE_DONATIONS );
 			}
 		}, Application::EARLY_EVENT );
 	}

--- a/tests/Unit/Presentation/PaymentTypesSettingsTest.php
+++ b/tests/Unit/Presentation/PaymentTypesSettingsTest.php
@@ -16,20 +16,20 @@ class PaymentTypesSettingsTest extends TestCase {
 	public function testEnabledForDonation(): void {
 		$settings = new PaymentTypesSettings( [
 			'a' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 			'b' => [
-				PaymentTypesSettings::PURPOSE_DONATION => false,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => false,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 			'c' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => false
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => false
 			],
 			'd' => [
-				PaymentTypesSettings::PURPOSE_DONATION => false,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => false
+				PaymentTypesSettings::ENABLE_DONATIONS => false,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => false
 			]
 		] );
 		$this->assertSame( [ 'a', 'c' ], $settings->getEnabledForDonation() );
@@ -38,16 +38,16 @@ class PaymentTypesSettingsTest extends TestCase {
 	public function testEnabledForMembershipApplication(): void {
 		$settings = new PaymentTypesSettings( [
 			'd' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 			'e' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => false
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => false
 			],
 			'f' => [
-				PaymentTypesSettings::PURPOSE_DONATION => false,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => false,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 		] );
 		$this->assertSame( [ 'd', 'f' ], $settings->getEnabledForMembershipApplication() );
@@ -56,12 +56,12 @@ class PaymentTypesSettingsTest extends TestCase {
 	public function testSettingsOnlyTrueWhenStriclySo(): void {
 		$settings = new PaymentTypesSettings( [
 			'a' => [
-				PaymentTypesSettings::PURPOSE_DONATION => 1,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => 'yes'
+				PaymentTypesSettings::ENABLE_DONATIONS => 1,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => 'yes'
 			],
 			'b' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 		] );
 		$this->assertSame( [ 'b' ], $settings->getEnabledForDonation() );
@@ -71,27 +71,27 @@ class PaymentTypesSettingsTest extends TestCase {
 	public function testDisablePurposeForOneType(): void {
 		$settings = new PaymentTypesSettings( [
 			'BEZ' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 			'UEB' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 			'MCP' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 			'PPL' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			],
 			'SUB' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			]
 		] );
-		$settings->updateSetting( 'SUB', PaymentTypesSettings::PURPOSE_DONATION, false );
+		$settings->setSettingToFalse( 'SUB', PaymentTypesSettings::ENABLE_DONATIONS );
 		$this->assertSame( [ 'BEZ', 'UEB', 'MCP', 'PPL' ], $settings->getEnabledForDonation() );
 	}
 
@@ -102,11 +102,11 @@ class PaymentTypesSettingsTest extends TestCase {
 	public function testUpdateSettingWithUnknownPaymentTypeThrowsException(): void {
 		$settings = new PaymentTypesSettings( [
 			'dolor' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			]
 		] );
-		$settings->updateSetting( 'IPSUM', PaymentTypesSettings::PURPOSE_DONATION, false );
+		$settings->setSettingToFalse( 'IPSUM', PaymentTypesSettings::ENABLE_DONATIONS );
 	}
 
 	/**
@@ -116,11 +116,11 @@ class PaymentTypesSettingsTest extends TestCase {
 	public function testUpdateSettingWithUnknownPurposeThrowsException(): void {
 		$settings = new PaymentTypesSettings( [
 			'dolor' => [
-				PaymentTypesSettings::PURPOSE_DONATION => true,
-				PaymentTypesSettings::PURPOSE_MEMBERSHIP => true
+				PaymentTypesSettings::ENABLE_DONATIONS => true,
+				PaymentTypesSettings::ENABLE_MEMBERSHIP_APPLICATIONS => true
 			]
 		] );
-		$settings->updateSetting( 'dolor', 'foo', false );
+		$settings->setSettingToFalse( 'dolor', 'foo' );
 	}
 
 	public function testFunkySettingsNotValidatedButHarmless(): void {


### PR DESCRIPTION
Follow up to https://github.com/wmde/FundraisingFrontend/pull/971

I decreased the generalness of the class a little. It is still quite general, as it deals with "settings" for payment types rather than just if they are enabled or not for memberships or donations. The latter would be easier to understand, but I left this alone, as I don't know why it was done like this.