### PR TITLE
Remove Paypal notice in JS

### DIFF
--- a/skins/10h16/web/_js/donationForm.js
+++ b/skins/10h16/web/_js/donationForm.js
@@ -159,13 +159,6 @@ $( function () {
 				viewHandler: WMDE.View.createSlidingVisibilitySwitcher( $( '.notice-anonymous' ), 'anonym' ),
 				stateKey: 'donationFormContent.addressType'
 			},
-			// Show "credit card required" notice for recurrent payments via Paypal
-			{
-				viewHandler: WMDE.View.createRecurrentPaypalNoticeHandler(
-					WMDE.View.Animator.createSlidingElementAnimator( $( '.notice-ppl-recurrent' ) )
-				),
-				stateKey: 'donationFormContent'
-			},
 			// Show warning when street contains no house number
 			{
 				viewHandler: WMDE.View.createWarningBox(


### PR DESCRIPTION
Follow-up to #1330 

I did not remove the view handler on the membership page, because that one shows another, membership-specific notice that is still relevant. 

Feature: [T202718](https://phabricator.wikimedia.org/T202718)

