### PR TITLE
Update css affecting checkboxes on donation and membership forms

### DIFF
--- a/skins/cat17/src/sass/layouts/_borders-system.scss
+++ b/skins/cat17/src/sass/layouts/_borders-system.scss
@@ -255,7 +255,7 @@
     }
     input[type=checkbox] + label {
             &.focused {
-                border: 1px dotted $brand-primary;
+                outline: 1px dotted $gray-darker;
             }
             padding: 5px;
 


### PR DESCRIPTION
The focus frame of check boxes is dark-gray for both donation and membership pages.
"Hopping" of the label text for a check box is removed.

Bug: T181615