### PR TITLE
Make BIC output optional in SEPA mandate

### DIFF
--- a/skins/cat17/templates/Membership_Application_Confirmation.html.twig
+++ b/skins/cat17/templates/Membership_Application_Confirmation.html.twig
@@ -51,7 +51,9 @@
 							<div class="col-xs-6">
 								<p>
 									<strong>{$ 'iban' | trans $}</strong> {$ bankData.iban $}<br/>
-									<strong>{$ 'bic' | trans $}</strong> {$ bankData.bic $}<br/>
+									{%  if bankData.bic %}
+										<strong>{$ 'bic' | trans $}</strong> {$ bankData.bic $}<br/>
+									{% endif %}
 									{% if bankData.bankName %}
 										<strong>{$ 'bank_name' | trans $}</strong> {$ bankData.bankName $}
 									{% endif %}

--- a/skins/cat17/templates/partials/donation_confirmation/direct_debit.html.twig
+++ b/skins/cat17/templates/partials/donation_confirmation/direct_debit.html.twig
@@ -62,7 +62,9 @@
                     <div class="col-xs-6">
                         <p>
                             <strong>{$ 'iban' | trans $}</strong> {$ bankData.iban $}<br/>
-                            <strong>{$ 'bic' | trans $}</strong> {$ bankData.bic $}<br/>
+                            {%  if bankData.bic %}
+                                <strong>{$ 'bic' | trans $}</strong> {$ bankData.bic $}<br/>
+                            {% endif %}
                             {% if bankData.bankname %}
                                 <strong>{$ 'bank_name' | trans $}</strong> {$ bankData.bankname $}
                             {% endif %}


### PR DESCRIPTION
Only show BIC in cat17 SEPA mandate if there actually is one.

This is a followup for
https://phabricator.wikimedia.org/T181151
https://phabricator.wikimedia.org/T192921