### PR TITLE
Remove exception message from error page

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -118,7 +118,7 @@ $app->error( function ( \Exception $e, Request $request, $code ) use ( $ffFactor
 	}
 
 	return new Response(
-		$ffFactory->newInternalErrorHtmlPresenter()->present( $e ),
+		$ffFactory->newInternalErrorHtmlPresenter()->present(),
 		$code
 	);
 } );

--- a/skins/10h16/templates/Error_Page.html.twig
+++ b/skins/10h16/templates/Error_Page.html.twig
@@ -10,14 +10,13 @@
 				<div class="ctcol">
 					<div class="box partial rounded no-margin">
 						<div class="box-header container clearfix">
-							<span class="icon-bug f-left">Fehler</span>
+							<span class="icon-bug f-left">{$ 'error_page_header' | trans $}</span>
 						</div>
 
 						<div class="box-section box-footer">
 							<div class="container clearfix">
 								<p>
-									Bei der Verarbeitung Ihrer Anfrage ist ein Fehler aufgetreten.
-									Bitte versuchen Sie es zu einem späteren Zeitpunkt erneut.
+									{$ 'error_page' | trans $}
 								</p>
 								{% if message is defined %}
 								<p>

--- a/src/Presentation/Presenters/InternalErrorHtmlPresenter.php
+++ b/src/Presentation/Presenters/InternalErrorHtmlPresenter.php
@@ -20,8 +20,8 @@ class InternalErrorHtmlPresenter {
 		$this->template = $template;
 	}
 
-	public function present( \Exception $exception ): string {
-		return $this->template->render( [ 'message' => $exception->getMessage() ] );
+	public function present(): string {
+		return $this->template->render( [] );
 	}
 
 }


### PR DESCRIPTION
Because the error page is in German and the exception message is in English.
Small fix in the error page of `10h16` was added as well.

Follow up on #1257