### PR TITLE
Schedule end of address test

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -23,7 +23,7 @@
 usability:
   description: Change the user experience on the donation page by removing immediate scrolling, some subheaders and moving newsletter opt-in
   reference: "https://phabricator.wikimedia.org/T202855"
-  start: "2018-09-10"
+  start: "2018-09-10 14:00:00"
   end: "2019-01-31"
   active: false
   buckets:
@@ -36,7 +36,7 @@ donation_address:
   description: Test address form being required immediately against only being presented optionally on the confirmation page
   reference: "https://phabricator.wikimedia.org/T196885"
   start: "2018-07-01"
-  end: "2019-01-31"
+  end: "2018-09-10 14:00:00"
   active: true
   buckets:
     - required


### PR DESCRIPTION
Make a seamless transition between the end of testing the optional
address form and the improved usability on donation form.

See https://phabricator.wikimedia.org/T202854 and https://phabricator.wikimedia.org/T202858