### PR TITLE
T179940 consistent use of page identifier

### DIFF
--- a/skins/cat17/src/sass/main.scss
+++ b/skins/cat17/src/sass/main.scss
@@ -19,3 +19,9 @@
 @import "layouts/pages";
 @import "layouts/borders-system";
 
+// @fixme Remove when all pages set the correct page_identifier (see Base_Layout.html.twig)
+.page-uncustomized .header h1::after {
+	content: '@todo';
+	color: fuchsia;
+	font-size: 20px;
+}

--- a/skins/cat17/templates/Base_Layout.html.twig
+++ b/skins/cat17/templates/Base_Layout.html.twig
@@ -24,8 +24,8 @@
 	<link rel="stylesheet" href="{$ basepath $}/skins/cat17/css/print.css" media="print">
 	<!--endbuild-->
 </head>
-<body id="{% block page_identifier %}{% endblock%}" class="{% block page_theme %}theme-donation{% endblock %}">
-	<div class="{$ block('page_identifier') $} others">
+<body class="{% block page_theme %}theme-donation{% endblock %}">
+	<div class="page-{% block page_identifier %}uncustomized{% endblock %}">
 		{% include 'partials/' ~ header_template with { page_identifier: block('page_identifier') } only %}
 
 		<main>

--- a/skins/cat17/templates/Display_Page_Layout.twig
+++ b/skins/cat17/templates/Display_Page_Layout.twig
@@ -1,6 +1,6 @@
 {% extends 'Base_Layout.html.twig' %}
 
-{% block page_identifier %}page-{$ page_id $}{% endblock %}
+{% block page_identifier %}{$ page_id $}{% endblock %}
 
 {% block main %}
 	<div class="container">


### PR DESCRIPTION
* consolidate use of page identifier (fixes #999 #997 incompatibility)
* mark page w/o page identifier as todo - meaning, it is very likely that custom styles delivered for that page are not applied (and JS does not work). This has to be fixed by specifying a page identifier in the template, finding the custom CSS/JS, and changing the selectors. Proposal: **Only class-based selector.** 