### PR TITLE
Ignore tmp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ web/skins
 
 deployment/deployment.retry
 deployment/inventory
+
+tmp/


### PR DESCRIPTION
The tmp directory is created by the make install-js command and never
purged, however, it should never be committed