### PR TITLE
Improve README and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,15 @@ install-js:
 install-php:
 	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) composer install --ignore-platform-reqs $(COMPOSER_FLAGS)
 
+update-js:
+	-mkdir -p $(TMPDIR)/home
+	-echo "node:x:$(current_user):$(current_group)::/var/nodehome:/bin/bash" > $(TMPDIR)/passwd
+	docker run --rm $(DOCKER_FLAGS) --user $(current_user):$(current_group) -v $(BUILD_DIR)/skins/cat17:/data:delegated -w /data -v $(TMPDIR)/home:/var/nodehome:delegated -v $(TMPDIR)/passwd:/etc/passwd node:8 npm update $(NPM_FLAGS)
+	docker run --rm $(DOCKER_FLAGS) --user $(current_user):$(current_group) -v $(BUILD_DIR)/skins/10h16:/data:delegated -w /data -v $(TMPDIR)/home:/var/nodehome:delegated -v $(TMPDIR)/passwd:/etc/passwd node:8 npm update $(NPM_FLAGS)
+
+update-php:
+	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) composer update --ignore-platform-reqs $(COMPOSER_FLAGS)
+
 default-config:
 	cp build/app/config.prod.json app/config
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ TMPDIR        := $(BUILD_DIR)/tmp
 COMPOSER_FLAGS :=
 NPM_FLAGS     := --prefer-offline
 DOCKER_FLAGS  := --interactive --tty
+TEST_DIR :=
+REDUX_LOG :=
 
 install-js:
 	-mkdir -p $(TMPDIR)/home
@@ -14,8 +16,11 @@ install-js:
 install-php:
 	docker run --rm $(DOCKER_FLAGS) --volume $(BUILD_DIR):/app -w /app --volume ~/.composer:/composer --user $(current_user):$(current_group) composer install --ignore-platform-reqs $(COMPOSER_FLAGS)
 
+default-config:
+	cp build/app/config.prod.json app/config
+
 js:
-	docker run --rm $(DOCKER_FLAGS) --user $(current_user):$(current_group) -v $(BUILD_DIR):/data:delegated -w /data -e NO_UPDATE_NOTIFIER=1 node:8 npm run build-assets
+	docker run --rm $(DOCKER_FLAGS) --user $(current_user):$(current_group) -v $(BUILD_DIR):/data:delegated -w /data -e NO_UPDATE_NOTIFIER=1 -e REDUX_LOG=$(REDUX_LOG) node:8 npm run build-assets
 	docker run --rm $(DOCKER_FLAGS) --user $(current_user):$(current_group) -v $(BUILD_DIR):/data:delegated -w /data -e NO_UPDATE_NOTIFIER=1 node:8 npm run copy-assets
 
 clear:
@@ -25,14 +30,15 @@ ui: clear js
 
 test: covers phpunit
 
-setup:
+setup-db:
 	docker-compose run --rm app ./vendor/bin/doctrine orm:schema-tool:create
+	docker-compose run --rm app ./vendor/bin/doctrine orm:generate-proxies var/doctrine_proxies
 
 covers:
 	docker-compose run --rm --no-deps app ./vendor/bin/covers-validator
 
 phpunit:
-	docker-compose run --rm app ./vendor/bin/phpunit
+	docker-compose run --rm app ./vendor/bin/phpunit $(TEST_DIR)
 
 phpunit-system:
 	docker-compose run --rm app ./vendor/bin/phpunit tests/System/
@@ -56,5 +62,7 @@ npm-ci:
 	docker run --rm $(DOCKER_FLAGS) --user $(current_user):$(current_group) -v $(BUILD_DIR):/code -w /code -e NO_UPDATE_NOTIFIER=1 node:8 npm run ci
 
 ci: covers phpunit cs npm-ci validate-app-config stan
+
+setup: install-php install-js default-config ui setup-db
 
 .PHONY: ci clear covers cs install-php install-js js npm-ci npm-install phpmd phpunit phpunit-system setup stan test ui validate-app-config

--- a/README.md
+++ b/README.md
@@ -5,40 +5,41 @@
 User facing application for the [Wikimedia Deutschland](https://wikimedia.de) fundraising.
 
 * [Installation](#installation)
-* [Configuration](#configuration)
 * [Running the application](#running-the-application)
+* [Configuration](#configuration)
 * [Running the tests](#running-the-tests)
+* [Emails](#emails)
+* [Frontend development](#frontend-development)
 * [Skins](#skins)
+* [Updating the dependencies](#updating-the-dependencies)
 * [Deployment](#deployment)
+* [Profiling](#profiling)
 * [Project structure](#project-structure)
-
+* [See also](#see-also)
 
 ## Installation
 
-For development you need to have Docker and [Docker-compose](https://docs.docker.com/compose/) installed.
+For development you need to have Docker and [docker-compose](https://docs.docker.com/compose/) installed.
 Local PHP and Composer are not needed.
 
     sudo apt-get install docker docker-compose
 
-Get a clone of our git repository and then run these commands in it:
+Get a clone of our git repository and then run:
 
-Install PHP dependencies
+    make setup
 
-    make install-php
-        
-Copy the example configuration
+This will
+ 
+- Install PHP and Node.js dependencies with composer and npm
+- Copy a basic configuration file. See section [Configuration](#configuration) for more details on the configuration.
+- (Re-)Create the database structure and generate the Doctrine Proxy classes
+- Build the assets & JavaScript
 
-    cp build/app/config.prod.json app/config
+## Running the application
 
-(Re-)Create Database
+    docker-compose up
 
-    docker-compose run --rm app ./vendor/bin/doctrine orm:schema-tool:create
-    docker-compose run --rm app ./vendor/bin/doctrine orm:generate-proxies var/doctrine_proxies
-
-Build Assets & Javascript
-
-    make install-js
-    make js
+The application can now be reached at http://localhost:8082/index.php, debug info will be shown in your CLI.
 
 ## Configuration
 
@@ -47,13 +48,15 @@ Build Assets & Javascript
 To speed up the tests when running them locally, use SQLite instead of the default MySQL. This can be done by
 adding the file `app/config/config.test.local.json` with the following content:
 
-    {
-    	"db": {
-    		"driver": "pdo_sqlite",
-    		"memory": true
-    	}
+```json
+{
+    "db": {
+        "driver": "pdo_sqlite",
+        "memory": true
     }
-    
+}
+```
+
 ### Payments
 
 For a fully working instance with all payment types and working templates you need to fill out the following
@@ -74,12 +77,6 @@ The following example shows the configuration when the content repository is at 
 
     "i18n-base-path": "../fundraising-frontend-content/i18n"
 
-## Running the application
-
-    docker-compose up
-
-The application can now be reached at http://localhost:8082/index.php, debug info will be shown in your CLI.
-
 ## Running the tests
 
 ### Full CI run
@@ -89,16 +86,16 @@ The application can now be reached at http://localhost:8082/index.php, debug inf
 ### For tests only
 
     make test
-    docker run -it --rm --user $(id -u):$(id -g) -v "$PWD":/data digitallyseamless/nodejs-bower-grunt npm run test
+    docker run -it --rm --user $(id -u):$(id -g) -v $(pwd):/app -w /app node:8 npm run test
 
 ### For style checks only
 
     make cs
-    docker run -it --rm --user $(id -u):$(id -g) -v "$PWD":/data digitallyseamless/nodejs-bower-grunt npm run cs
+    docker run -it --rm --user $(id -u):$(id -g) -v $(pwd):/app -w /app node:8 npm run cs
 
 For one context only
 
-    vendor/bin/phpunit contexts/DonationContext/
+    make phpunit TEST_DIR=contexts/PaymentContext
 
 ### phpstan
 
@@ -111,37 +108,59 @@ In the absence of dev-dependencies (i.e. to simulate the vendor/ code on product
 
 These tasks are also performed during the [travis](.travis.yml) runs.
 
-### JS
 ## Emails
 
 All emails sent by the application can be inspected via [mailhog](https://github.com/mailhog/MailHog)
 at [http://localhost:8025/](http://localhost:8025/)
 
-## JS
+## Frontend development
 
 For a full JS CI run
 
-	docker run -it --rm --user $(id -u):$(id -g) -v "$PWD":/data digitallyseamless/nodejs-bower-grunt npm run ci
+    make ci
 
 If JavaScript files where changed, you will need to (re)run
 
-    docker run -it --rm --user $(id -u):$(id -g) -v "$PWD":/data digitallyseamless/nodejs-bower-grunt npm run build-js
+    make js
 
-If you are working on the JavaScript files and need automatic recompilation when a files changes, then run
+If you want to debug problems in the Redux data flow, use the command
 
-    docker run -it --rm --user $(id -u):$(id -g) -v "$PWD":/data digitallyseamless/nodejs-bower-grunt npm run watch-js
-
-If you want to debug problems in the Redux data flow, set the following variable in the shell environment:
-
-    export REDUX_LOG=on
+    make js REDUX_LOG=on
 
 Actions and their resulting state will be logged.
+    
+### Automatic recompilation of assets during development
+
+If you are working on the JavaScript files and need automatic recompilation when a files changes, 
+you can run the following Docker commands 
+
+Run the Docker command corresponding to the skin:
+
+    docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/app -v $(pwd)/web/skins/cat17:/app/skins/cat17/web -w /app/skins/cat17 -e NO_UPDATE_NOTIFIER=1 node:8 npm run watch
+    docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/app -v $(pwd)/web/skins/10h16:/app/skins/10h16/web -w /app/skins/10h16 -e NO_UPDATE_NOTIFIER=1 node:8 npm run watch 
+
+If you want to debug problems in the Redux data flow add the parameter `-e REDUX_LOG=on` to the command line above
+
+Actions and their resulting state will be logged.
+
+Until [issue T192906](https://phabricator.wikimedia.org/T192906) is fixed, the commands `make js` and `make ui` will 
+issue (harmless) error messages as long as the symlinks are in place. 
 
 ## Skins
 
 If skin assets where changed, you will need to run
 
-    docker run -it --rm --user $(id -u):$(id -g) -v "$PWD":/data digitallyseamless/nodejs-bower-grunt npm run build-assets
+    make ui
+
+## Updating the dependencies
+
+To update the PHP dependencies, run
+
+    docker run --rm -it -v $(pwd):/app -v ~/.composer:/composer -u $(id -u):$(id -g) composer update --ignore-platform-reqs
+
+To update the dependencies of a skin edit its package.json file and run
+
+    make install-js 
 
 ## Deployment
 
@@ -256,6 +275,7 @@ persistence, you should use `TestEnvironment` defined in `tests/TestEnvironment.
 ### Other directories
 
 * `deployment/`: Ansible scripts and configuration for deploying the application
+* `build/`: Configuration and Dockerfiles for the development environment and Travis CI
 
 ## See also
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,19 @@ If skin assets where changed, you will need to run
 
 ## Updating the dependencies
 
-To update the PHP dependencies, run
+To update all the PHP dependencies, run
 
-    docker run --rm -it -v $(pwd):/app -v ~/.composer:/composer -u $(id -u):$(id -g) composer update --ignore-platform-reqs
+    make update-php
 
-To update the dependencies of a skin edit its package.json file and run
+For updating an individual package, use the command line
 
-    make install-js 
+    docker run --rm -it -v $(pwd):/app -v ~/.composer:/composer -u $(id -u):$(id -g) composer update --ignore-platform-reqs PACKAGE_NAME
+
+and replace the `PACKAGE_NAME` placeholder with the name of your package.
+
+To update the skins, run
+
+    make update-js 
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 User facing application for the [Wikimedia Deutschland](https://wikimedia.de) fundraising.
 
+<!-- toc -->
+
 * [Installation](#installation)
 * [Running the application](#running-the-application)
 * [Configuration](#configuration)
@@ -16,6 +18,8 @@ User facing application for the [Wikimedia Deutschland](https://wikimedia.de) fu
 * [Profiling](#profiling)
 * [Project structure](#project-structure)
 * [See also](#see-also)
+
+<!-- tocstop -->
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,470 @@
 {
-  "name": "wmde_fundraising",
-  "version": "2.0.0-dev",
-  "lockfileVersion": 1
+	"name": "wmde_fundraising",
+	"version": "2.0.0-dev",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"ansi-red": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "1.0.3"
+			}
+		},
+		"autolinker": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
+			"integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI=",
+			"dev": true
+		},
+		"buffer-from": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+			"dev": true
+		},
+		"coffee-script": {
+			"version": "1.12.7",
+			"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+			"integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+			"dev": true
+		},
+		"concat-stream": {
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"dev": true,
+			"requires": {
+				"buffer-from": "1.0.0",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"typedarray": "0.0.6"
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"diacritics-map": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+			"integrity": "sha1-bfwP+dAQAKLt8oZTccrDFulJd68=",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"dev": true
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "2.2.3"
+			}
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "0.1.1"
+			}
+		},
+		"fill-range": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+			"dev": true,
+			"requires": {
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "1.1.7",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"gray-matter": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+			"integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+			"dev": true,
+			"requires": {
+				"ansi-red": "0.1.1",
+				"coffee-script": "1.12.7",
+				"extend-shallow": "2.0.1",
+				"js-yaml": "3.11.0",
+				"toml": "2.3.3"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"js-yaml": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"dev": true,
+			"requires": {
+				"argparse": "1.0.10",
+				"esprima": "4.0.0"
+			}
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "1.1.6"
+			}
+		},
+		"lazy-cache": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+			"integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+			"dev": true,
+			"requires": {
+				"set-getter": "0.1.0"
+			}
+		},
+		"list-item": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+			"integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
+			"dev": true,
+			"requires": {
+				"expand-range": "1.8.2",
+				"extend-shallow": "2.0.1",
+				"is-number": "2.1.0",
+				"repeat-string": "1.6.1"
+			}
+		},
+		"markdown-link": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+			"integrity": "sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=",
+			"dev": true
+		},
+		"markdown-toc": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+			"integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+			"dev": true,
+			"requires": {
+				"concat-stream": "1.6.2",
+				"diacritics-map": "0.1.0",
+				"gray-matter": "2.1.1",
+				"lazy-cache": "2.0.2",
+				"list-item": "1.1.1",
+				"markdown-link": "0.1.1",
+				"minimist": "1.2.0",
+				"mixin-deep": "1.3.1",
+				"object.pick": "1.3.0",
+				"remarkable": "1.7.1",
+				"repeat-string": "1.6.1",
+				"strip-color": "0.1.0"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "2.0.4"
+					}
+				}
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"randomatic": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+			"dev": true,
+			"requires": {
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "3.2.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "1.1.6"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "1.1.6"
+					}
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
+			}
+		},
+		"remarkable": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
+			"integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
+			"dev": true,
+			"requires": {
+				"argparse": "0.1.16",
+				"autolinker": "0.15.3"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "0.1.16",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+					"integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+					"dev": true,
+					"requires": {
+						"underscore": "1.7.0",
+						"underscore.string": "2.4.0"
+					}
+				}
+			}
+		},
+		"repeat-element": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+			"dev": true
+		},
+		"set-getter": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+			"integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+			"dev": true,
+			"requires": {
+				"to-object-path": "0.3.0"
+			}
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "5.1.1"
+			}
+		},
+		"strip-color": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+			"integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
+			"dev": true
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "3.2.2"
+			}
+		},
+		"toml": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
+			"integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA==",
+			"dev": true
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"dev": true
+		},
+		"underscore": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+			"integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+			"dev": true
+		},
+		"underscore.string": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+			"integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+			"dev": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"copy-assets": "find skins/ -maxdepth 2 -name 'web' -type d -exec sh -c 'dirname \"$1\" | xargs -I{} cp -r \"./{}/web/.\" \"./web/{}\"' -- {} \\;",
 		"test": "node npm_skins run test",
 		"cs": "node npm_skins run cs",
-		"ci": "node npm_skins run ci"
+		"ci": "node npm_skins run ci",
+		"toc": "markdown-toc --maxdepth 2 --bullets '*' -i README.md"
 	},
 	"repository": {
 		"type": "git",
@@ -23,6 +24,8 @@
 		"url": "https://github.com/wmde/FundraisingFrontend/issues"
 	},
 	"homepage": "https://github.com/wmde/FundraisingFrontend#readme",
-	"devDependencies": {},
+	"devDependencies": {
+		"markdown-toc": "^1.2.0"
+	},
 	"dependencies": {}
 }

--- a/skins/10h16/package.json
+++ b/skins/10h16/package.json
@@ -4,7 +4,7 @@
   "description": "WMDE fundraising application (end user facing part)",
   "scripts": {
     "build-assets": "browserify js/main.js -s WMDE -o web/_js/wmde.js",
-    "watch-js": "watchify js/main.js -v -s WMDE -o web/_js/wmde.js",
+    "watch": "watchify js/main.js -v -s WMDE -o web/_js/wmde.js",
     "test": "tape 'js/tests/**/*.js' | tap-min",
     "cs": "jshint js && jscs js",
     "ci": "npm run cs && npm run test && browserify js/main.js -s WMDE -o /dev/null"


### PR DESCRIPTION
* Add `make setup` command to initialize a freshly cloned project.
* Change README to use make targets wherever possible.
* Update Docker commands in README
* Add section for updating in README
* Add npm task for updating the table of contents in the README
* Parameterize make targets to make JS debugging and running specific PHPUnit test possible again.

Followup for #1220