### PR TITLE
Show canceled status on confirmation page

### DIFF
--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -157,6 +157,8 @@ class DonationConfirmationHtmlPresenter {
 				return 'status-pledge';
 			case Donation::STATUS_EXTERNAL_BOOKED:
 				return 'status-booked';
+			case Donation::STATUS_CANCELLED:
+				return 'status-canceled';
 			default:
 				return 'status-unknown';
 		}


### PR DESCRIPTION
When a user cancels and then reload the confirmation page, the donation
should be shown with as canceled, not with an "unknown" state.

See https://phabricator.wikimedia.org/T180720

Needs the content from
https://github.com/wmde/fundraising-frontend-content/pull/49 to be
merged.