### PR TITLE
T182400 Hide detail elements properly

### DIFF
--- a/skins/cat17/src/sass/components/_state-overview.scss
+++ b/skins/cat17/src/sass/components/_state-overview.scss
@@ -408,9 +408,6 @@
                     .overview-text {
                         padding-top: 20px;
                     }
-                    .info-text-bottom {
-                        display: block;
-                    }
                 }
                 &.error, &.invalid {
                     .wrap-input {
@@ -439,8 +436,6 @@
                     }
                 }
                 .info-text-bottom {
-                    display: block;
-					overflow: visible;
                     &.opened {
                         padding-left: 0;
                     }

--- a/skins/cat17/src/sass/layouts/_landing.scss
+++ b/skins/cat17/src/sass/layouts/_landing.scss
@@ -1,13 +1,8 @@
 
 .info-text, .wrap-check, .info-text-bottom{
-    opacity: 0;
-    //transition:  opacity 500ms ease-out, height 500ms ease-out;
-    height: 0;
-    overflow: hidden;
-    display: block;
+    display: none;
 	&.opened {
-        opacity: 1;
-        height: auto;
+        display:block;
 	}
 	.icon-done {
 		position: absolute;
@@ -15,15 +10,10 @@
 		right: 10px;
 	}
 }
-.info-text.opened{
-	overflow: visible;
-	height: auto;
-}
 
 .info-text-bottom {
 	@include bkp(lg) {
-		opacity:1;
-		height: auto;
+		display: block;
 	}
 
 }


### PR DESCRIPTION
Use `display: none` instead of `opacity` and `height` for hiding detail
elements. The latter were vestiges of trying to animate showing and
hiding the elements but since the animation was commented out anyways by
the 3rd party, we can use display and avoid invisible overlapping
elements that obstruct the submit button.