### PR TITLE
Specify language version for Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,6 +22,9 @@ filter:
         - 'vendor/'
 
 build:
+    environment:
+        node: v6.2.0
+        php: 7.2.0
     nodes:
         analysis:
             tests:


### PR DESCRIPTION
Specify PHP and Node version, to avoid scrutinizer errors on outdated Node versions