### PR TITLE
Improve bucket selection logic

### DIFF
--- a/app/config/campaigns.dev.yml
+++ b/app/config/campaigns.dev.yml
@@ -5,10 +5,6 @@
 confirmation_pages:
   active: false
 
-
 skins:
-  active: false
-  buckets:
-    - "cat17"
-    - "10h16"
-  default_bucket: "cat17"
+  end: "2020-10-10"
+  active: true

--- a/src/BucketTesting/BucketSelectionStrategy.php
+++ b/src/BucketTesting/BucketSelectionStrategy.php
@@ -5,5 +5,5 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\BucketTesting;
 
 interface BucketSelectionStrategy {
-	public function selectBucketFromCampaign( Campaign $campaign ): Bucket;
+	public function selectBucketForCampaign( Campaign $campaign ): ?Bucket;
 }

--- a/src/BucketTesting/Campaign.php
+++ b/src/BucketTesting/Campaign.php
@@ -17,6 +17,7 @@ class Campaign {
 	private $endTimestamp;
 	private $buckets;
 	private $urlKey;
+	private $defaultBucketIndex;
 
 	public const ACTIVE = true;
 	public const INACTIVE = false;
@@ -28,6 +29,7 @@ class Campaign {
 		$this->startTimestamp = $startTimestamp;
 		$this->endTimestamp = $endTimestamp;
 		$this->buckets = [];
+		$this->defaultBucketIndex = -1;
 	}
 
 	public function isActive(): bool {
@@ -67,12 +69,26 @@ class Campaign {
 			throw new \OutOfBoundsException();
 		}
 		return $index;
-
 	}
 
 	public function addBucket( Bucket $bucket ): self {
 		$this->buckets[] = $bucket;
+		if ( $bucket->isDefaultBucket() ) {
+			$this->defaultBucketIndex = count( $this->buckets ) - 1;
+		}
 		return $this;
+	}
+
+	public function isExpired( \DateTime $now ): bool {
+		return $this->startTimestamp > $now || $this->endTimestamp < $now;
+	}
+
+	public function getDefaultBucket(): Bucket {
+		$bucket = $this->getBucketByIndex( $this->defaultBucketIndex );
+		if ( is_null( $bucket ) ) {
+			throw new \LogicException( 'No default bucket was added to this campaign' );
+		}
+		return $bucket;
 	}
 
 

--- a/src/BucketTesting/CampaignCollection.php
+++ b/src/BucketTesting/CampaignCollection.php
@@ -4,31 +4,14 @@ declare(strict_types = 1);
 
 namespace WMDE\Fundraising\Frontend\BucketTesting;
 
-class CampaignCollection {
+use ArrayIterator;
+use IteratorAggregate;
+
+class CampaignCollection implements IteratorAggregate {
 	private $campaigns;
 
 	public function __construct( Campaign ...$campaigns ) {
 		$this->campaigns = $campaigns;
-	}
-
-	/**
-	 * Use urlKey => BucketIndex values to select matching buckets from campaigns.
-	 * Also return all campaigns that were not matched.
-	 *
-	 * @return array [ Bucket[], Campaign[] ]
-	 */
-	public function splitBucketsFromCampaigns( array $params ): array {
-		$buckets = [];
-		$campaigns = [];
-		foreach ( $this->campaigns as $campaign ) {
-			$urlKey = $campaign->getUrlKey();
-			if ( isset( $params[$urlKey] ) && $bucket = $campaign->getBucketByIndex( $params[$urlKey] ) ) {
-				$buckets[]= $bucket;
-				continue;
-			}
-			$campaigns[]= $campaign;
-		}
-		return [ $buckets, $campaigns ];
 	}
 
 	/**
@@ -47,5 +30,10 @@ class CampaignCollection {
 			return $mostDistant->getEndTimestamp() > $current->getEndTimestamp() ? $mostDistant : $current;
 		}, null );
 	}
+
+	public function getIterator(): ArrayIterator {
+		return new ArrayIterator( $this->campaigns );
+	}
+
 
 }

--- a/src/BucketTesting/InactiveCampaignBucketSelection.php
+++ b/src/BucketTesting/InactiveCampaignBucketSelection.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\BucketTesting;
+
+use DateTime;
+
+/**
+ * @license GNU GPL v2+
+ */
+class InactiveCampaignBucketSelection implements BucketSelectionStrategy {
+
+	private $now;
+
+	public function __construct( ?DateTime $now = null ) {
+		$this->now = $now ?: new DateTime();
+	}
+
+	public function selectBucketForCampaign( Campaign $campaign ): ?Bucket {
+		if ( !$campaign->isActive() || $campaign->isExpired( $this->now ) ) {
+			return $campaign->getDefaultBucket();
+		}
+		return null;
+	}
+
+
+}

--- a/src/BucketTesting/ParameterBucketSelection.php
+++ b/src/BucketTesting/ParameterBucketSelection.php
@@ -1,0 +1,27 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\BucketTesting;
+
+/**
+ * @license GNU GPL v2+
+ */
+class ParameterBucketSelection implements BucketSelectionStrategy {
+
+	private $parameters;
+
+	public function __construct( array $parameters ) {
+		$this->parameters = $parameters;
+	}
+
+	public function selectBucketForCampaign( Campaign $campaign ): ?Bucket {
+		$urlKey = $campaign->getUrlKey();
+		if ( isset( $this->parameters[$urlKey] ) &&
+				$bucket = $campaign->getBucketByIndex( $this->parameters[$urlKey] ) ) {
+			return $bucket;
+		}
+		return null;
+	}
+
+}

--- a/src/BucketTesting/RandomBucketSelection.php
+++ b/src/BucketTesting/RandomBucketSelection.php
@@ -8,7 +8,7 @@ namespace WMDE\Fundraising\Frontend\BucketTesting;
  * @license GNU GPL v2+
  */
 class RandomBucketSelection implements BucketSelectionStrategy {
-	public function selectBucketFromCampaign( Campaign $campaign ): Bucket {
+	public function selectBucketForCampaign( Campaign $campaign ): Bucket {
 		return $campaign->getBuckets()[array_rand( $campaign->getBuckets() )];
 	}
 

--- a/tests/Fixtures/BucketSelectionSpy.php
+++ b/tests/Fixtures/BucketSelectionSpy.php
@@ -18,8 +18,8 @@ class BucketSelectionSpy implements BucketSelectionStrategy {
 		$this->bucketSelections = [];
 	}
 
-	public function selectBucketFromCampaign( Campaign $campaign ): Bucket {
-		$bucket = $this->bucketSelector->selectBucketFromCampaign( $campaign );
+	public function selectBucketForCampaign( Campaign $campaign ): Bucket {
+		$bucket = $this->bucketSelector->selectBucketForCampaign( $campaign );
 		$this->bucketSelections[] = $bucket;
 		return $bucket;
 	}

--- a/tests/Unit/BucketTesting/BucketSelectorTest.php
+++ b/tests/Unit/BucketTesting/BucketSelectorTest.php
@@ -30,15 +30,15 @@ class BucketSelectorTest extends TestCase {
 		$this->campaign = new Campaign(
 			'test1',
 			't1',
-			new \DateTime(),
-			new \DateTime(),
+			( new \DateTime() )->sub( new \DateInterval( 'P1M' ) ),
+			( new \DateTime() )->add( new \DateInterval( 'P1M' ) ),
 			Campaign::ACTIVE
 		);
 		$this->defaultBucket = new Bucket( 'a', $this->campaign, Bucket::DEFAULT );
 		$this->alternativeBucket = new Bucket( 'b', $this->campaign, Bucket::NON_DEFAULT );
 		$this->campaign
 			->addBucket( $this->defaultBucket )      // default bucket has index 0
-			->addBucket( $this->alternativeBucket ); // default bucket has index 1
+			->addBucket( $this->alternativeBucket ); // alternative bucket has index 1
 		$this->campaignCollection = new CampaignCollection( $this->campaign );
 		$this->bucketSelectionStrategy = new BucketSelectionSpy( new RandomBucketSelection() );
 	}
@@ -47,6 +47,62 @@ class BucketSelectorTest extends TestCase {
 		$bucketSelector = new BucketSelector( new CampaignCollection(), new RandomBucketSelection() );
 
 		$this->assertSame( [], $bucketSelector->selectBuckets( [], [] ) );
+	}
+
+	public function testGivenInactiveCampaign_defaultBucketIsSelected() {
+		$campaign = new Campaign(
+			'test1',
+			't1',
+			new \DateTime(),
+			new \DateTime(),
+			Campaign::INACTIVE
+		);
+		$defaultBucket = new Bucket( 'a', $campaign, Bucket::DEFAULT );
+		$alternativeBucket = new Bucket( 'b', $campaign, Bucket::NON_DEFAULT );
+		$campaign->addBucket( $defaultBucket )->addBucket( $alternativeBucket );
+		$bucketSelector = new BucketSelector( new CampaignCollection( $campaign ), $this->bucketSelectionStrategy );
+
+		$this->assertSame(
+			[ $defaultBucket ],
+			$bucketSelector->selectBuckets( [ 't1' => 0 ], [] )
+		);
+		$this->assertSame(
+			[ $defaultBucket ],
+			$bucketSelector->selectBuckets( [], [ 't1' => 0 ] )
+		);
+		$this->assertSame(
+			[ $defaultBucket ],
+			$bucketSelector->selectBuckets( [], [] )
+		);
+		$this->assertFalse( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket not should be selected by selection strategy.' );
+	}
+
+	public function testGivenExpiredActiveCampaign_defaultBucketIsSelected() {
+		$campaign = new Campaign(
+			'test1',
+			't1',
+			( new \DateTime() )->sub( new \DateInterval( 'P1M' ) ),
+			( new \DateTime() )->sub( new \DateInterval( 'P1D' ) ),
+			Campaign::ACTIVE
+		);
+		$defaultBucket = new Bucket( 'a', $campaign, Bucket::DEFAULT );
+		$alternativeBucket = new Bucket( 'b', $campaign, Bucket::NON_DEFAULT );
+		$campaign->addBucket( $defaultBucket )->addBucket( $alternativeBucket );
+		$bucketSelector = new BucketSelector( new CampaignCollection( $campaign ), $this->bucketSelectionStrategy );
+
+		$this->assertSame(
+			[ $defaultBucket ],
+			$bucketSelector->selectBuckets( [ 't1' => 0 ], [] )
+		);
+		$this->assertSame(
+			[ $defaultBucket ],
+			$bucketSelector->selectBuckets( [], [ 't1' => 0 ] )
+		);
+		$this->assertSame(
+			[ $defaultBucket ],
+			$bucketSelector->selectBuckets( [], [] )
+		);
+		$this->assertFalse( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket not should be selected by selection strategy.' );
 	}
 
 	public function testGivenMatchingUrlParams_bucketIsSelected() {
@@ -77,7 +133,13 @@ class BucketSelectorTest extends TestCase {
 		$this->assertFalse( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket should be selected by Cookie parameters' );
 	}
 
-	public function testGivenNoParams_bucketIsSelectedWithSelectionStrategy() {
+	public function testGivenUrlAndCookieParameters_urlOverridesCookie() {
+		$bucketSelector = new BucketSelector( $this->campaignCollection, $this->bucketSelectionStrategy );
+
+		$this->assertEquals( [ $this->alternativeBucket ], $bucketSelector->selectBuckets( [ 't1' => 0 ], [ 't1' => 1 ] ) );
+	}
+
+	public function testGivenNoParamsAndActiveCampaign_bucketIsSelectedWithFallbackSelectionStrategy() {
 		$bucketSelector = new BucketSelector( $this->campaignCollection, $this->bucketSelectionStrategy );
 
 		$this->assertThat(
@@ -87,13 +149,13 @@ class BucketSelectorTest extends TestCase {
 				$this->equalTo( [ $this->alternativeBucket ] )
 			)
 		);
-		$this->assertTrue( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket should be selected by selection strategy' );
+		$this->assertTrue( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket should be selected by fallback selection strategy' );
 	}
 
 	/**
 	 * @dataProvider invalidParametersProvider
 	 */
-	public function testGivenInvalidParams_bucketIsSelectedWithSelectionStrategy( string $description, array $cookie, array $url ) {
+	public function testGivenInvalidParams_bucketIsSelectedWithFallbackSelectionStrategy( string $description, array $cookie, array $url ) {
 		$bucketSelector = new BucketSelector( $this->campaignCollection, $this->bucketSelectionStrategy );
 
 		$this->assertThat(
@@ -117,11 +179,5 @@ class BucketSelectorTest extends TestCase {
 		yield [ 'non-numeric index in url', [], [ 't1' => 'lol' ] ];
 		yield [ 'non-numeric index in cookie', [ 't1' => 'cat' ], [] ];
 		yield [ 'colorful mix', [ 't1' => 'cat', 't2' => 0 ], [ 't1' => 99, 'goats' => 1 ] ];
-	}
-
-	public function testGivenUrlAndCookieParameters_urlOverridesCookie() {
-		$bucketSelector = new BucketSelector( $this->campaignCollection, $this->bucketSelectionStrategy );
-
-		$this->assertEquals( [ $this->alternativeBucket ], $bucketSelector->selectBuckets( [ 't1' => 0 ], [ 't1' => 1 ] ) );
 	}
 }

--- a/tests/Unit/BucketTesting/CampaignCollectionTest.php
+++ b/tests/Unit/BucketTesting/CampaignCollectionTest.php
@@ -50,31 +50,15 @@ class CampaignCollectionTest extends TestCase {
 			->addBucket( $this->alternativeBucketOfSecondCampaign );
 	}
 
-
-	public function testGivenValidUrlAndValue_splittingReturnsBucket() {
+	public function testGivenCampaigns_itCanIterateOverThem() {
 		$collection = new CampaignCollection( $this->firstCampaign, $this->secondCampaign );
+		$iterator = $collection->getIterator();
 
-		$this->assertEquals(
-			[ [ $this->defaultBucketOfFirstCampaign ], [ $this->secondCampaign ] ],
-			$collection->splitBucketsFromCampaigns( [ 't1' => 0 ] )
-		);
-		$this->assertEquals(
-			[ [ $this->defaultBucketOfFirstCampaign, $this->alternativeBucketOfSecondCampaign ], [] ],
-			$collection->splitBucketsFromCampaigns( [ 't1' => 0, 't2' => 1 ] )
-		);
-	}
-
-	public function testGivenInvalidUrlValue_splittingReturnsCampaigns() {
-		$collection = new CampaignCollection( $this->firstCampaign, $this->secondCampaign );
-
-		$this->assertEquals(
-			[ [], [ $this->firstCampaign, $this->secondCampaign ] ],
-			$collection->splitBucketsFromCampaigns( [ 't21' => 0 ] )
-		);
-		$this->assertEquals(
-			[ [], [ $this->firstCampaign, $this->secondCampaign ] ],
-			$collection->splitBucketsFromCampaigns( [ 't21' => 0, 't2' => 99 ] )
-		);
+		$this->assertSame( $this->firstCampaign, $iterator->current() );
+		$iterator->next();
+		$this->assertSame( $this->secondCampaign, $iterator->current() );
+		$iterator->next();
+		$this->assertFalse( $iterator->valid() );
 	}
 
 	public function testGivenActiveCampaigns_itCanSelectTheOneWithTheMostDistantEndDate() {
@@ -96,7 +80,7 @@ class CampaignCollectionTest extends TestCase {
 		$this->assertSame( $this->firstCampaign, $collection->getMostDistantCampaign() );
 	}
 
-	public function testGivenOnlyInactiveCampaigs_itWillSelectNone() {
+	public function testGivenOnlyInactiveCampaigs_itWillSelectNoneAsMostDistant() {
 		$inactiveFirstCampaign = new Campaign(
 			$this->firstCampaign->getName(),
 			$this->firstCampaign->getUrlKey(),
@@ -109,7 +93,7 @@ class CampaignCollectionTest extends TestCase {
 		$this->assertNull( $collection->getMostDistantCampaign() );
 	}
 
-	public function testGivenOnlyCampaigsInThePast_itWillSelectNone() {
+	public function testGivenOnlyCampaigsInThePast_itWillSelectNoneAsMostDistant() {
 		$pastFirstCampaign = new Campaign(
 			$this->firstCampaign->getName(),
 			$this->firstCampaign->getUrlKey(),

--- a/tests/Unit/BucketTesting/CampaignTest.php
+++ b/tests/Unit/BucketTesting/CampaignTest.php
@@ -53,4 +53,40 @@ class CampaignTest extends TestCase {
 
 		$this->assertNull( $campaign->getBucketByIndex( 0 ) );
 	}
+
+	public function testGivenDefaultBucket_campaignCanReturnIt() {
+		$campaign = new Campaign( 'test', 't', new \DateTime(), new \DateTime(), true );
+		$firstBucket = new Bucket( 'default', $campaign, Bucket::DEFAULT );
+		$secondBucket = new Bucket( 'variant_1', $campaign, Bucket::NON_DEFAULT );
+
+		$campaign->addBucket( $firstBucket )->addBucket( $secondBucket );
+
+		$this->assertSame( $firstBucket, $campaign->getDefaultBucket() );
+	}
+
+	public function testGivenCampaignWithNoBuckets_getDefaultBucketWillThrowException() {
+		$campaign = new Campaign( 'test', 't', new \DateTime(), new \DateTime(), true );
+
+		$this->expectException( \LogicException::class );
+		$campaign->getDefaultBucket();
+	}
+
+	public function testGivenCampaignWithNoDefaultBuckets_getDefaultBucketWillThrowException() {
+		$campaign = new Campaign( 'test', 't', new \DateTime(), new \DateTime(), true );
+		$firstBucket = new Bucket( 'default', $campaign, Bucket::NON_DEFAULT );
+		$secondBucket = new Bucket( 'variant_1', $campaign, Bucket::NON_DEFAULT );
+
+		$campaign->addBucket( $firstBucket )->addBucket( $secondBucket );
+
+		$this->expectException( \LogicException::class );
+		$campaign->getDefaultBucket();
+	}
+
+	public function testGivenCampaignwithDateRange_itCanBeCheckedForExpiration() {
+		$campaign = new Campaign( 'test', 't', new \DateTime( '2018-10-01' ), new \DateTime( '2018-12-31' ), true );
+
+		$this->assertTrue( $campaign->isExpired( new \DateTime( '2018-09-09' ) ), 'Campaign is expired before start date' );
+		$this->assertTrue( $campaign->isExpired( new \DateTime( '2025-02-25' ) ), 'Campaign is expired after end date' );
+		$this->assertFalse( $campaign->isExpired( new \DateTime( '2018-10-02' ) ), 'Campaign is not expired inside date range' );
+	}
 }


### PR DESCRIPTION
For inactive or expired campaigns, always select the default bucket.

The CampaignFeatureBuilder will now always add a bucket check to all
features.
This enables us to check the feature flags in any order in the
ChoiceFactory:

- If the campaign is inactive, the CampaignFeatureBuilder has built
  rules that ignore the buckets.
- If the campaign is active but expired, the BucketSelector will have
  put the visitor in the default bucket. The date range checks for the
  non-default features will disable them. The default feature has no
  date range check, only a bucket name check.
- If the campaign is active and inside its date range, the normal bucket
  selection rule priorities ( URL > Cookie > Random) apply.