### PR TITLE
T182423 Improve error message CSS

### DIFF
--- a/skins/cat17/src/sass/components/_forms.scss
+++ b/skins/cat17/src/sass/components/_forms.scss
@@ -116,14 +116,14 @@ input[type=submit] {
 
 .error-text {
 	color: $brand-error;
-	padding-left: 16px;
-	margin-bottom: 30px;
+	margin-bottom: 2em;
+	display: inline-block;
 }
 
 .warning-text {
 	color: $brand-warning;
-	padding-left: 16px;
-	margin-bottom: 30px;
+	margin-bottom: 2em;
+	display: inline-block;
 }
 
 label, input#amount-typed, .wrap-amount-typed:after{


### PR DESCRIPTION
* Remove left padding to avoid indentation on multiline error messages.
* Add `display: inline-block` to enable margin below the element.
* Set margin to em value that is not too big, but still adds enough
  whitespace to show which field the error message belongs to.

This also solves the bad positioning mentioned in https://phabricator.wikimedia.org/T180042#3808770