### PR TITLE
Fix JS CI

### DIFF
--- a/npm_skins.js
+++ b/npm_skins.js
@@ -17,5 +17,10 @@ fs.readdirSync( skins ).forEach( function ( skin ) {
 		return;
 	}
 
-	cp.spawn( 'npm', commands, { env: process.env, cwd: skinPath, stdio: 'inherit' } );
+	cp.spawn( 'npm', commands, { env: process.env, cwd: skinPath, stdio: 'inherit' } )
+		.on( 'close', function( code ) {
+			if ( code !== 0 ) {
+				process.exitCode = code;
+			}
+		} );
 } );

--- a/skins/10h16/js/tests/test_simple_currency_formatter.js
+++ b/skins/10h16/js/tests/test_simple_currency_formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require( 'tape-catch' ),
+var test = require( 'tape' ),
 	createCurrencyFormatter = require( '../lib/simple_currency_formatter' ).createCurrencyFormatter,
 	expectedFormattedAmountInGermanLocale = '23,00' + String.fromCharCode( 160 ) + '€',
 	expectedFormattedAmountInEnglishLocale = '€23.00'


### PR DESCRIPTION
* fix fat-fingered replacement in wrong skin
* make sure skin exit codes propagate to project level - this was a bug in the npm task spawning ([exit status 1, and green still](https://travis-ci.org/wmde/FundraisingFrontend/jobs/308870387#L4527))