### PR TITLE
Ignore FunFunFactory in Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -18,6 +18,7 @@ filter:
         - 'skins/10h16/*'
         - 'node_modules/*'
         - 'tests/*'
+        - 'src/Factories/FunFunFactory.php'
     dependency_paths:
         - 'vendor/'
 


### PR DESCRIPTION
FunFunFactory brings down our score, but since it's our central entry
point, and *known* to be "too long" we don't care.