### PR TITLE
Fix DateTimeInterface-related crash on production

### DIFF
--- a/src/BucketTesting/CampaignDate.php
+++ b/src/BucketTesting/CampaignDate.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\BucketTesting;
 
-use DateTimeInterface;
 use DateTimeZone;
 
 /**
@@ -27,6 +26,6 @@ class CampaignDate extends \DateTimeImmutable {
 		}
 		$instance = new \DateTime( $time, $timezone );
 		$instance->setTimezone( new DateTimeZone( self::TIMEZONE ) );
-		return new self( $instance->format( DateTimeInterface::ISO8601 ) );
+		return new self( $instance->format( \DateTime::ISO8601 ) );
 	}
 }


### PR DESCRIPTION
Production servers are still running on PHP 7.1, however the
DateTimeInterface only received class constants in PHP 7.2 causing the
code to throw a fatal error on production as the class constant cannot
be found.