### PR TITLE
T177934 HTML meta info as it was before

### DIFF
--- a/skins/cat17/templates/Base_Layout.html.twig
+++ b/skins/cat17/templates/Base_Layout.html.twig
@@ -4,6 +4,17 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<title>Spenden für Freies Wissen - Wikimedia Fördergesellschaft</title>
+
+	<meta name="title" content="Spenden für Freies Wissen - Wikimedia Fördergesellschaft" />
+	<meta name="description" content="Wenn jeder nur einen kleinen Beitrag leisten würde, wäre unsere Spendenkampagne in einer Stunde vorüber." />
+
+	<meta property="og:title" content="Wenn jeder nur einen kleinen Beitrag leisten würde, wäre unsere Spendenkampagne in einer Stunde vorüber." />
+	<meta property="og:type" content="non_profit" />
+	<meta property="og:url" content="https://spenden.wikimedia.de/" />
+	<meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Wikipedia_svg_logo-de.svg/200px-Wikipedia_svg_logo-de.svg.png" />
+	<meta property="og:site_name" content="Gemeinnnützige Wikimedia Fördergesellschaft mbH" />
+	<meta property="og:description" content="Mir liegt Wikipedia am Herzen, deshalb habe ich gespendet. Denn was wäre das Netz ohne Wikipedia?" />
+
 	<link rel="shortcut icon" href="{$ basepath $}/skins/cat17/assets/images/favicon.ico" />
 	<link rel="apple-touch-icon" href="{$ basepath $}/skins/cat17/assets/images/apple-touch-icon.png" />
 	<!--build:css css/styles.min.css-->


### PR DESCRIPTION
* use meta info as it was before ([cp.](https://github.com/wmde/FundraisingFrontend/blob/master/skins/10h16/templates/Base_Layout.html.twig#L8))
* Fixed open graph link to wikipedia logo