### PR TITLE
check data attribute exists to prevent vagueness

### DIFF
--- a/skins/cat17/src/app/lib/form_components.js
+++ b/skins/cat17/src/app/lib/form_components.js
@@ -24,12 +24,9 @@ var objectAssign = require( 'object-assign' ),
 
 	createRegexValidator = function ( store, contentName ) {
 		return function ( evt ) {
-			var optionalAttribute = evt.target.getAttribute( 'data-optional' ),
-				fieldIsOptional;
-			if ( optionalAttribute === null || typeof optionalAttribute === 'undefined' ) {
-				fieldIsOptional = false;
-			} else {
-				fieldIsOptional = JSON.parse( optionalAttribute );
+			var fieldIsOptional = false;
+			if ( evt.target.hasAttribute( 'data-optional' ) ) {
+				fieldIsOptional = JSON.parse( evt.target.getAttribute( 'data-optional' ) );
 			}
 			store.dispatch( actions.newValidateInputAction(
 				contentName,

--- a/skins/cat17/src/app/tests/test_form_components.js
+++ b/skins/cat17/src/app/tests/test_form_components.js
@@ -78,11 +78,12 @@ test( 'Change handler of components dispatches validation action to store', func
 		store = {
 			dispatch: sinon.spy()
 		},
-		fakeEvent = { target: { value: 'current value', getAttribute: sinon.stub() } },
+		fakeEvent = { target: { value: 'current value', getAttribute: sinon.stub(), hasAttribute: sinon.stub() } },
 		expectedAction = { type: 'VALIDATE_INPUT', payload: { contentName: 'city', value: 'current value', pattern: '^.+$', optionalField: false } },
 		component = formComponents.createValidatingTextComponent( store, element, 'city' );
 
 	fakeEvent.target.getAttribute.withArgs( 'data-pattern' ).returns( '^.+$' );
+	fakeEvent.target.hasAttribute.withArgs( 'data-optional' ).returns( false );
 	component.validator( fakeEvent );
 
 	t.ok( store.dispatch.calledWith( expectedAction ), 'action contains event value and element pattern' );
@@ -90,16 +91,17 @@ test( 'Change handler of components dispatches validation action to store', func
 	t.end();
 } );
 
-test( 'Change handler of components passes optional attribute when dispacthing validation action to store', function ( t ) {
+test( 'Change handler of component passes optional attribute when dispatching validation action to store', function ( t ) {
 	var element = createSpyingElement(),
 		store = {
 			dispatch: sinon.spy()
 		},
-		fakeEvent = { target: { value: 'current value', getAttribute: sinon.stub() } },
+		fakeEvent = { target: { value: 'current value', getAttribute: sinon.stub(), hasAttribute: sinon.stub() } },
 		expectedAction = { type: 'VALIDATE_INPUT', payload: { contentName: 'city', value: 'current value', pattern: '^.+$', optionalField: true } },
 		component = formComponents.createValidatingTextComponent( store, element, 'city' );
 
 	fakeEvent.target.getAttribute.withArgs( 'data-pattern' ).returns( '^.+$' );
+	fakeEvent.target.hasAttribute.withArgs( 'data-optional' ).returns( true );
 	fakeEvent.target.getAttribute.withArgs( 'data-optional' ).returns( 'true' );
 	component.validator( fakeEvent );
 


### PR DESCRIPTION
For #1152

Got scared by the native .getAttribute(), apparently rightfully so
https://developer.mozilla.org/de/docs/Web/API/Element/getAttribute#Notes