### PR TITLE
integrate latest donations + fix

### DIFF
--- a/app/RouteHandlers/PayPalNotificationHandler.php
+++ b/app/RouteHandlers/PayPalNotificationHandler.php
@@ -63,10 +63,14 @@ class PayPalNotificationHandler {
 	}
 
 	private function requestIsForPaymentCompletion( ParameterBag $post ): bool {
-		return $this->isSuccessfulPaymentNotification( $post ) || (
-				$this->isForRecurringPayment( $post ) &&
-				!$this->isRecurringPaymentCompletion( $post )
-			);
+		if ( !$this->isSuccessfulPaymentNotification( $post ) ) {
+			return false;
+		}
+		if ( $this->isForRecurringPayment( $post ) && !$this->isRecurringPaymentCompletion( $post ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	private function isSuccessfulPaymentNotification( ParameterBag $post ): bool {

--- a/composer.lock
+++ b/composer.lock
@@ -3276,12 +3276,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-donations.git",
-                "reference": "9fae93c26006c6f831c5e9188011b31b9f29512a"
+                "reference": "1fe504656af13a445eb8de60db99a7d1b860df01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/9fae93c26006c6f831c5e9188011b31b9f29512a",
-                "reference": "9fae93c26006c6f831c5e9188011b31b9f29512a",
+                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/1fe504656af13a445eb8de60db99a7d1b860df01",
+                "reference": "1fe504656af13a445eb8de60db99a7d1b860df01",
                 "shasum": ""
             },
             "require": {
@@ -3333,7 +3333,7 @@
                 "source": "https://github.com/wmde/fundraising-donations/tree/master",
                 "issues": "https://github.com/wmde/fundraising-donations/issues"
             },
-            "time": "2017-12-19T11:45:45+00:00"
+            "time": "2017-12-19T12:50:19+00:00"
         },
         {
             "name": "wmde/fundraising-store",

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -285,7 +285,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			$this->assertSame( 200, $client->getResponse()->getStatusCode() );
 
 			$this->assertSame(
-				[ 'Unhandled PayPal subscription notification' ],
+				[ 'PayPal request not handled' ],
 				$logger->getLogCalls()->getMessages()
 			);
 

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
 use Symfony\Component\HttpKernel\Client;
+use Symfony\Component\HttpFoundation\Request;
 use WMDE\Fundraising\Frontend\DonationContext\Domain\Repositories\DonationRepository;
 use WMDE\Fundraising\Frontend\DonationContext\Tests\Data\ValidDonation;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
@@ -32,6 +33,7 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 	const DONATION_ID = 1;
 	const VALID_VERIFICATION_RESPONSE = 'VERIFIED';
 	const FAILING_VERIFICATION_RESPONSE = 'FAIL';
+	private const PATH = '/handle-paypal-payment-notification';
 
 	public function testGivenValidRequest_applicationIndicatesSuccess(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ): void {
@@ -47,8 +49,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				$this->newHttpParamsForPayment()
 			);
 
@@ -167,8 +169,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				[
 					'receiver_email' => 'mr.robot@evilcorp.com',
 					'payment_status' => 'Completed'
@@ -190,8 +192,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				$params
 			);
 
@@ -215,8 +217,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			$factory->setPaypalLogger( $logger );
 
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				$this->newPendingPaymentParams()
 			);
 
@@ -239,8 +241,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			);
 
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				$this->newHttpParamsForPayment()
 			);
 
@@ -258,8 +260,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			$requestData = $this->newHttpParamsForPayment();
 			$requestData['mc_currency'] = 'DOGE';
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				$requestData
 			);
 
@@ -277,8 +279,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			$factory->setPaypalLogger( $logger );
 
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				$this->newSubscriptionModificationParams()
 			);
 
@@ -379,8 +381,8 @@ class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 			$factory->setPaypalLogger( $logger );
 
 			$client->request(
-				'POST',
-				'/handle-paypal-payment-notification',
+				Request::METHOD_POST,
+				self::PATH,
 				$this->newValidRequestParametersWithNegativeTransactionFee()
 			);
 

--- a/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/HandlePayPalPaymentNotificationRouteTest.php
@@ -26,13 +26,13 @@ use WMDE\PsrLogTestDoubles\LoggerSpy;
  */
 class HandlePayPalPaymentNotificationRouteTest extends WebRouteTestCase {
 
-	const BASE_URL = 'https://that.paymentprovider.com/';
-	const EMAIL_ADDRESS = 'foerderpp@wikimedia.de';
-	const ITEM_NAME = 'My preciousss';
-	const UPDATE_TOKEN = 'my_secret_token';
-	const DONATION_ID = 1;
-	const VALID_VERIFICATION_RESPONSE = 'VERIFIED';
-	const FAILING_VERIFICATION_RESPONSE = 'FAIL';
+	private const BASE_URL = 'https://that.paymentprovider.com/';
+	private const EMAIL_ADDRESS = 'foerderpp@wikimedia.de';
+	private const ITEM_NAME = 'My preciousss';
+	private const UPDATE_TOKEN = 'my_secret_token';
+	private const DONATION_ID = 1;
+	private const VALID_VERIFICATION_RESPONSE = 'VERIFIED';
+	private const FAILING_VERIFICATION_RESPONSE = 'FAIL';
 	private const PATH = '/handle-paypal-payment-notification';
 
 	public function testGivenValidRequest_applicationIndicatesSuccess(): void {


### PR DESCRIPTION
Apparently https://github.com/wmde/FundraisingFrontend/pull/1140 failed to update to the changes provided by https://github.com/wmde/fundraising-donations/pull/33, i.e. never really integrated them - basically what I meant in [this comment](https://github.com/wmde/FundraisingFrontend/pull/1140#discussion_r157697594); but back then I did not understand why the test would pass...

Fix is in ad36b4e - the fact that the bug was introduced seems to prove the point that the guard notation ([originally here](https://github.com/wmde/fundraising-donations/commit/37df0f35adf8042b7b662b1d944bdf4086658aa5#diff-8a070cff273db3663316ce1fe0a4a2a3L46)) is easier to grasp.
  
This
* constitutes a [prod bug](https://phabricator.wikimedia.org/T184059#3871573)
* blocks #1164
* blocks #1167