### PR TITLE
Hide Bootstrap and Route from Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,6 +19,8 @@ filter:
         - 'node_modules/*'
         - 'tests/*'
         - 'src/Factories/FunFunFactory.php'
+        - 'app/Bootstrap.php'
+        - 'app/Routes.php'
     dependency_paths:
         - 'vendor/'
 


### PR DESCRIPTION
This is the HTTP environment setup code that will be changed during the
Symfony migration. Formerly, those files were not classes, now
Scrutinizer complains. Routes.php is tested by the E2E tests.