### PR TITLE
[WIP] T181615 Fix keyboard navigation caused by overloading the native UI elements with jcf

### DIFF
--- a/skins/cat17/src/app/lib/form_components.js
+++ b/skins/cat17/src/app/lib/form_components.js
@@ -52,6 +52,12 @@ var objectAssign = require( 'object-assign' ),
 		onChange: null,
 		render: function ( formContent ) {
 			this.element.val( [ formContent[ this.contentName ] ] ); // Needs to be an array
+			this.element.on( 'focus', function () {
+				jQuery( this ).addClass( 'focused' );
+			} );
+			this.element.on( 'focusout', function () {
+				jQuery( '.focused' ).removeClass( 'focused' );
+			} );
 		}
 	},
 
@@ -81,6 +87,12 @@ var objectAssign = require( 'object-assign' ),
 		onChange: null,
 		render: function ( formContent ) {
 			this.element.prop( 'checked', !!formContent[ this.contentName ] ); // !! converts to boolean
+			this.element.on( 'focus', function () {
+				jQuery( this ).parent().find( 'label' ).addClass( 'focused' );
+			} );
+			this.element.on( 'focusout', function () {
+				jQuery( '.focused' ).removeClass( 'focused' );
+			} );
 		}
 	},
 

--- a/skins/cat17/src/app/lib/scrolling.js
+++ b/skins/cat17/src/app/lib/scrolling.js
@@ -87,7 +87,6 @@ var objectAssign = require( 'object-assign' ),
 				if ( $element.is( ':focus' ) ) { // Checking if the target was focused
 					return false;
 				} else {
-					$element.attr( 'tabindex', '-1' ); // Adding tabindex for elements not focusable
 					$element.focus(); // Set focus again
 				}
 			} );

--- a/skins/cat17/src/app/tests/test_scrolling.js
+++ b/skins/cat17/src/app/tests/test_scrolling.js
@@ -352,7 +352,6 @@ test( 'AnimatedScroller treats element once scroll position reached', function (
 
 	body.animate.args[ 0 ][ 2 ]();
 
-	t.ok( element.attr.withArgs( 'tabindex', '-1' ).calledOnce );
 	t.ok( element.focus.calledTwice );
 
 	delete global.jQuery;

--- a/skins/cat17/src/sass/layouts/_borders-system.scss
+++ b/skins/cat17/src/sass/layouts/_borders-system.scss
@@ -250,16 +250,30 @@
 
 .wrap-input, .wrap-check {
     input {
-        opacity: 0;
+        opacity: 0.01;
         position: absolute;
     }
+    input[type=checkbox] + label {
+            &.focused {
+                border: 1px dotted $brand-primary;
+            }
+            padding: 5px;
+
+    }
+    input[type=radio].focused + label {
+            &:before {
+                outline: 1px dotted $gray-darker;
+            }
+    }
+
     input:checked + label {
-		&:before {
-			box-shadow: inset 0 0 0 2px white;
-			@include themify($themes) {
-				background-color: themed('brandPrimary');
-			}
-		}
+        &:before {
+            box-shadow: inset 0 0 0 2px white;
+            @include themify($themes) {
+                background-color: themed('brandPrimary');
+            }
+        }
+
     }
     label {
         display: flex;
@@ -286,11 +300,11 @@
             text-align: center;
             transition: all 250ms ease;
         }
-		span + i {
-			position: absolute;
-			right: 0;
-			top: 20px;
-		}
+        span + i {
+            position: absolute;
+            right: 0;
+            top: 20px;
+        }
     }
     input label, &:hover label {
         align-items: center;

--- a/skins/cat17/templates/partials/payment_preset_amounts.html.twig
+++ b/skins/cat17/templates/partials/payment_preset_amounts.html.twig
@@ -1,7 +1,7 @@
 {% spaceless %}
 {% for amount in presetAmounts %}
 	<div class="wrap-radio">
-		<input type="radio" id="amount{$ loop.index $}" value="{$ amount.euroCents $}">
+		<input type="radio" id="amount{$ loop.index $}" name="amount-grp" value="{$ amount.euroCents $}">
 		<label for="amount{$ loop.index $}">
 			<span>{$ amount.euroFloat | number_format( 0 ) $} €</span>
 		</label>


### PR DESCRIPTION
You can navigate through the preset amount buttons using the arrow keys.
You can navigate through radio buttons using arrow keys.
You can navigate between different groups of components on the page using tab key.

TODO: checkboxes should also receive the focus somehow..

Note: This works best on Chrome, not horrible on Firefox, complete mess on Opera.
Any help is highly appreciated :pray: 


Bug: T181615