### PR TITLE
T181732 align amount-typed field with other inputs

### DIFF
--- a/skins/cat17/src/sass/layouts/_landing.scss
+++ b/skins/cat17/src/sass/layouts/_landing.scss
@@ -136,31 +136,11 @@ form {
                 height: 60px;
                 width: 100%;
                 position: relative;
-
-				@include themify($themes) {
-					border: themed('border2pxfieldNormal');
-                    background-color: themed('fieldNormal');
-				}
-                &.focused {
-                    @include themify($themes) {
-                          border-bottom: themed('border2pxPrimary');
-                      }
-                    &.filled {
-                        border-bottom: 2px solid #000000;
-                    }
-                }
                 input {
                     height: 56px;
                     width: 100%;
 					padding-right: 25px;
                     text-align: right;
-                    @include themify($themes) {
-                        border: themed('border2pxfieldNormal');
-                        background-color: themed('fieldNormal');
-                    }
-                    &:focus {
-                        outline: none;
-                    }
                 }
 				@media ( min-width: $screen-xs-min ) and ( max-width: $screen-xs-max ) {
 					margin-right: 7px;
@@ -187,12 +167,13 @@ form {
                     }
                 }
 				&:after {
-					content: "€";
+					content: attr( data-currency );
+					font-family: $font-main;
+					font-size: 12px;
 					position: absolute;
 					right: 10px;
                     top: 50%;
                     transform: translateY(-50%);
-
 				}
             }
 			input#amount-typed:invalid {

--- a/skins/cat17/templates/Donation_Form.html.twig
+++ b/skins/cat17/templates/Donation_Form.html.twig
@@ -65,7 +65,7 @@
 							<div class="wrap-amounts">
 								{% include 'partials/payment_preset_amounts.html.twig' with { 'presetAmounts': [ 5, 15, 25, 50, 75, 100, 250, 300 ] } %}
 
-								<div class="wrap-amount-typed">
+								<div class="wrap-amount-typed field-grp" data-currency="€">
 									<input type="text" id="amount-typed">
 								</div>
 								<input type="hidden" name="betrag" id="amount-hidden">

--- a/skins/cat17/templates/Membership_Application.html.twig
+++ b/skins/cat17/templates/Membership_Application.html.twig
@@ -265,7 +265,7 @@
 							<div class="wrap-amounts">
 								{% include 'partials/payment_preset_amounts.html.twig' with { 'presetAmounts': [ 5, 15, 25, 50, 75, 100, 250, 300 ] } %}
 
-								<div class="wrap-amount-typed">
+								<div class="wrap-amount-typed field-grp" data-currency="€">
 									<input type="text" id="amount-typed">
 								</div>
 								<input type="hidden" name="membership_fee" id="amount-hidden">


### PR DESCRIPTION
* align amount-typed field with other inputs
* take currency symbol from template instead of hard-coding in CSS [0]

[0] https://caniuse.com/#feat=css-gencontent