### PR TITLE
Update Vagrant node.js to 8

### DIFF
--- a/build/vagrant/install_packages.sh
+++ b/build/vagrant/install_packages.sh
@@ -4,7 +4,7 @@
 add-apt-repository ppa:ondrej/php -y
 
 # Add node.js repo
-curl -sL https://deb.nodesource.com/setup_6.x | bash -
+curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
 apt-get update
 #apt-get upgrade -y


### PR DESCRIPTION
Otherwise npm build-assets will fail on Vagrant for cat17 skin