### PR TITLE
add context specific payment interval notices

### DIFF
--- a/skins/cat17/templates/Donation_Form.html.twig
+++ b/skins/cat17/templates/Donation_Form.html.twig
@@ -64,7 +64,7 @@
 							class="show-info padding-right-4 col-xs-12 col-sm-8 col-sm-offset-right-4 col-md-6 col-md-offset-right-7 no-gutter-left">
 							<legend class="sr-only">{$ 'payment_interval_legend' | trans $}</legend>
 
-							{% include 'partials/payment_intervals.html.twig' with { 'intervals': PAYMENT_INTERVALS, 'fieldName': 'periode' } only %}
+							{% include 'partials/payment_intervals.html.twig' with { 'context': 'donation', 'intervals': PAYMENT_INTERVALS, 'fieldName': 'periode' } only %}
 						</fieldset>
 					</section>
 

--- a/skins/cat17/templates/Membership_Application.html.twig
+++ b/skins/cat17/templates/Membership_Application.html.twig
@@ -268,7 +268,7 @@
 								  class="show-info padding-right-4 col-xs-12 col-sm-8 col-sm-offset-right-4 col-md-6 col-md-offset-right-7 no-gutter-left">
 							<legend class="sr-only">{$ 'membership_section_interval_legend' | trans $}</legend>
 
-							{% include 'partials/payment_intervals.html.twig' with { 'intervals': PAYMENT_INTERVALS, 'fieldName': 'membership_fee_interval' } only %}
+							{% include 'partials/payment_intervals.html.twig' with { 'context': 'membership', 'intervals': PAYMENT_INTERVALS, 'fieldName': 'membership_fee_interval' } only %}
 
 							<div class="more-info">
 								<p>{$ 'membership_section_fee_minimum_info' | trans $}</p>

--- a/skins/cat17/templates/partials/payment_intervals.html.twig
+++ b/skins/cat17/templates/partials/payment_intervals.html.twig
@@ -12,7 +12,7 @@
 } %}
 {% spaceless %}
 {% for interval in intervals %}
-	<div class="wrap-field" data-info-text="{$ ( 'payment_interval_' ~ interval ~ '_info' ) | trans | e( 'html_attr' ) $}">
+	<div class="wrap-field" data-info-text="{$ ( context ~ '_payment_interval_' ~ interval ~ '_info' ) | trans | e( 'html_attr' ) $}">
 		<div class="wrap-input">
 			<input type="radio" name="{$ fieldName $}" id="{$ PAYMENT_INTERVAL_OPTIONS[interval].id $}" value="{$ interval $}">
 			<label for="{$ PAYMENT_INTERVAL_OPTIONS[interval].id $}">

--- a/skins/cat17/templates/partials/payment_intervals.html.twig
+++ b/skins/cat17/templates/partials/payment_intervals.html.twig
@@ -1,6 +1,7 @@
-{# paramters:
+{# parameters:
 	intervals List of interval types to actually show
 	fieldName Name of the form fields used to submit the selected interval
+	context The context by which this partial was included (can be either `membership` or `donation`)
 #}
 {% set PAYMENT_INTERVAL_OPTIONS = {
 	0:  { 'id': 'one-time', 'icon': 'icon-unique' },

--- a/skins/cat17/templates/partials/payment_intervals.html.twig
+++ b/skins/cat17/templates/partials/payment_intervals.html.twig
@@ -21,7 +21,7 @@
 		</div>
 
 		<p class="info-text" data-info="{$ PAYMENT_INTERVAL_OPTIONS[interval].id $}">
-			{$ ( 'payment_interval_' ~ interval ~ '_info' ) | trans $}
+			{$ ( context ~ '_payment_interval_' ~ interval ~ '_info' ) | trans $}
 		</p>
 	</div>
 {% endfor %}


### PR DESCRIPTION
This uses the context specific payment interval notices introduced in wmde/fundraising-frontend-content#89.

See also: [phab:T183463](https://phabricator.wikimedia.org/T183463)