### PR TITLE
Update the route when coming from a banner

### DIFF
--- a/app/Routes.php
+++ b/app/Routes.php
@@ -375,7 +375,7 @@ class Routes {
 				try {
 					$amount = Euro::newFromFloat(
 						( new AmountParser( 'en_EN' ) )->parseAsFloat(
-							$request->get( 'betrag_auswahl', $request->get( 'amountGiven', '' ) )
+							$request->get( 'betrag_auswahl', $request->get( 'betrag',  $request->get( 'amountGiven', '' ) ) )
 						)
 					);
 				}


### PR DESCRIPTION
Bug: T204113

My theory why the bug occurs: 
`amountGiven` is a parameter set when the chosen amount is custom. And there's validation for it in the Fundraising Frontend. 
In the A/B test case of `Address Change` and `Desktop Banner Campaign 05` the donation form is skipped and the user is presented with either the donation confirmation page or the 3rd party payment provider web. Therefor we shouldn't allow `amountGiven` to be set because practically no validation can happen.
When a custom amount is filled in the banner, `amountGiven` is sent to the fundraising app and then all hell breaks loose. :no_good_woman: 