### PR TITLE
Add temporary fix for failing JS build

### DIFF
--- a/skins/cat17/address-form/package.json
+++ b/skins/cat17/address-form/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-vue": "^5.0.0",
     "node-sass": "^4.9.0",
     "sass-loader": "^7.0.1",
+    "terser": "~3.14",
     "typescript": "~3.1.1",
     "vue-template-compiler": "^2.5.21"
   }


### PR DESCRIPTION
Pin version number of a dependency.
See https://github.com/vuejs/vue-cli/issues/3407

When that issue is resolved, revert this.