### PR TITLE
Change background color on focusout in contact form

### DIFF
--- a/skins/cat17/src/sass/layouts/pages/contact.scss
+++ b/skins/cat17/src/sass/layouts/pages/contact.scss
@@ -11,6 +11,24 @@
 			.error-text {
 				display: block;
 			}
+			input, textarea {
+				@include themify($themes) {
+					background-color: themed('fieldNormal');
+					border-bottom: themed('border2pxfieldNormal');
+				}
+				&.filled {
+					@include themify($themes) {
+						background-color: themed('fieldSelected');
+						border-bottom: themed('border2pxfieldSelected');
+					}
+					&:hover {
+						@include themify($themes) {
+							border-bottom: themed('border2pxPrimary');
+						}
+
+					}
+				}
+			}
 		}
 		input[type="submit"] {
 			position: relative;

--- a/skins/cat17/src/scripts/contactForm.js
+++ b/skins/cat17/src/scripts/contactForm.js
@@ -1,0 +1,17 @@
+(function( $ ) {
+	$( document ).ready( function() {
+		attachEvents();
+	} );
+
+	function attachEvents() {
+		$( '#contact-form input, #contact-form textarea' ).focusout( function() {
+			if ( $( this ).val() ) {
+				$( this ).addClass( 'filled' );
+			}
+			else {
+				$( this ).removeClass( 'filled' );
+			}
+		} );
+	}
+
+})( jQuery );

--- a/skins/cat17/templates/contact_form.html.twig
+++ b/skins/cat17/templates/contact_form.html.twig
@@ -82,3 +82,7 @@
 	</div>
 	</div>
 {% endblock %}
+
+{% block scripts %}
+	<script src="{$ basepath $}/skins/cat17/scripts/contactForm.js"></script>
+{% endblock %}


### PR DESCRIPTION
Color should be light blue after focus is out of the `input`or `textarea` to indicate change.
This also keeps it consistent with the other forms on the website, e.g. in `Daten` section.

Feature: T198882