### PR TITLE
Move some Silex routes to controller classes

### DIFF
--- a/app/Controllers/ValidationController.php
+++ b/app/Controllers/ValidationController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App\Controllers;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+
+/**
+ * @license GNU GPL v2+
+ */
+class ValidationController {
+
+	public function validateEmail( Request $request, FunFunFactory $ffFactory ): Response {
+		$validationResult = $ffFactory->getEmailValidator()->validate( $request->request->get( 'email', '' ) );
+		return new JsonResponse( [
+			'status' => $validationResult->isSuccessful() ? 'OK' : 'ERR'
+		] );
+	}
+
+	public function validateDonationPayment( Request $request, FunFunFactory $ffFactory ): Response {
+		$amount = (float) $ffFactory->newDecimalNumberFormatter()->parse( $request->get( 'amount', '0' ) );
+		$validator = $ffFactory->newPaymentDataValidator();
+		$validationResult = $validator->validate( $amount, (string) $request->get( 'paymentType', '' ) );
+
+		if ( $validationResult->isSuccessful() ) {
+			return new JsonResponse( [ 'status' => 'OK' ] );
+		}
+
+		$errors = [];
+		foreach( $validationResult->getViolations() as $violation ) {
+			$errors[$violation->getSource()] = $ffFactory->getTranslator()->trans( $violation->getMessageIdentifier() );
+		}
+		return new JsonResponse( [ 'status' => 'ERR', 'messages' => $errors ] );
+
+	}
+}

--- a/app/FundraisingFactoryServiceProvider.php
+++ b/app/FundraisingFactoryServiceProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App;
+
+use Generator;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+
+/**
+ * Make FunFunFactory an injectable argument for Silex routes and controllers
+ *
+ * Inspired by https://github.com/derrabus/silex-psr11-provider
+ *
+ * @license GNU GPL v2+
+ */
+class FundraisingFactoryServiceProvider implements ServiceProviderInterface {
+
+	private $fffactory;
+
+	public function __construct( FunFunFactory $fffactory ) {
+		$this->fffactory = $fffactory;
+	}
+
+	public function register( Container $pimple ) {
+		$pimple['fundraising_factory'] = function ( Container $c ) {
+			return $this->fffactory;
+		};
+		$pimple->extend( 'argument_value_resolvers', function ( array $resolvers, Container $c ) {
+			$resolvers[] = new class( $c['fundraising_factory'] ) implements ArgumentValueResolverInterface {
+
+				private $ffFactory;
+
+				public function __construct( FunFunFactory $ffFactory ) {
+					$this->ffFactory = $ffFactory;
+				}
+
+				public function supports( Request $request, ArgumentMetadata $argument ): bool {
+					return $argument->getType() === FunFunFactory::class;
+				}
+
+				public function resolve( Request $request, ArgumentMetadata $argument ): Generator {
+					yield $this->ffFactory;
+				}
+			};
+
+			return $resolvers;
+		} );
+	}
+}

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use WMDE\Fundraising\Frontend\App\AccessDeniedException;
+use WMDE\Fundraising\Frontend\App\FundraisingFactoryServiceProvider;
 use WMDE\Fundraising\Frontend\BucketTesting\BucketSelectionServiceProvider;
 use WMDE\Fundraising\Frontend\Infrastructure\TrackingDataSelector;
 
@@ -26,6 +27,7 @@ $app->register( new SessionServiceProvider() );
 $app->register( new RoutingServiceProvider() );
 $app->register( new TwigServiceProvider() );
 $app->register( new BucketSelectionServiceProvider( $ffFactory ) );
+$app->register( new FundraisingFactoryServiceProvider( $ffFactory ) );
 
 $app->before(
 	function ( Request $request, Application $app ) {


### PR DESCRIPTION
This example shows how the anonymous functions from the routes.php files
can be moved into controller methods. This is a preparation to move to
Symfony, where all routing actions must be placed in controller methods.

This example also shows, how a RouteHandler class can be converted into
a controller class.

The new FundraisingFactoryServiceProvider enables the Silex Application
container to automatically inject the FunFunFactory into all controller
classes.

In the future, the FundraisingFactoryServiceProvider might also provide
the use case classes to the controllers, to make it more clear what the
controller is actually about and to further reduce the access surface.