### PR TITLE
Turn off sendfile on vagrant

### DIFF
--- a/build/vagrant/fundraising_nginx.conf
+++ b/build/vagrant/fundraising_nginx.conf
@@ -7,6 +7,7 @@ server {
     listen 0.0.0.0:8080;
     root  /vagrant/web;
     index index.php;
+    sendfile off;
 
     access_log  /var/log/nginx/fundraising.access.log;
     error_log /var/log/nginx/fundraising.error.log;


### PR DESCRIPTION
Some virtualbox hosts do some strange caching stuff, see
https://serverfault.com/questions/401081/nginx-serves-broken-characters-nginx-on-linux-as-guest-system-in-vbox