### PR TITLE
Change default Matomo siteId

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -130,7 +130,7 @@
 	},
 	"piwik": {
 		"baseUrl": "//tracking.wikimedia.de/",
-		"siteId": 1,
+		"siteId": 5,
 		"siteUrlBase": ""
 	},
 	"translation": {


### PR DESCRIPTION
Change default siteId from 1 (production) to 5 (test).

I've updated the configuration defaults on the deploy server.