### PR TITLE
T182419 - Set header element class during scrolling

### DIFF
--- a/skins/cat17/src/app/lib/scrolling.js
+++ b/skins/cat17/src/app/lib/scrolling.js
@@ -75,10 +75,13 @@ var objectAssign = require( 'object-assign' ),
 	AnimatedScroller = {
 		fixedHeaderElements: null,
 		scrollTo: function( $element, options ) {
+			var self = this;
+			this.fixedHeaderElements.addClass( 'scrolling' );
 			$( 'html, body' ).stop( true ).animate( {
 				scrollTop: calculateElementOffset( $element, this.fixedHeaderElements, options )
 			}, 1000, function () {
 				// Callback after animation
+				self.fixedHeaderElements.removeClass( 'scrolling' );
 				// Must change focus!
 				$element.focus();
 				if ($element.is( ':focus' ) ) { // Checking if the target was focused

--- a/skins/cat17/src/app/tests/test_form_data_extractor.js
+++ b/skins/cat17/src/app/tests/test_form_data_extractor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require( 'tape' ),
+var test = require( 'tape-catch' ),
 	sinon = require( 'sinon' ),
 	extractor = require( '../lib/form_data_extractor' )
 ;

--- a/skins/cat17/src/app/tests/test_integer_currency.js
+++ b/skins/cat17/src/app/tests/test_integer_currency.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var test = require( 'tape' ),
+var test = require( 'tape-catch' ),
 	IntegerCurrency = require( '../lib/integer_currency' )
 ;
 

--- a/skins/cat17/src/sass/components/_state-overview.scss
+++ b/skins/cat17/src/sass/components/_state-overview.scss
@@ -162,7 +162,7 @@
 		margin: 0 auto;
 		padding: 0;
 	}
-	&.active {
+	&.active, &.scrolling {
 		opacity: 1;
 		height: auto;
 		position: fixed;

--- a/skins/cat17/src/scripts/donationForm.js
+++ b/skins/cat17/src/scripts/donationForm.js
@@ -299,9 +299,6 @@ $( function () {
 		var $introBanner = $('.introduction-banner');
 		$introBanner.insertBefore( nextRequired ).removeClass( 'hidden' );
 
-		// The fixed horizontal state bar is hidden initially and only shown when scrolling, which leads to wrong offset.
-		// Thus, we have to make it visible for offset calculation.
-		$( '.state-bar' ).addClass( 'active' );
 		scroller.scrollTo( $introBanner, { elementStart: WMDE.Scrolling.ElementStart.MARGIN } );
 	}
 


### PR DESCRIPTION
The header status bar becomes only visible (with the CSS class `active`)
after a certain scroll position which messes with the calculation of the
final scroll offset.

This change introduces the `scrolling` CSS class that is only active on
an element when scrolling iwth the `scrollTo` method. By giving it the
same CSS properties as `active`, the element has the proper height
before the offset is calculated.

This also improves on the kind of hackish solution of https://phabricator.wikimedia.org/T182790