### PR TITLE
Fix campaign configuration

### DIFF
--- a/app/config/campaigns.test.yml
+++ b/app/config/campaigns.test.yml
@@ -1,7 +1,11 @@
 # This file is used during unit tests and overrides campaign configurations
 #
-# Set all campaigns to inactive to force the tests using the default code paths
+# All campaigns *MUST* be inactive to force the tests using the default code paths
+# Unit tests that test campaign features might override the campaign state
 
+
+# Until https://phabricator.wikimedia.org/T163452 is resolved,
+# we must force the unit tests to use the `test` skin.
 skins:
   active: false
   buckets:
@@ -9,4 +13,4 @@ skins:
   default_bucket: "test"
 
 donation_address:
-  active: true
+  active: false

--- a/build/app/config.dev.json
+++ b/build/app/config.dev.json
@@ -124,5 +124,8 @@
   "cookie": {
     "secure": false,
     "httpOnly": false
+  },
+  "campaigns": {
+    "configurations": [ "campaigns.yml", "campaigns.dev.yml" ]
   }
 }


### PR DESCRIPTION
Load `campaigns.dev.yml` in the default configuration for the
"dev" environment.

Clarify the contents of `campaigns.test.yml`.