### PR TITLE
Avoid endless loop on empty select elements

### DIFF
--- a/skins/cat17/src/app/lib/form_components.js
+++ b/skins/cat17/src/app/lib/form_components.js
@@ -60,7 +60,8 @@ var objectAssign = require( 'object-assign' ),
 				return;
 			}
 
-			this.element.val( [ formContent[ this.contentName ] ] ).change();
+			this.element.val( [ formContent[ this.contentName ] ] );
+			this.element.change();
 		},
 		elementAndContentAreEmpty: function( formContent ) {
 			// calling this.element.val( '' ) leads to this.element.val() === null in some cases,
@@ -242,5 +243,7 @@ module.exports = {
 			}
 		} ) );
 		return textComponent;
-	}
+	},
+
+	SelectComponent: SelectComponent
 };

--- a/skins/cat17/src/app/lib/form_components.js
+++ b/skins/cat17/src/app/lib/form_components.js
@@ -55,11 +55,17 @@ var objectAssign = require( 'object-assign' ),
 		contentName: '',
 		onChange: null,
 		render: function ( formContent ) {
-			if ( this.element.val() === formContent[ this.contentName ] ) {
+
+			if ( this.element.val() === formContent[ this.contentName ]  || this.elementAndContentAreEmpty( formContent ) ) {
 				return;
 			}
 
 			this.element.val( [ formContent[ this.contentName ] ] ).change();
+		},
+		elementAndContentAreEmpty: function( formContent ) {
+			// calling this.element.val( '' ) leads to this.element.val() === null in some cases,
+			// so we need to compare different types
+			return this.element.val() === null && formContent[ this.contentName ] === '';
 		}
 	},
 

--- a/skins/cat17/src/app/tests/test_form_components.js
+++ b/skins/cat17/src/app/tests/test_form_components.js
@@ -4,6 +4,7 @@
 var test = require( 'tape-catch' ),
 	sinon = require( 'sinon' ),
 	formComponents = require( '../lib/form_components' ),
+	objectAssign = require( 'object-assign' ),
 	createSpyingElement = function () {
 		return {
 			on: sinon.spy(),
@@ -346,3 +347,43 @@ test( 'addEagerChangeBehavior calls onChange and validator handler on keypress e
 	t.end();
 } );
 
+test( 'SelectComponent renders when value changed', function ( t ) {
+	var element = {
+			val: sinon.stub(),
+			change: sinon.stub()
+		},
+		component = objectAssign( Object.create( formComponents.SelectComponent ), {
+			element: element,
+			contentName: 'somesome'
+		} );
+
+	element.val.withArgs().returns( '6' ); // .val() is both the getter and setter method
+
+	component.render( { somesome: '5' } );
+
+	t.equals( element.val.callCount, 3 );
+	t.deepEquals( element.val.thirdCall.args[ 0 ], [ '5' ], 'value gets set' );
+	t.ok( element.change.calledOnce );
+
+	t.end();
+} );
+
+test( 'SelectComponent treats null like empty string in update check', function ( t ) {
+	var element = {
+			val: sinon.stub(),
+			change: sinon.stub()
+		},
+		component = objectAssign( Object.create( formComponents.SelectComponent ), {
+			element: element,
+			contentName: 'lorem'
+		} );
+
+	element.val.withArgs().returns( null ); // .val() is both the getter and setter method
+
+	component.render( { lorem: '' } );
+
+	t.equals( element.val.callCount, 2 );
+	t.ok( element.change.notCalled );
+
+	t.end();
+} );


### PR DESCRIPTION
The usual "has this element the exact value from the store" comparison
failed because the empty string that is set gets converted to `null`.