### PR TITLE
Fix double title on membership confirmation page

### DIFF
--- a/skins/10h16/templates/Membership_Application_Confirmation.html.twig
+++ b/skins/10h16/templates/Membership_Application_Confirmation.html.twig
@@ -68,7 +68,7 @@
 						<div class="address f-left">
 							<p class="title"><strong>Ihre Daten</strong></p>
 							<p>
-								<span class="confirm-name">{$ person.salutation $} {$ person.title $} {$ person.fullName $}</span>
+								<span class="confirm-name">{$ person.salutation $} {$ person.fullName $}</span>
 							</p>
 
 							<p class="no-margin">


### PR DESCRIPTION
https://phabricator.wikimedia.org/T181392

fullName already includes the title

```php
'fullName' => $applicant->getName()->getFullName(),
```

```php
	public function getFullName(): string {
		return join( ', ', array_filter( [
			$this->getFullPrivatePersonName(),
			$this->companyName
		] ) );
	}

	private function getFullPrivatePersonName(): string {
		return join( ' ', array_filter( [
			$this->getTitle(),
			$this->getFirstName(),
			$this->getLastName()
		] ) );
	}
```