### PR TITLE
DNM - use twig path() function

### DIFF
--- a/skins/cat17/templates/partials/donation_confirmation/direct_debit.html.twig
+++ b/skins/cat17/templates/partials/donation_confirmation/direct_debit.html.twig
@@ -63,7 +63,11 @@
     <div class="row">
         <nav class="menu menu-footer col-xs-12 col-sm-5 col-sm-offset-7 col-md-offset-8 col-md-4">
             <ul class="list-menu list-unstyled">
-                <li><a href="{$ commentUrl $}"><span>{$ "add_donation_comment" | trans $}</span></a></li>
+                <li>
+                    <a href="{$ path( 'commentUrl', { donation.id: donationId, updateToken: donation.updateToken, accessToken: donation.accessToken } ) $}">
+                        <span>{$ "add_donation_comment" | trans $}</span>
+                    </a>
+                </li>
                 {% include 'partials/share_on_social_networks.html.twig' %}
             </ul>
         </nav>

--- a/skins/cat17/templates/partials/donation_confirmation/external_payment.html.twig
+++ b/skins/cat17/templates/partials/donation_confirmation/external_payment.html.twig
@@ -53,7 +53,11 @@
     <div class="row">
         <nav class="menu menu-footer col-xs-12 col-sm-5 col-sm-offset-7 col-md-offset-8 col-md-4">
         <ul class="list-menu list-unstyled">
-            <li><a href="{$ commentUrl $}"><span>{$ "add_donation_comment" | trans $}</span></a></li>
+            <li>
+                <a href="{$ path( 'commentUrl', { donation.id: donationId, updateToken: donation.updateToken, accessToken: donation.accessToken } ) $}">
+                    <span>{$ "add_donation_comment" | trans $}</span>
+                </a>
+            </li>
             {% include 'partials/share_on_social_networks.html.twig' %}
         </ul>
         </nav>

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -55,20 +55,13 @@ class DonationConfirmationHtmlPresenter {
 				'creationDate' => ( new \DateTime() )->format( 'd.m.Y' ),
 				// TODO: set cookie duration for "hide banner cookie"
 				'cookieDuration' => '15552000', // 180 days
-				'updateToken' => $updateToken
+				'updateToken' => $updateToken,
+				'accessToken' => $accessToken
 			],
 			'person' => $this->getPersonArguments( $donation ),
 			'bankData' => $this->getBankDataArguments( $donation->getPaymentMethod() ),
 			'initialFormValues' => $this->getInitialMembershipFormValues( $donation ),
 			'piwikEvents' => $piwikEvents->getEvents(),
-			'commentUrl' => $this->urlGenerator->generateUrl(
-				'AddCommentPage',
-				[
-					'donationId' => $donation->getId(),
-					'updateToken' => $updateToken,
-					'accessToken' =>$accessToken
-				]
-			)
 		];
 	}
 


### PR DESCRIPTION
While working on this supposed improvement I started thinking this is actually making things worse.

I think we should not have logic in the twig templates. This URL building might not be application or domain logic and be presentation specific (though not as much as the twig template), yet it is still logic. If the template constructs the URL it needs to know which data is in the URL and what the names of the parameters are. There is no need for the template for have this knowledge.

Consider the left bottom part of this Clean Architecture diagram:

![Clean Architecture](https://user-images.githubusercontent.com/146040/34028386-fc1e616a-e162-11e7-8bf5-10886232e056.jpg)

The Presenter gets the Response Model from the UC (in our case the UC does not give this directly to the Presenter but that does not matter for the topic at hand). In the diagram the Presenter constructs a View Model, which like the Reponse Model of the UC is a Data Transfer Object, and hands it to the View. This object is supposed to contain all the data the View needs, in the form the view needs it. This means the view might contain loops and if statements to choose if some section should be shown or not, but no further logic. One important effect of this is that the views are so simple that they do not require automated testing.

I'm not sure if I ever brought that up already, yet I've been viewing the twig templates used directly by the presenters as having the role of the View in this diagram, and the argument list we provide to them as the View Model. If you follow that, then it is clear URL construction should go in the Presenter, not in the Twig template (View).