### PR TITLE
extract messages into content repo

### DIFF
--- a/skins/10h16/templates/Donation_Form_Bank_Data_Confirmation.html.twig
+++ b/skins/10h16/templates/Donation_Form_Bank_Data_Confirmation.html.twig
@@ -98,10 +98,7 @@
 
                         <div class="container clearfix">
                             <input type="checkbox" id="confirm_shortterm" name="confirm_shortterm" value="1"  title="Bestätigung Fristverkürzung">
-                            <label for="confirm_shortterm">
-                                Mit SEPA wurde eine Informationsfrist für Lastschriften eingeführt. Ich bin damit einverstanden,
-                                dass ich spätestens 5 Tage vor der geplanten Abbuchung der Spende per Email benachrichtigt werde.
-                            </label>
+                            <label for="confirm_shortterm">{$ 'donation-confirm-sepa-shortterm'|trans $}</label>
                         </div>
 
                         <hr/>

--- a/skins/10h16/templates/Donation_Form_Personal_Data.html.twig
+++ b/skins/10h16/templates/Donation_Form_Personal_Data.html.twig
@@ -398,7 +398,7 @@
                         <!-- Informationsmaterial -->
                         <div class="container" style="margin-top: 40px; font-size:90%">
                             <input type="checkbox" id="send-information" name="info" value="1" title="Bitte senden Sie mir Informationsmaterial.">
-                            <label for="send-information" style="margin-right: 30px; width: auto;">Ja, ich bin damit einverstanden, dass Wikimedia mich per E-Mail kontaktiert, wenn Wikipedia meine Unterstützung benötigt.</label>
+                            <label for="send-information" style="margin-right: 30px; width: auto;">{$ 'donation-info-opt-in'|trans $}</label>
                             <a href="#" class="right top help tooltip icon-only tooltip-track" data-title="Infomaterial_F2_Intrvar" title="Einmal im Jahr bitten wir die Leserinnen und Leser Wikipedias um Unterstützung. Wir würden uns freuen, wenn wir in Zukunft auf Sie zählen können, wenn es um die Verbreitung Freien Wissens geht."><span class="icon-question-sign"></span></a>
                         </div>
                         <!-- Informationsmaterial -->


### PR DESCRIPTION
While doing [phab:T180170](https://phabricator.wikimedia.org/T180170), I extracted the messages into the content repository,
- label of sepa short term confirmation checkbox in donation form
- label of info opt-in checkbox in donation form

Respective messages were [added](https://github.com/wmde/fundraising-frontend-content/commit/dbb3d4153326fc2957131300ff0bcf1636741d62) into test and production.