### PR TITLE
Remove deprecated template method for errors

### DIFF
--- a/skins/10h16/templates/Error_Page.html.twig
+++ b/skins/10h16/templates/Error_Page.html.twig
@@ -1,3 +1,6 @@
+{% extends 'Base_Layout.html.twig' %}
+
+{% block main %}
 		<section id="error-page">
 			<div class="container clearfix">
 				<div class="ltcol">
@@ -40,3 +43,4 @@
 				</div>
 			</div>
 		</section>
+{% endblock %}

--- a/skins/10h16/templates/System_Message.html.twig
+++ b/skins/10h16/templates/System_Message.html.twig
@@ -1,34 +1,38 @@
-<section>
-	<div class="container clearfix">
-		<div class="ltcol">
-			&nbsp;
-		</div>
+{% extends 'Base_Layout.html.twig' %}
 
-		<div class="ctcol">
-			<div class="box partial rounded no-margin">
-				<div class="box-header container clearfix">
-					<span class="icon-bug">Fehler</span>
-				</div>
+{% block main %}
+	<section>
+		<div class="container clearfix">
+			<div class="ltcol">
+				&nbsp;
+			</div>
 
-				<div class="box-section box-footer">
-					<div class="container clearfix">
-						<p>
-							{$ message|trans()|raw $}
-						</p>
+			<div class="ctcol">
+				<div class="box partial rounded no-margin">
+					<div class="box-header container clearfix">
+						<span class="icon-bug">Fehler</span>
+					</div>
+
+					<div class="box-section box-footer">
+						<div class="container clearfix">
+							<p>
+								{$ message| trans | raw $}
+							</p>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
 
-		<div class="rtcol">
-			<div class="icon-hand-right _icon-list-item last">
-				<p>
-					<strong>Spenden</strong>
-				</p>
-				<p>
-					<a href="{$ path( '/' ) $}" target="_blank">Zurück</a> zur Spendenseite
-				</p>
+			<div class="rtcol">
+				<div class="icon-hand-right _icon-list-item last">
+					<p>
+						<strong>Spenden</strong>
+					</p>
+					<p>
+						<a href="{$ path( '/' ) $}" target="_blank">Zurück</a> zur Spendenseite
+					</p>
+				</div>
 			</div>
 		</div>
-	</div>
 </section>
+{% endblock %}

--- a/skins/cat17/templates/Error_Page.html.twig
+++ b/skins/cat17/templates/Error_Page.html.twig
@@ -1,21 +1,25 @@
-<div class="container">
-	<div class="row">
-		<div class="content col-xs-12 col-sm-10 col-md-8">
-			<h1>{$ 'error_page_header' | trans $}</h1>
+{% extends 'Base_Layout.html.twig' %}
 
-			<p>
-				{$ 'error_page' | trans $}
-			</p>
+{% block main %}
+	<div class="container">
+		<div class="row">
+			<div class="content col-xs-12 col-sm-10 col-md-8">
+				<h1>{$ 'error_page_header' | trans $}</h1>
 
-			{% if message is defined %}
 				<p>
-					{$ message $}
+					{$ 'error_page' | trans $}
 				</p>
-			{% endif %}
 
-			<p>
-				<a href="{$ path( '/' ) $}">{$ 'error_pages_return_to_donation' | trans $}</a>
-			</p>
+				{% if message is defined %}
+					<p>
+						{$ message $}
+					</p>
+				{% endif %}
+
+				<p>
+					<a href="{$ path( '/' ) $}">{$ 'error_pages_return_to_donation' | trans $}</a>
+				</p>
+			</div>
 		</div>
 	</div>
-</div>
+{% endblock %}

--- a/skins/cat17/templates/System_Message.html.twig
+++ b/skins/cat17/templates/System_Message.html.twig
@@ -1,15 +1,19 @@
-<div class="container">
-	<div class="row">
-		<div class="content col-xs-12 col-sm-10 col-md-8">
-			<h1>{$ 'system_message_page_header' | trans $}</h1>
+{% extends 'Base_Layout.html.twig' %}
 
-			<p>
-				{$ message | trans | raw $}
-			</p>
+{% block main %}
+	<div class="container">
+		<div class="row">
+			<div class="content col-xs-12 col-sm-10 col-md-8">
+				<h1>{$ 'system_message_page_header' | trans $}</h1>
 
-			<p>
-				<a href="{$ path( '/' ) $}">{$ 'error_pages_return_to_donation' | trans $}</a>
-			</p>
+				<p>
+					{$ message | trans | raw $}
+				</p>
+
+				<p>
+					<a href="{$ path( '/' ) $}">{$ 'error_pages_return_to_donation' | trans $}</a>
+				</p>
+			</div>
 		</div>
 	</div>
-</div>
+{% endblock %}

--- a/skins/test/templates/Donation_Form.html.twig
+++ b/skins/test/templates/Donation_Form.html.twig
@@ -27,3 +27,5 @@ Payment data: {% if validationResult.paymentData == true %}valid{% else %}invali
 Tracking data:
 Impression Count: {$ tracking.impressionCount $}
 Banner Impression Count: {$ tracking.bannerImpressionCount $}
+
+{% include 'Piwik.twig' %}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -865,7 +865,7 @@ class FunFunFactory {
 	}
 
 	public function newInternalErrorHtmlPresenter(): InternalErrorHtmlPresenter {
-		return new InternalErrorHtmlPresenter( $this->getIncludeTemplate( 'Error_Page.html.twig' ) );
+		return new InternalErrorHtmlPresenter( $this->getLayoutTemplate( 'Error_Page.html.twig' ) );
 	}
 
 	public function newAccessDeniedHtmlPresenter(): InternalErrorHtmlPresenter {
@@ -1399,8 +1399,8 @@ class FunFunFactory {
 	}
 
 	public function newSystemMessageResponse( string $message ): string {
-		$test = $this->getIncludeTemplate( 'System_Message.html.twig' );
-		return $test->render( [ 'message' => $message ] );
+		return $this->getLayoutTemplate( 'System_Message.html.twig' )
+			->render( [ 'message' => $message ] );
 	}
 
 	public function getMembershipApplicationTimeframeLimit(): string {

--- a/tests/EdgeToEdge/PiwikTest.php
+++ b/tests/EdgeToEdge/PiwikTest.php
@@ -13,13 +13,13 @@ class PiwikTest extends WebRouteTestCase {
 	const PIWIK_SITE_ID = 1;
 
 	public function testPiwikScriptGetsEmbedded(): void {
-		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
+		$client = $this->createClient( [], null, self::ENABLE_DEBUG );
 		$client->request( 'GET', '/' );
 		$this->assertContains( '<!-- Piwik -->', $client->getResponse()->getContent() );
 	}
 
 	public function testConfigParametersAreUsed(): void {
-		$client = $this->createClient( [], null, self::DISABLE_DEBUG );
+		$client = $this->createClient( [], null, self::ENABLE_DEBUG );
 		$client->request( 'GET', '/' );
 
 		$this->assertContains( 'tracking.wikimedia.de', $client->getResponse()->getContent() );


### PR DESCRIPTION
Use getLayoutTemplate instead of getIncludeTemplate.

Had to adapt PiwikTest: when debug is enabled in the client,
there seems to be an internal error (which is why the test
worked before, because the donation/new template does not contain
the Piwik inlcude).