### PR TITLE
Set token validity to 30 minutes

### DIFF
--- a/app/config/config.dist.json
+++ b/app/config/config.dist.json
@@ -93,7 +93,7 @@
 	"donation-timeframe-limit": "PT30M",
 	"membership-application-timeframe-limit": "PT10M",
 	"token-length": 16,
-	"token-validity-timestamp": "PT4H",
+	"token-validity-timestamp": "PT30M",
 	"purging-secret": "",
 	"paypal-donation": {
 		"base-url": "https://www.paypal.com/cgi-bin/webscr?",


### PR DESCRIPTION
Allow users to cancel/comment for 30 minutes.

We set the previous value of 4 hours for the "address form on confirmation page" A/B tests.

https://phabricator.wikimedia.org/T212404