### PR TITLE
Reorganize components in the contact form

### DIFF
--- a/skins/cat17/src/sass/components/_menu.scss
+++ b/skins/cat17/src/sass/components/_menu.scss
@@ -1,78 +1,79 @@
 .list-menu {
-    li {
-
-        height: 57px;
-        padding-right: 30px;
+	li {
+		height: 57px;
+		padding-right: 30px;
 		font-weight: $font-main-light;
-        position: relative;
-        &:after {
-            content: '';
-            position: absolute;
-            left: 0;
-            bottom: 0;
-            width: 800px;
-            border-bottom: 1px solid #808080;
-
-            @include bkp(sm) {
-                width: 100%;
-            }
-        }
-        &:hover, &:focus {
-            &:after {
-                @include themify($themes) {
-                    border-bottom: themed('border1pxPrimary');
-                }
-            }
-        }
-        a {
-            display: block;
-            position: relative;
-            top:50%;
-            transform: translateY(-50%);
-            &:after {
-                content: $icon-keyboard_arrow_right;
-                position: absolute;
-                right: -30px;
-                font-family: 'icomoonwikimedia';
-                font-size: 20px;
-                top:50%;
-                transform: translateY(-50%);
-            }
-        }
-        &.facebook {
-            a:after {
-                content: $icon-facebook;
-                font-size: 14px;
-            }
-        }
-        &.twitter {
-            a:after {
-                content: $icon-twitter;
-                font-size: 14px;
-            }
-        }
-    }
-    &.link-reverse {
-        li {
-            padding-left: 30px;
-            padding-right: 0;
-            a {
-                &:after {
-                    content: "";
-                }
-                &:before {
-                    content: $icon-keyboard_arrow_left;
-                    position: absolute;
-                    left: -30px;
-                    font-family: 'icomoonwikimedia';
-                    font-size: 20px;
-                    top: 50%;
-                    transform: translateY(-50%);
-                }
-            }
-        }
-       // margin-bottom: 60px;
-    }
+		position: relative;
+		&:after {
+			content: '';
+			position: absolute;
+			left: 0;
+			bottom: 0;
+			width: 800px;
+			border-bottom: 1px solid #808080;
+			@include bkp(sm) {
+				width: 800px;
+			}
+			@include bkp(xs) {
+				width: 320px;
+			}
+		}
+		&:hover, &:focus {
+			&:after {
+				@include themify($themes) {
+					border-bottom: themed('border1pxPrimary');
+				}
+			}
+		}
+		a {
+			display: block;
+			position: relative;
+			top:50%;
+			transform: translateY(-50%);
+			&:after {
+				content: $icon-keyboard_arrow_right;
+				position: absolute;
+				right: -30px;
+				font-family: 'icomoonwikimedia';
+				font-size: 20px;
+				top:50%;
+				transform: translateY(-50%);
+			}
+		}
+		&.facebook {
+			a:after {
+				content: $icon-facebook;
+				font-size: 14px;
+			}
+		}
+		&.twitter {
+			a:after {
+				content: $icon-twitter;
+				font-size: 14px;
+			}
+		}
+	}
+	&.link-reverse {
+		li {
+			padding-left: 30px;
+			padding-right: 0;
+			a {
+				&:after {
+					content: "";
+				}
+				&:before {
+					content: $icon-keyboard_arrow_left;
+					position: absolute;
+					left: -30px;
+					font-family: 'icomoonwikimedia';
+					font-size: 20px;
+					top: 50%;
+					transform: translateY(-50%);
+				}
+			}
+		}
+	   // margin-bottom: 60px;
+	}
 	&.link-tax li {
 		height: 110px;
 	}

--- a/skins/cat17/src/sass/layouts/_introduction.scss
+++ b/skins/cat17/src/sass/layouts/_introduction.scss
@@ -11,17 +11,11 @@
 	}
 	.link-back {
 		margin-top: 22px;
-
-		@include bkp(md) {
-			padding-left: 30px;
-		}
-		@include bkp(lg) {
-			padding-left: 52px;
-		}
 		a {
 			display: block;
-			border-bottom: 1px solid $gray-light;
 			padding: 10px 0;
+			text-decoration: none;
+			margin-left: 3em;
 			&:after {
 				content: $icon-keyboard_arrow_right;
 				font-family: 'icomoonwikimedia';

--- a/skins/cat17/src/sass/layouts/pages/contact.scss
+++ b/skins/cat17/src/sass/layouts/pages/contact.scss
@@ -33,13 +33,32 @@
 			}
 		}
 		.wrap-submit {
-			margin-top: 70px;
 			width: 90%;
 			display: flex;
 			justify-content: center;
+			@include bkp(sm) {
+				margin-top: 70px;
+			}
 		}
 		.list-menu {
 			margin-top: 30px;
+		}
+	}
+	@include bkp(smmax) {
+		.content {
+			.link-back {
+				a {
+					margin-left: 0;
+				}
+			}
+		}
+
+		.list-menu {
+			li {
+				&::after {
+					width: 100%;
+				}
+			}
 		}
 	}
 }

--- a/skins/cat17/src/sass/layouts/pages/contact.scss
+++ b/skins/cat17/src/sass/layouts/pages/contact.scss
@@ -46,6 +46,8 @@
 	}
 	@include bkp(smmax) {
 		.content {
+			padding-top: 24px; /* Add a bit more space to the submit button container so that it's visually separated from form fields but not too much */
+
 			.link-back {
 				a {
 					margin-left: 0;

--- a/skins/cat17/src/sass/layouts/pages/contact.scss
+++ b/skins/cat17/src/sass/layouts/pages/contact.scss
@@ -5,22 +5,11 @@
 			margin-top: 50px;
 		}
 		.field-grp {
-			.contact-subject {
-				@include bkp(sm) {
-					max-width: 227px;
-				}
-			}
 			textarea {
 				height: 180px;
 			}
 			.error-text {
 				display: block;
-			}
-		}
-		.wrap-submit {
-			margin-top: 40px;
-			@include bkp(sm) {
-				margin-top: 80px;
 			}
 		}
 		input[type="submit"] {
@@ -35,6 +24,19 @@
 				padding: 0;
 				height: 45px;
 			}
+			@include bkp(xs) {
+				max-width: 100%;
+				display: flex;
+				margin: 0 auto;
+				padding: 0;
+				height: 45px;
+			}
+		}
+		.wrap-submit {
+			margin-top: 70px;
+			width: 90%;
+			display: flex;
+			justify-content: center;
 		}
 		.list-menu {
 			margin-top: 30px;

--- a/skins/cat17/templates/contact_form.html.twig
+++ b/skins/cat17/templates/contact_form.html.twig
@@ -7,10 +7,36 @@
 {% block main %}
 	<div class="container">
 		<form method="post" action="{$ basepath $}/contact/get-in-touch"  id="contact-form" class="row">
-			<div class="content col-xs-12 col-md-8 col-sm-8">
+			<div class="content col-xs-12 col-sm-6 col-md-8">
 				<h2 class="h1">Kontakt</h2>
 				<div class="row">
-					<fieldset class="col-xs-12 col-sm-6">
+					<fieldset class="col-xs-12 col-md-6">
+						<div class="field-grp">
+							<input type="text" id="name" name="firstname" placeholder="{$ 'contact_firstname'|trans $}">
+							<label for="name" class="sr-only">{$ 'contact_firstname'|trans $}</label>
+							{$ util.form_error('firstname', errors) $}
+						</div>
+					</fieldset>
+					<fieldset class="col-xs-12 col-md-6">
+						<div class="field-grp">
+							<input type="text" id="surname" name="lastname" placeholder="{$ 'contact_lastname'|trans $}">
+							<label for="surname" class="sr-only">{$ 'contact_lastname'|trans $}</label>
+							{$ util.form_error('lastname', errors) $}
+						</div>
+					</fieldset>
+				</div>
+				<div class="row">
+					<fieldset class="col-xs-12 col-md-6">
+						<div class="field-grp">
+							<input type="email" id="email" name="email" placeholder="{$ 'contact_email'|trans $}">
+							<label for="email" class="sr-only">{$ 'contact_email'|trans $}</label>
+							{$ util.form_error('email', errors) $}
+						</div>
+						{$ util.form_error('category', errors) $}
+					</fieldset>
+				</div>
+				<div class="row">
+					<fieldset class="col-xs-12 col-md-6">
 						<select class="no-outline category" id="category" name="category"
 								data-jcf='{"wrapNative": false, "wrapNativeOnMobile": true}'>
 							<option hidden class="hideme" value="">{$ 'contact_topic_title' | trans $}</option>
@@ -19,32 +45,12 @@
 							{% endfor %}
 						</select>
 					</fieldset>
-					<fieldset class="col-xs-12 col-sm-6">
+					<fieldset class="col-xs-12 col-md-6">
 						<div class="field-grp">
 							<input type="text" class="contact-subject" id="subject" name="subject" placeholder="{$ 'contact_subject'|trans $}">
 							<label for="subject" class="sr-only">{$ 'contact_subject'|trans $}</label>
 							{$ util.form_error('subject', errors) $}
 						</div>
-					</fieldset>
-				</div>
-				<div class="row">
-					<fieldset class="col-xs-12 col-sm-6">
-					<div class="field-grp">
-						<input type="text" id="name" name="firstname" placeholder="{$ 'contact_firstname'|trans $}">
-						<label for="name" class="sr-only">{$ 'contact_firstname'|trans $}</label>
-						{$ util.form_error('firstname', errors) $}
-					</div>
-					<div class="field-grp">
-						<input type="text" id="surname" name="lastname" placeholder="{$ 'contact_lastname'|trans $}">
-						<label for="surname" class="sr-only">{$ 'contact_lastname'|trans $}</label>
-						{$ util.form_error('lastname', errors) $}
-					</div>
-					<div class="field-grp">
-						<input type="email" id="email" name="email" placeholder="{$ 'contact_email'|trans $}">
-						<label for="email" class="sr-only">{$ 'contact_email'|trans $}</label>
-						{$ util.form_error('email', errors) $}
-					</div>
-					{$ util.form_error('category', errors) $}
 					</fieldset>
 				</div>
 				<div class="row">
@@ -55,7 +61,7 @@
 					</div>
 				</div>
 			</div>
-			<div class="content col-xs-12 col-md-4 col-sm-4">
+			<div class="content col-xs-12 col-sm-6 col-md-4">
 				<div class="row align-items-end">
 					<div class="wrap-submit btn">
 						<input type="submit" value="{$ 'contact_submit'|trans $}" class="btn btn-introduction bk-blue text-center text-uppercase">

--- a/skins/cat17/templates/contact_form.html.twig
+++ b/skins/cat17/templates/contact_form.html.twig
@@ -7,25 +7,10 @@
 {% block main %}
 	<div class="container">
 		<form method="post" action="{$ basepath $}/contact/get-in-touch"  id="contact-form" class="row">
-			<div class="content col-xs-12 col-md-9">
+			<div class="content col-xs-12 col-md-8 col-sm-8">
 				<h2 class="h1">Kontakt</h2>
 				<div class="row">
-					<fieldset class="col-xs-12 col-sm-5">
-						<div class="field-grp">
-							<input type="text" id="name" name="firstname" placeholder="{$ 'contact_firstname'|trans $}">
-							<label for="name" class="sr-only">{$ 'contact_firstname'|trans $}</label>
-							{$ util.form_error('firstname', errors) $}
-						</div>
-						<div class="field-grp">
-							<input type="text" id="surname" name="lastname" placeholder="{$ 'contact_lastname'|trans $}">
-							<label for="surname" class="sr-only">{$ 'contact_lastname'|trans $}</label>
-							{$ util.form_error('lastname', errors) $}
-						</div>
-						<div class="field-grp">
-							<input type="email" id="email" name="email" placeholder="{$ 'contact_email'|trans $}">
-							<label for="email" class="sr-only">{$ 'contact_email'|trans $}</label>
-							{$ util.form_error('email', errors) $}
-						</div>
+					<fieldset class="col-xs-12 col-sm-6">
 						<select class="no-outline category" id="category" name="category"
 								data-jcf='{"wrapNative": false, "wrapNativeOnMobile": true}'>
 							<option hidden class="hideme" value="">{$ 'contact_topic_title' | trans $}</option>
@@ -33,31 +18,54 @@
 								<option {% if category == cat | trans %}selected{% endif %}>{$ cat | trans $}</option>
 							{% endfor %}
 						</select>
-						{$ util.form_error('category', errors) $}
 					</fieldset>
-					<fieldset class="col-xs-12 col-sm-7">
+					<fieldset class="col-xs-12 col-sm-6">
 						<div class="field-grp">
 							<input type="text" class="contact-subject" id="subject" name="subject" placeholder="{$ 'contact_subject'|trans $}">
 							<label for="subject" class="sr-only">{$ 'contact_subject'|trans $}</label>
 							{$ util.form_error('subject', errors) $}
 						</div>
-						<div class="field-grp">
-							<textarea name="messageBody" rows="50" cols="10" id="comment" placeholder="{$ 'contact_body'|trans $}"></textarea>
-							<label for="subject" class="sr-only">{$ 'contact_body'|trans $}</label>
-							{$ util.form_error('messageBody', errors) $}
-						</div>
 					</fieldset>
 				</div>
+				<div class="row">
+					<fieldset class="col-xs-12 col-sm-6">
+					<div class="field-grp">
+						<input type="text" id="name" name="firstname" placeholder="{$ 'contact_firstname'|trans $}">
+						<label for="name" class="sr-only">{$ 'contact_firstname'|trans $}</label>
+						{$ util.form_error('firstname', errors) $}
+					</div>
+					<div class="field-grp">
+						<input type="text" id="surname" name="lastname" placeholder="{$ 'contact_lastname'|trans $}">
+						<label for="surname" class="sr-only">{$ 'contact_lastname'|trans $}</label>
+						{$ util.form_error('lastname', errors) $}
+					</div>
+					<div class="field-grp">
+						<input type="email" id="email" name="email" placeholder="{$ 'contact_email'|trans $}">
+						<label for="email" class="sr-only">{$ 'contact_email'|trans $}</label>
+						{$ util.form_error('email', errors) $}
+					</div>
+					{$ util.form_error('category', errors) $}
+					</fieldset>
+				</div>
+				<div class="row">
+					<div class="field-grp col-xs-12 col-sm-12">
+						<textarea name="messageBody" rows="50" cols="10" id="comment" placeholder="{$ 'contact_body'|trans $}"></textarea>
+						<label for="subject" class="sr-only">{$ 'contact_body'|trans $}</label>
+						{$ util.form_error('messageBody', errors) $}
+					</div>
+				</div>
 			</div>
-			<div class="col-xs-12 col-sm-5 col-sm-offset-7 col-md-offset-8 col-md-4">
-				<div class="wrap-submit btn">
-					<input type="submit" value="{$ 'contact_submit'|trans $}" class="btn btn-introduction bk-blue text-center text-uppercase">
+			<div class="content col-xs-12 col-md-4 col-sm-4">
+				<div class="row align-items-end">
+					<div class="wrap-submit btn">
+						<input type="submit" value="{$ 'contact_submit'|trans $}" class="btn btn-introduction bk-blue text-center text-uppercase">
+					</div>
+				</div>
+				<div class="row align-items-end">
+                    {% include 'partials/back_link.html.twig' %}
 				</div>
 			</div>
 		</form>
-
-		<div class="row">
-			{% include 'partials/back_link.html.twig' %}
-		</div>
+	</div>
 	</div>
 {% endblock %}

--- a/skins/cat17/templates/partials/back_link.html.twig
+++ b/skins/cat17/templates/partials/back_link.html.twig
@@ -1,5 +1,5 @@
-<div class="back-block col-xs-12 col-sm-5 col-sm-offset-7 col-md-4 col-md-offset-8">
-	<ul class="list-menu link-reverse link-back list-unstyled">
+<div class="back-block col-xs-12 col-sm-12 col-md-12">
+	<ul class="list-menu link-back list-unstyled">
 		<li><a href="{$ path( '/' ) $}" class="">{$ 'back_to_donation' | trans $}</a></li>
 	</ul>
 </div>


### PR DESCRIPTION
Feature: T198052

- Contact form input fields are reorganized.
- Submit button and back link are moved to the top in line with `Topics` and `Subject`.
- In mobile view (or very small screens) everything is in 1 column.
- In mobile view the submit button and back link fit the view port.
