### PR TITLE
Specify return type in FeatureToggleParser

### DIFF
--- a/src/BucketTesting/Validation/FeatureToggleParser.php
+++ b/src/BucketTesting/Validation/FeatureToggleParser.php
@@ -32,6 +32,10 @@ class FeatureToggleParser {
 		return $featureToggleChecks;
 	}
 
+	/**
+	 * @param string $choiceFactoryLocation
+	 * @return MethodCall[]
+	 */
 	private static function parseMethodCalls( string $choiceFactoryLocation ): array {
 		$parser = ( new ParserFactory() )->create( ParserFactory::PREFER_PHP7 );
 		$nodeFinder = new NodeFinder();


### PR DESCRIPTION
$nodeFinder->find returns node interface, but we're returning concrete
implementations (MethodCall). This change will hopefully appease syntax
checkers and make it more clear what's returned.