### PR TITLE
T182434 - Fix donation cancellation template

### DIFF
--- a/skins/10h16/templates/Donation_Cancellation_Confirmation.html.twig
+++ b/skins/10h16/templates/Donation_Cancellation_Confirmation.html.twig
@@ -1,3 +1,6 @@
+{% extends 'Base_Layout.html.twig' %}
+
+{% block main %}
 <section>
 	<div class="container clearfix">
 		<div class="ltcol">
@@ -9,9 +12,9 @@
 				<div class="box-header container clearfix">
 					<span class="icon-bug">
 						{% if cancellationSuccessful %}
-							{$ 'donation-cancellation-header'|trans({}) $}
+							{$ 'donation_cancellation_header'|trans({}) $}
 						{% else %}
-							{$ 'donation-cancellation-failed-header'|trans({}) $}
+							{$ 'donation_cancellation_failed_header'|trans({}) $}
 						{% endif %}
 					</span>
 				</div>
@@ -20,14 +23,20 @@
 					<div class="container clearfix">
 						<p>
 							{% if cancellationSuccessful %}
-								{$ 'donation-cancellation-text'|trans( { '%donation.id%': donationId } )|raw $}
+								{$ 'donation_cancellation_text' | trans( {
+									'%donation.id%': donationId,
+									'%mailto_link%': 'spenden@wikimedia.de?subject=Online-Spende%20%' ~ donation.id
+								} ) | raw $}
 							{% else %}
-								{$ 'donation-cancellation-failed-text'|trans( { '%donation.id%': donationId } )|raw $}
+								{$ 'donation_cancellation_failed_text' | trans( {
+									'%donation.id%': donationId ,
+									'%mailto_link%': 'spenden@wikimedia.de?subject=Online-Spende%20%' ~ donation.id
+								} ) | raw $}
 							{% endif %}
 						</p>
 						<p>
 							{% if mailDeliveryFailed %}
-								{$ 'donation-cancellation-mail-delivery-failure'|trans|raw $}
+								{$ 'donation_cancellation_mail_delivery_failure'|trans|raw $}
 							{% endif %}
 						</p>
 					</div>
@@ -47,3 +56,4 @@
 		</div>
 	</div>
 </section>
+{% endblock %}

--- a/skins/cat17/src/sass/layouts/_pages.scss
+++ b/skins/cat17/src/sass/layouts/_pages.scss
@@ -91,17 +91,6 @@ main.conclusion {
 	}
 }
 
-.donation-cancel {
-	.introduction {
-		margin-bottom: 60px;
-		@include bkp(sm) {
-			margin-bottom: 25vh;
-		}
-	}
-}
-
-@import "pages/contact";
-
 .donation-comment {
 	form {
 		margin-top: 25px;
@@ -168,9 +157,11 @@ main.conclusion {
 	}
 }
 
+@import "pages/contact";
 @import "pages/comments_list";
 @import "pages/donation_confirmation";
 @import "pages/donation_receipt";
+@import "pages/donation_cancel";
+@import "pages/membership_confirmation";
 @import "pages/privacy_protection";
 @import "pages/use_of_resources";
-@import "pages/membership_confirmation";

--- a/skins/cat17/src/sass/layouts/pages/donation_cancel.scss
+++ b/skins/cat17/src/sass/layouts/pages/donation_cancel.scss
@@ -1,0 +1,6 @@
+.page-donation-cancel {
+  .h2 {
+    font-size: 16px;
+    line-height: 26px;
+  }
+}

--- a/skins/cat17/templates/Donation_Cancellation_Confirmation.html.twig
+++ b/skins/cat17/templates/Donation_Cancellation_Confirmation.html.twig
@@ -1,30 +1,42 @@
-<div class="container">
-	<div class="row">
-		<div class="content col-xs-12 col-sm-10 col-md-8">
-			<h2 class="sr-only">Spende stornieren</h2>
+{% extends 'Base_Layout.html.twig' %}
 
-			<p class="h1">
-				{% if cancellationSuccessful %}
-					{$ 'donation-cancellation-header'|trans $}
-				{% else %}
-					{$ 'donation-cancellation-failed-header'|trans $}
-				{% endif %}
-			</p>
-			<p class="h2">
-				{% if cancellationSuccessful %}
-					{$ 'donation-cancellation-text'|trans( { '%donation.id%': donationId } )|raw $}
-				{% else %}
-					{$ 'donation-cancellation-failed-text'|trans( { '%donation.id%': donationId } )|raw $}
-				{% endif %}
-			</p>
+{% block page_identifier %}donation-cancel{% endblock %}
 
-			{% if mailDeliveryFailed %}
-				<p class="h2">
-					{$ 'donation-cancellation-mail-delivery-failure'|trans|raw $}
+{% block main %}
+	<div class="container">
+		<div class="row">
+			<div class="content col-xs-12 col-sm-10 col-md-8">
+				<h2 class="sr-only">Spende stornieren</h2>
+
+				<p class="h1">
+					{% if cancellationSuccessful %}
+						{$ 'donation_cancellation_header' | trans $}
+					{% else %}
+						{$ 'donation_cancellation_failed_header' | trans $}
+					{% endif %}
 				</p>
-			{% endif %}
-		</div>
+				<p class="h2">
+					{% if cancellationSuccessful %}
+						{$ 'donation_cancellation_text' | trans( {
+							'%donation.id%': '<span class="strong field">' ~ donationId ~ '</span>' ,
+							'%mailto_link%': 'spenden@wikimedia.de?subject=Online-Spende%20' ~ donationId
+						} ) | raw $}
+					{% else %}
+						{$ 'donation_cancellation_failed_text' | trans( {
+							'%donation.id%': '<span class="strong field">' ~ donationId ~ '</span>',
+							'%mailto_link%': 'spenden@wikimedia.de?subject=Online-Spende%20' ~ donationId,
+						} ) | raw $}
+					{% endif %}
+				</p>
 
-		{% include 'partials/back_link.html.twig' %}
+				{% if mailDeliveryFailed %}
+					<p class="h2">
+						{$ 'donation_cancellation_mail_delivery_failure' | trans | raw $}
+					</p>
+				{% endif %}
+			</div>
+
+			{% include 'partials/back_link.html.twig' %}
+		</div>
 	</div>
-</div>
+{% endblock %}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1098,7 +1098,7 @@ class FunFunFactory {
 
 	public function newCancelDonationHtmlPresenter(): CancelDonationHtmlPresenter {
 		return new CancelDonationHtmlPresenter(
-			$this->getIncludeTemplate( 'Donation_Cancellation_Confirmation.html.twig' )
+			$this->getLayoutTemplate( 'Donation_Cancellation_Confirmation.html.twig' )
 		);
 	}
 


### PR DESCRIPTION
Make cancellation template a layouted template, to get rid of the "todo"
designator.

Move CSS to its own file.

Change translation message keys from kebab-case to snake_case and
extract mailto link.

This is for https://phabricator.wikimedia.org/T182434

Needs https://github.com/wmde/fundraising-frontend-content/pull/66 to be merged