### PR TITLE
Fix amount selection

### DIFF
--- a/skins/cat17/src/app/lib/form_components.js
+++ b/skins/cat17/src/app/lib/form_components.js
@@ -194,9 +194,7 @@ module.exports = {
 			) );
 		} );
 		selectElement.on( 'change', function ( evt ) {
-			store.dispatch( actions.newSelectAmountAction(
-				numberParser.parse( evt.target.value )
-			) );
+			store.dispatch( actions.newSelectAmountAction( evt.target.value ) );
 		} );
 		return component;
 	},

--- a/skins/cat17/src/app/tests/test_form_components.js
+++ b/skins/cat17/src/app/tests/test_form_components.js
@@ -213,7 +213,7 @@ test( 'Rendering the amount component with non-custom amount sets the hidden fie
 	t.end();
 } );
 
-test( 'Changing the amount selection dispatches select action with parsedContent', function ( t ) {
+test( 'Changing the amount selection dispatches select action with selected value', function ( t ) {
 	var textElement = createSpyingElement(),
 		selectElement = createSpyingElement(),
 		hiddenElement = createSpyingElement(),
@@ -223,8 +223,8 @@ test( 'Changing the amount selection dispatches select action with parsedContent
 		store = {
 			dispatch: sinon.spy()
 		},
-		fakeEvent = { target: { value: '50,00' } },
-		expectedAction = { type: 'SELECT_AMOUNT', payload: { amount: 'XX50,00YY' } };
+		fakeEvent = { target: { value: 5000 } },
+		expectedAction = { type: 'SELECT_AMOUNT', payload: { amount: 5000 } };
 
 	formComponents.createAmountComponent( store, textElement, selectElement, hiddenElement, dummyAmountParser );
 


### PR DESCRIPTION
This commit avoids anounts*100 when the amount is selected instead of
typed.

The change in template values made it necessary to pass the value from
the select field as-is.