### PR TITLE
T181982 Membership type deeplink

### DIFF
--- a/skins/cat17/templates/Membership_Application.html.twig
+++ b/skins/cat17/templates/Membership_Application.html.twig
@@ -10,6 +10,11 @@
 {% set initialPaymentType = paymentTypes|length == 1 ? paymentTypes|first : '' %}
 {% set initialFormValues = initialFormValues | merge( { 'paymentType': initialPaymentType } ) %}
 
+{% set showMembershipTypeOption = showMembershipTypeOption is defined ? showMembershipTypeOption : 'true' %}
+{% if showMembershipTypeOption != 'true' %}
+	{% set initialFormValues = initialFormValues | merge( { 'membershipType': 'sustaining' } ) %}
+{% endif %}
+
 {% block page_identifier %}membership{% endblock %}
 {% block page_theme %}membership{% endblock %}
 
@@ -41,7 +46,9 @@
 							<li class="col-xs-12 col-sm-6">{$ 'membership_benefit_list_1' | trans $}</li>
 							<li class="col-xs-12 col-sm-6">{$ 'membership_benefit_list_2' | trans $}</li>
 							<li class="col-xs-12 col-sm-6">{$ 'membership_benefit_list_3' | trans $}</li>
-							<li class="col-xs-12 col-sm-6">{$ 'membership_benefit_list_4' | trans $}</li>
+							{% if showMembershipTypeOption == 'true' %}
+								<li class="col-xs-12 col-sm-6">{$ 'membership_benefit_list_4' | trans $}</li>
+							{% endif %}
 							<li class="col-xs-12 col-sm-6">{$ 'membership_benefit_list_5' | trans $}</li>
 						</ul>
 					</div>
@@ -63,7 +70,7 @@
 
 				<div class="form-shadow-wrap col-xs-12 col-sm-8 col-md-8">
 
-					<section id="membership-type" class="donation-amount clearfix">
+					<section id="membership-type" class="donation-amount clearfix"{% if showMembershipTypeOption != 'true' %} style="display:none"{% endif %}>
 						<h2 class="">{$ 'membership_section_membership_type_title' | trans $}</h2>
 
 						<fieldset id="type-membership"
@@ -98,6 +105,12 @@
 
 						</fieldset>
 					</section>
+
+					{% if showMembershipTypeOption == 'true' %}
+						<input type="hidden" name="showMembershipTypeOption" value="true" />
+					{% else %}
+						<input type="hidden" name="showMembershipTypeOption" value="false" />
+					{% endif %}
 
 					<section id="donation-type" class="donation-daten clearfix">
 						<h2>{$ 'membership_section_applicant_title' | trans $}</h2>

--- a/skins/cat17/templates/Membership_Application.html.twig
+++ b/skins/cat17/templates/Membership_Application.html.twig
@@ -2,7 +2,13 @@
 
 {% set COUNTRIES = [ 'DE', 'AT', 'CH', 'BE', 'IT', 'LI', 'LU' ] %}
 {% set PAYMENT_INTERVALS = [ 1, 3, 6, 12 ] %}
+
+{% if initialFormValues is not defined or initialFormValues is null %}
+	{% set initialFormValues = {} %}
+{% endif %}
+
 {% set initialPaymentType = paymentTypes|length == 1 ? paymentTypes|first : '' %}
+{% set initialFormValues = initialFormValues | merge( { 'paymentType': initialPaymentType } ) %}
 
 {% block page_identifier %}membership{% endblock %}
 {% block page_theme %}membership{% endblock %}
@@ -306,7 +312,7 @@
 {% block scripts %}
 	<script type="text/javascript" src="{$ basepath|e('html_attr') $}{$ '/skins/cat17/scripts/wmde.js'|prefix_file $}"></script>
 	<script id="init-form" src="{$ basepath|e('html_attr') $}{$ '/skins/cat17/scripts/membershipForm.js'|prefix_file $}"
-		data-initial-form-values="{% if initialFormValues %}{$ initialFormValues|merge({'paymentType': initialPaymentType})|json_encode|e('html_attr') $}{% else %}{$ {'paymentType': initialPaymentType}|json_encode|e('html_attr') $}{% endif %}"
+		data-initial-form-values="{$ initialFormValues | json_encode | e( 'html_attr' ) $}"
 		data-violated-fields="{% if violatedFields %}{$ violatedFields|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
 		data-validate-fee-url="{$ basepath|e('html_attr') $}/validate-fee"
 		data-validate-address-url="{$ basepath|e('html_attr') $}/validate-address"


### PR DESCRIPTION
* optional visibility of membership type in membership application

Decided not to remove the elements from the rendered DOM entirely to avoid adverse effects in JS, which could only be programmatically avoided (with sane code) _after_ refactoring (`main.js` in particular).