### PR TITLE
Enable cat17 skin in Dev environment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "install_konto_check", type: "shell", path: "build/installKontoCheck.sh"
   config.vm.provision "restart_ws", type: "shell", inline: "systemctl restart php7.1-fpm"
   config.vm.provision "configure_app", type: "shell", path: "build/vagrant/configure_app.sh"
-  config.vm.provision "install_app", type: "shell", path: "build/vagrant/install_app.sh"
+  config.vm.provision "install_app", type: "shell", path: "build/vagrant/install_app.sh", privileged: false
   config.vm.provision "configure_db", type: "shell", path: "build/vagrant/configureForMysql.sh", env: { DB_PASSWD: ENV["DB_PASSWD"] }
 
 end

--- a/build/vagrant/config.prod.json
+++ b/build/vagrant/config.prod.json
@@ -76,5 +76,16 @@
 		"theme": "x1",
 		"return-url": "https://spenden.wikimedia.de/show-donation-confirmation",
 		"testmode": true
-	}
+	},
+    "skin": {
+        "options": [
+            "10h16", "cat17"
+        ],
+        "default": "10h16",
+        "cookie-lifetime": 2592000
+    },
+    "cookie": {
+        "secure": false,
+        "httpOnly": false
+    }
 }

--- a/skins/cat17/package.json
+++ b/skins/cat17/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "browser-sync": "^2.18.13",
     "gulp": "^3.9.1",
+    "gulp-cli": "^1.4.0",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-changed": "^3.1.0",
     "gulp-concat": "^2.6.1",


### PR DESCRIPTION
* Install npm and composer packages as non-privileged user to avoid npm
  errors.
* Install gulp-cli as a dependency to be able to run gulp.
* Keep dist directory (but not its contents) in repo.
* Enable skin in Vagrant dist configuration and loosen cookie setting to
  be able to store the skin name without using https.