### PR TITLE
Make code more functional

### DIFF
--- a/src/Presentation/Presenters/CreditCardNotificationPresenter.php
+++ b/src/Presentation/Presenters/CreditCardNotificationPresenter.php
@@ -48,17 +48,15 @@ class CreditCardNotificationPresenter {
 	 * @see https://www.micropayment.de/help/documentation/
 	 */
 	private function render( array $result ): string {
-		return array_reduce(
+		return implode(
+			'',
 			array_map(
 				function( $key, $value ): string {
-					return $key . self::VALUE_ASSIGNMENT . $value;
+					return $key . self::VALUE_ASSIGNMENT . $value . self::ARG_SEPARATOR;
 				},
 				array_keys( $result ),
 				array_values( $result )
-			),
-			function( $accumulator, string $argument ): string {
-				return $accumulator . $argument . self::ARG_SEPARATOR;
-			}
+			)
 		);
 	}
 }

--- a/src/Presentation/Presenters/CreditCardNotificationPresenter.php
+++ b/src/Presentation/Presenters/CreditCardNotificationPresenter.php
@@ -48,9 +48,17 @@ class CreditCardNotificationPresenter {
 	 * @see https://www.micropayment.de/help/documentation/
 	 */
 	private function render( array $result ): string {
-		array_walk( $result, function( & $value, $key ) {
-			$value = $key . self::VALUE_ASSIGNMENT . $value;
-		} );
-		return implode( self::ARG_SEPARATOR, $result ) . self::ARG_SEPARATOR;
+		return array_reduce(
+			array_map(
+				function( $key, $value ): string {
+					return $key . self::VALUE_ASSIGNMENT . $value;
+				},
+				array_keys( $result ),
+				array_values( $result )
+			),
+			function( $accumulator, string $argument ): string {
+				return $accumulator . $argument . self::ARG_SEPARATOR;
+			}
+		);
 	}
 }


### PR DESCRIPTION
The below was written for the first commit:

PHP, Y U NO two array arguments for array_reduce?! <o>

If it had, the code would just be

```php
return array_reduce(
    function( string $accumulator, string $key, $value ): string {
        return $accumulator . $key . self::VALUE_ASSIGNMENT . $value . self::ARG_SEPARATOR;
    },
    array_keys( $result ),
    array_values( $result )
);
```
  