### PR TITLE
Extend campaign end dates until January 2019

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -24,7 +24,7 @@ donation_address:
   description: Test address form being required immediately against only being presented optionally on the confirmation page
   reference: "https://phabricator.wikimedia.org/T211666"
   start: "2018-12-12 12:00:00"
-  end: "2018-12-31 23:00:00"
+  end: "2019-01-07 23:00:00"
   active: true
   buckets:
     - required
@@ -37,7 +37,7 @@ skins:
   description: Test different skins
   reference: "https://phabricator.wikimedia.org/T206994"
   start: "2018-10-31 13:00:00"
-  end: "2018-12-31 23:00:00"
+  end: "2019-01-07 23:00:00"
   buckets:
     - "cat17"
     - "10h16"
@@ -49,7 +49,7 @@ membership_call_to_action:
   description: Display different content for membership call to action on donation confirmation page
   reference: "https://phabricator.wikimedia.org/T210083"
   start: "2018-11-29 19:00:00"
-  end: "2018-12-31 23:59:59"
+  end: "2019-01-07 23:59:59"
   buckets:
   - "regular"
   - "video"
@@ -77,7 +77,7 @@ donation_form_design:
   description: Test design changes to donation form
   reference: "https://phabricator.wikimedia.org/T212203"
   start: "2018-12-29 12:00:00"
-  end: "2018-12-31 23:00:00"
+  end: "2019-01-07 23:00:00"
   active: false
   buckets:
     - default


### PR DESCRIPTION
To avoid timezone problems when the campaigns end (see
https://github.com/wmde/FundraisingFrontend/pull/1406 ) we extend the
campaign end dates by 1 week (just to be sure).

Short-Term fix for https://phabricator.wikimedia.org/T211716

Feel free to remove/deactivate campaigns before that date,