### PR TITLE
Wait for db container on make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ ui: clear js
 test: covers phpunit
 
 setup-db:
+	docker-compose run --rm start_dependencies
 	docker-compose run --rm app ./vendor/bin/doctrine orm:schema-tool:create
 	docker-compose run --rm app ./vendor/bin/doctrine orm:generate-proxies var/doctrine_proxies
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,12 @@ services:
     expose:
       - "1025"
 
+  start_dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - database
+    command: database:3306
+
 volumes:
   var-data:
   db-storage:


### PR DESCRIPTION
The actual database container was not starting up fast enough in some
instances, leading to connection errors on CI setup (and later DB errors
on unit tests).

The setup target now uses a special container that checks if the
database port is available.

See
https://8thlight.com/blog/dariusz-pasciak/2016/10/17/docker-compose-wait-for-dependencies.html