### PR TITLE
T180339 Fix validation for email 10h16

### DIFF
--- a/skins/10h16/templates/Donation_Form_Personal_Data.html.twig
+++ b/skins/10h16/templates/Donation_Form_Personal_Data.html.twig
@@ -391,7 +391,7 @@
 
                         <div class="input-container">
                             <label for="email">E-Mail</label>
-                            <input id="email" name="email" type="text" value="{$ email $}" placeholder="z.B. name@domain.de" class="required">
+                            <input id="email" name="email" type="text" value="{$ email $}" placeholder="z.B. name@domain.de" class="required" data-pattern="^[^@]+@.+$">
                             <span class="validation icon-placeholder"></span>
                         </div>
 

--- a/skins/10h16/web/_js/donationForm.js
+++ b/skins/10h16/web/_js/donationForm.js
@@ -30,7 +30,7 @@ $( function () {
 			WMDE.Components.createValidatingTextComponent( store, $( '#post-code' ), 'postcode' ),
 			WMDE.Components.createValidatingTextComponent( store, $( '#city' ), 'city' ),
 			WMDE.Components.createSelectMenuComponent( store, $( '#country' ), 'country' ),
-			WMDE.Components.createTextComponent( store, $( '#email' ), 'email' ),
+			WMDE.Components.createValidatingTextComponent( store, $( '#email' ), 'email' ),
 			WMDE.Components.createValidatingCheckboxComponent( store, $( '#confirm_sepa' ), 'confirmSepa' ),
 			WMDE.Components.createValidatingCheckboxComponent( store, $( '#confirm_shortterm' ), 'confirmShortTerm' )
 		],


### PR DESCRIPTION
The email field was always valid after it was filled and then removed,
since there was no client-side validation, only server-side when the
field was filled. Now the email is always checked on the client side
with a (very lenient) regex pattern, that says "field must contain at
least two characters, separated by an at-sign".

The error does not exist on cat17, no need to change that skin.

This is for https://phabricator.wikimedia.org/T180339