### PR TITLE
Make dependecy on ext-json explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
 		"php": ">=7.1",
 		"ext-intl": "*",
 		"ext-curl": "*",
+		"ext-json": "*",
 
 		"silex/silex": "~2.0",
 		"twig/twig": "~1.23",


### PR DESCRIPTION
Since JSON handling is a PHP extension (albeit one the most PHP
installatiosn come pre-installed with) we make the dependency explicit
in composer.json

Also, this will appease the IDE.