### PR TITLE
Emphasize confirmation page info based on context

### DIFF
--- a/app/Controllers/UpdateDonorController.php
+++ b/app/Controllers/UpdateDonorController.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\App\Controllers;
 
+use Silex\Application;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,7 +17,9 @@ use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
  */
 class UpdateDonorController {
 
-	public function updateDonor( Request $request, FunFunFactory $ffFactory ): Response {
+	public const ADDRESS_CHANGE_SESSION_KEY = 'address_changed';
+
+	public function updateDonor( Request $request, FunFunFactory $ffFactory, Application $app ): Response {
 		$updateToken = $request->request->get( 'updateToken', '' );
 		$accessToken = $request->query->get( 'accessToken', '' );
 		$responseModel = $ffFactory
@@ -26,6 +29,10 @@ class UpdateDonorController {
 			throw new AccessDeniedException();
 		}
 		if ( $responseModel->isSuccessful() ) {
+			$app['session']->set(
+				self::ADDRESS_CHANGE_SESSION_KEY,
+				true
+			);
 			return new RedirectResponse(
 				$ffFactory->getUrlGenerator()->generateAbsoluteUrl(
 					'show-donation-confirmation',

--- a/app/RouteHandlers/AddDonationHandler.php
+++ b/app/RouteHandlers/AddDonationHandler.php
@@ -12,6 +12,7 @@ use WMDE\Fundraising\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationRequest;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationResponse;
 use WMDE\Fundraising\Frontend\App\Controllers\ShowDonationConfirmationController;
+use WMDE\Fundraising\Frontend\App\Controllers\UpdateDonorController;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\AmountParser;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
@@ -51,6 +52,7 @@ class AddDonationHandler {
 		}
 
 		$this->sendTrackingDataIfNeeded( $request, $responseModel );
+		$this->resetSessionState();
 
 		return $this->newHttpResponse( $responseModel );
 	}
@@ -220,5 +222,15 @@ class AddDonationHandler {
 	 */
 	private function filterAutofillCommas( string $value ): string {
 		return trim( preg_replace( ['/,/', '/\s{2,}/'], [' ', ' '], $value ) );
+	}
+
+	/**
+	 * Reset session data to prevent old donations from changing the application output due to old data leaking into the new session
+	 */
+	private function resetSessionState(): void {
+		$this->app['session']->set(
+			UpdateDonorController::ADDRESS_CHANGE_SESSION_KEY,
+			false
+		);
 	}
 }

--- a/skins/cat17/src/sass/layouts/pages/donation_confirmation.scss
+++ b/skins/cat17/src/sass/layouts/pages/donation_confirmation.scss
@@ -99,6 +99,20 @@
 		}
 	}
 
+	.address-change {
+		.highlighted {
+			&.content {
+				border: none;
+				margin: 0;
+			}
+		}
+		.receipt-info {
+			border: 1px solid $brand-primary;
+			margin: 30px -20px 0;
+			padding: 10px 20px;
+		}
+	}
+
 	.caption {
 		color: rgba(0,0,0,.5);
 		width: 80%;
@@ -116,45 +130,6 @@
 			max-width: 100%;
 			margin: 0;
 		}
-	}
-
-	.donation-data {
-		padding: 0;
-	}
-
-	.show-info {
-		padding-bottom: 100px;
-	}
-
-	.highlighted {
-		border: 1px solid $brand-primary;
-		padding-top: 0;
-		margin-top: 45px;
-
-		@media print {
-			border: none;
-		}
-	}
-
-	.receipt {
-		&-info {
-			padding: 0 0 10px;
-			.btn {
-				text-decoration: none;
-			}
-		}
-		&-confirmation {
-			font-size: 19px;
-			display: block;
-		}
-	}
-
-	.caption {
-		color: rgba(0,0,0,.5);
-		width: 80%;
-		font-size: 12px;
-		line-height: 17px;
-		margin-top: 5px;
 	}
 
 	.donation-data {

--- a/skins/cat17/templates/Donation_Confirmation.html.twig
+++ b/skins/cat17/templates/Donation_Confirmation.html.twig
@@ -4,15 +4,15 @@
 
 {% block main %}
 	{% set formattedAmount = donation.amount|localizedcurrency('EUR', 'de_DE') %}
-
-	{% if donation.paymentType == 'MCP' or donation.paymentType == 'PPL' or donation.paymentType == 'SUB' %}
-		{% include 'partials/donation_confirmation/external_payment.html.twig' %}
-	{% elseif donation.paymentType == 'BEZ' %}
-		{% include 'partials/donation_confirmation/direct_debit.html.twig' %}
-	{% elseif donation.paymentType == 'UEB' %}
-		{% include 'partials/donation_confirmation/bank_transfer.html.twig' %}
-	{% endif %}
-
+	<div{% if global.session.get('address_changed') %} class="address-change"{% endif %}>
+		{% if donation.paymentType == 'MCP' or donation.paymentType == 'PPL' or donation.paymentType == 'SUB' %}
+			{% include 'partials/donation_confirmation/external_payment.html.twig' %}
+		{% elseif donation.paymentType == 'BEZ' %}
+			{% include 'partials/donation_confirmation/direct_debit.html.twig' %}
+		{% elseif donation.paymentType == 'UEB' %}
+			{% include 'partials/donation_confirmation/bank_transfer.html.twig' %}
+		{% endif %}
+	</div>
 	{% if featureToggle.donorUpdateEnabled and not updateData.isSuccessful %}
 		{% include 'partials/donation_confirmation/donor_form.html.twig' %}
 	{% endif %}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T202259

Quick explanation here on why I implemented it the way it is: Since there currently is no real user session or persistence, I decided to implement a session cookie for this particular feature. After some thinking and debating, I felt like using a session cookie would be the best choice here, mostly because it was the least painful solution. 

The alternatives I saw were modifying the URL which I think is kind of ugly and allows users to easily modify site behavior which they are not supposed to be able to control. Modifying the database was another alternative so that we could persist some sort of "address was changed" flag or even an address update timestamp which would allow us to determine if a user had updated their address and returned to the confirmation page.

One advantage of the session cookie is also that if a user bookmarks the URL and comes back to it later to print it or view the payment information, the highlighting around the address is gone and the highlighting around the payment will be back.

I accessed the cookie via Twig instead of accessing it via PHP directly, I added a new wrapper div around the payment methods with the sole purpose of being able to toggle the highlighting states via one CSS class instead of having 5 separate if statements across all the different payment method templates, this seemed like the least painful approach since I would not have to find a way to access the request deep into the PHP logic nor be worried of making this code too error-prone to refactor in the future. However, if you think this is ugly and you know of a better way, let me know.