### PR TITLE
Remove further ways to get in touch

### DIFF
--- a/skins/cat17/faq-page/src/Faq.vue
+++ b/skins/cat17/faq-page/src/Faq.vue
@@ -49,7 +49,6 @@
 		<h5>{{ messages.no_answer }}</h5>
 		<ul>
 			<li><a href="/contact/get-in-touch">{{ messages.contact_link }}</a></li>
-			<li>{{ messages.further }} <a href="/contact/get-in-touch">{{ messages.contact_options }}</a></li>
 		</ul>
 	</div>
 	</div>


### PR DESCRIPTION
Removed, because there is no content to link to and the contact form is already in the first list item.