### PR TITLE
Unify placeholder color across browsers in 10h16

### DIFF
--- a/skins/10h16/web/_styles/styles.css
+++ b/skins/10h16/web/_styles/styles.css
@@ -162,10 +162,10 @@ input[type=text].valid + .validation,
 input[type=tel].valid ~ .validation-explanation,
 input[type=text].valid ~ .validation-explanation { color:  #a5da9b; }
 
-::-webkit-input-placeholder { color: #b2b2b2; }
-::-moz-placeholder { color: #b2b2b2; }
-:-ms-input-placeholder { color: #b2b2b2; }
-input:-moz-placeholder { color: #b2b2b2; }
+::-webkit-input-placeholder { color: #b2b2b2;  opacity: 1; }
+::-moz-placeholder { color: #b2b2b2; opacity: 1; }
+:-ms-input-placeholder { color: #b2b2b2;  opacity: 1; }
+input:-moz-placeholder { color: #b2b2b2; opacity: 1; }
 
 /*textarea + label,
 input[type=text] ~ label { color: #CCC; position: absolute; top: 6px; left: 11px; display: block; font-size: 12px; letter-spacing: 1px; }


### PR DESCRIPTION
The placeholder color of text fields was slightly lighrer than the one of dropdown fields on Firefox. This is because Firefox applies a [0.54 opacity](https://developer.mozilla.org/de/docs/Web/CSS/::-moz-placeholder) to the placeholder element by default.

The different colors were very visible on the new contact form, if you looked very closely the colors were also visible for the "Title" field in the donation and membership forms.

A small followup for #1247 