### PR TITLE
enable track-and-redirect for all external payments

### DIFF
--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -55,7 +55,7 @@ class AddDonationHandler {
 	}
 
 	private function sendTrackingDataIfNeeded( Request $request, AddDonationResponse $responseModel ) {
-		if ( $request->get( 'mbt', '' ) !== '1' || $responseModel->getDonation()->getPaymentType() !== PaymentType::PAYPAL ) {
+		if ( $request->get( 'mbt', '' ) !== '1' || !$responseModel->getDonation()->hasExternalPayment() ) {
 			return;
 		}
 

--- a/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/AddDonationRouteTest.php
@@ -716,7 +716,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 		];
 	}
 
-	public function testWhenMobileTrackingIsRequested_piwikTrackerIsNotCalledForNonPaypalPayment(): void {
+	public function testWhenMobileTrackingIsRequested_piwikTrackerIsNotCalledForNonExternalPayment(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ): void {
 			$factory->setNullMessenger();
 			$client->followRedirects( false );
@@ -730,7 +730,7 @@ class AddDonationRouteTest extends WebRouteTestCase {
 				'POST',
 				'/donation/add',
 				array_merge(
-					$this->newValidCreditCardInput(),
+					$this->newValidBankTransferInput(),
 					['mbt' => '1']
 				)
 			);


### PR DESCRIPTION
This PR extends the "track-and-redirect" functionality to all external payment types. Needed for [phab:T181292](https://phabricator.wikimedia.org/T181292)

related PR in wmde/fundraising-banners#65