### PR TITLE
Fix membership page skip button

### DIFF
--- a/skins/cat17/src/scripts/membershipForm.js
+++ b/skins/cat17/src/scripts/membershipForm.js
@@ -380,7 +380,7 @@ $( function () {
 	}
 
 	function forceValidateFeeData() {
-		if ( WMDE.StateAggregation.Membership.amountAndFrequencyAreValid( store.getState() ) !== WMDE.Validity.VALID ) {
+		if ( WMDE.StateAggregation.Membership.amountAndFrequencyAreValid( store.getState() ).isValid !== WMDE.Validity.VALID ) {
 			store.dispatch( WMDE.Actions.newFinishPaymentDataValidationAction( { status: WMDE.ValidationStates.ERR } ) );
 		}
 		return WMDE.Promise.resolve();

--- a/skins/cat17/templates/Membership_Application.html.twig
+++ b/skins/cat17/templates/Membership_Application.html.twig
@@ -29,7 +29,7 @@
 
 					<div class="row">
 						<div class="col-xs-12 col-sm-5 col-sm-offset-7 col-md-4 col-md-offset-8">
-							<a href="#membership-type"
+							<a href="{% if showMembershipTypeOption == 'true' %}#membership-type{% else %}#donation-type{% endif %}"
 							   class="btn btn-membership btn-introduction bk-blue text-center text-uppercase">{$ 'membership_submit' | trans $}</a>
 						</div>
 					</div>


### PR DESCRIPTION
The button scrolls to the first form element, however when the parameter
&type=sustaining is set, then the first form element is hidden and the
button does nothing. Solution: Button anchor now depends on the
parameter.