### PR TITLE
Fix donation summary overlay in tablet view when coming from a banner

### DIFF
--- a/skins/cat17/src/sass/components/_state-overview.scss
+++ b/skins/cat17/src/sass/components/_state-overview.scss
@@ -171,9 +171,6 @@
 		background-color: white;
 		z-index: 8;
 
-		@include bkp(sm) {
-			height: 60px;
-		}
 		li {
 			display: inline-block;
 			//width: 31.33%;


### PR DESCRIPTION
The donation overview overlaps the message coming from the banner on the donation front page.
This was observed only on tablet vertical view.

Bug: T199111