### PR TITLE
Override local repo changes on deploy checkout

### DIFF
--- a/deployment/tasks/build.yml
+++ b/deployment/tasks/build.yml
@@ -8,7 +8,7 @@
 # All other variables come from the inventory file.
 
 - name: Checkout code
-  git: repo=https://github.com/wmde/FundraisingFrontend.git dest={{ build_dir }} version={{ build_branch }}
+  git: repo=https://github.com/wmde/FundraisingFrontend.git dest={{ build_dir }} version={{ build_branch }} force=yes
 
 - name: Install PHP dependencies
   composer: command=install working_dir={{ build_dir }} no_dev={{ composer_no_dev }} optimize_autoloader=yes


### PR DESCRIPTION
This change is mainly motivated by an unwanted npm behavior where the
package-lock.json file is modified at the "Install JavaScript
dependencies" step, which prevents further deployments.

However, overriding "local changes" is a good idea anyway, IMHO. If some
local process or (malicious) user on the deployment machine has modified
something, we don't want to deploy that change.