### PR TITLE
Prepare Address Form for Unit Tests

### DIFF
--- a/skins/cat17/address-form/src/AddressForm.vue
+++ b/skins/cat17/address-form/src/AddressForm.vue
@@ -23,7 +23,7 @@
 	import Vue from 'vue';
 	import Name from './components/Name.vue';
 	import Postal from './components/Postal.vue';
-	import {inputField, ValidationResult} from './types';
+	import {InputField, ValidationResult} from './types';
 
 	export default Vue.extend ( {
 		name: 'addressForm',

--- a/skins/cat17/address-form/src/AddressForm.vue
+++ b/skins/cat17/address-form/src/AddressForm.vue
@@ -23,7 +23,7 @@
 	import Vue from 'vue';
 	import Name from './components/Name.vue';
 	import Postal from './components/Postal.vue';
-	import {InputField, ValidationResult} from './types';
+	import {InputField, ValidationResult, Transport} from './types';
 
 	export default Vue.extend ( {
 		name: 'addressForm',
@@ -107,7 +107,9 @@
 			}
 		},
 		props: {
-            transport: Object,
+            transport: {
+                type: Object as () => Transport
+            },
 			addressToken: String,
 			isCompany: Boolean,
 			messages: Object,
@@ -123,8 +125,8 @@
 		methods: {
 			validateForm() {
 				this.$store.dispatch('storeAddressFields', {
-                    transport: this.transport,
-					validateAddressURL: this.validateAddressURL,
+                    transport: this.$props.transport,
+					validateAddressURL: this.$props.validateAddressURL,
 					formData: this.formData
 				}).then( resp => {
 					if (!this.$store.getters.allFieldsAreValid) {

--- a/skins/cat17/address-form/src/AddressForm.vue
+++ b/skins/cat17/address-form/src/AddressForm.vue
@@ -107,6 +107,7 @@
 			}
 		},
 		props: {
+            transport: Object,
 			addressToken: String,
 			isCompany: Boolean,
 			messages: Object,
@@ -122,6 +123,7 @@
 		methods: {
 			validateForm() {
 				this.$store.dispatch('storeAddressFields', {
+                    transport: this.transport,
 					validateAddressURL: this.validateAddressURL,
 					formData: this.formData
 				}).then( resp => {

--- a/skins/cat17/address-form/src/main.ts
+++ b/skins/cat17/address-form/src/main.ts
@@ -2,17 +2,20 @@ import Vue from "vue";
 import store from "./store";
 import AddressForm from "./AddressForm.vue";
 
+const JQueryTransport = require('../../src/app/lib/jquery_transport').default;
+
 Vue.config.productionTip = false;
 
 let addressElement: any = document.getElementById( 'updateAddress' );
 let initAddressForm: any = document.getElementById( 'address-form' );
 
 new Vue( {
-	store,
+    store,
 	render: h => h(
 		AddressForm,
 		{
 			props: {
+                transport: new JQueryTransport(),
 				addressToken: addressElement.getAttribute('data-address-token'),
 				isCompany: JSON.parse( addressElement.getAttribute('data-is-company') ),
 				messages: JSON.parse(addressElement.getAttribute('data-messages')),

--- a/skins/cat17/address-form/src/mixins/helper.ts
+++ b/skins/cat17/address-form/src/mixins/helper.ts
@@ -1,4 +1,5 @@
 import { Validity } from '../lib/validation_states';
+import { PostData, FormData } from '../types';
 
 export const Helper = {
     inputIsValid: (value: string, pattern: string ) => {
@@ -6,5 +7,11 @@ export const Helper = {
             return value !== '' ? Validity.VALID : Validity.INVALID;
         }
         return new RegExp(pattern).test(value) ? Validity.VALID : Validity.INVALID;
+    },
+    formatPostData: (form: FormData) => {
+        return Object.keys(form).reduce((accumultaor: PostData, currentValue: string) => {
+            accumultaor[currentValue] = form[currentValue].value;
+            return accumultaor;
+        }, {});
     }
 }

--- a/skins/cat17/address-form/src/store.ts
+++ b/skins/cat17/address-form/src/store.ts
@@ -14,8 +14,6 @@ const ADDRESS_FIELD_VALIDATOR_NAMES: Array<string> = [
 	'companyName',
 	'street', 'postcode', 'city', 'country'
 ];
-const JQueryTransport = require('../../src/app/lib/jquery_transport').default;
-let transport = new JQueryTransport();
 
 Vue.use(Vuex);
 
@@ -126,7 +124,7 @@ const store: StoreOptions<AddressState> = {
 			if ( getters.allFieldsAreValid ) {
                 commit('BEGIN_ADDRESS_VALIDATION');
                 let postData = Helper.formatPostData(payload.formData);
-                return transport.postData(payload.validateAddressURL, postData)
+                return payload.transport.postData(payload.validateAddressURL, postData)
 					.then( (validationResult: ValidationResult) => {
 						commit('FINISH_ADDRESS_VALIDATION', validationResult);
 					});

--- a/skins/cat17/address-form/src/store.ts
+++ b/skins/cat17/address-form/src/store.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import Vuex, {StoreOptions} from 'vuex';
 import {Validity} from './lib/validation_states';
 import {Helper} from './mixins/helper';
-import {AddressState, InputField, Payload, ValidationResult} from './types';
+import { AddressState, InputField, Payload, PostData, ValidationResult} from './types';
 
 const VALIDATE_INPUT: string = 'VALIDATE_INPUT';
 const MARK_EMPTY_FIELD_INVALID: string = 'MARK_EMPTY_FIELD_INVALID';
@@ -124,8 +124,9 @@ const store: StoreOptions<AddressState> = {
 		storeAddressFields({ commit, getters }, payload: Payload) {
 			commit('MARK_EMPTY_FIELD_INVALID', payload.formData);
 			if ( getters.allFieldsAreValid ) {
-				commit('BEGIN_ADDRESS_VALIDATION');
-				return transport.postData(payload.validateAddressURL, payload.formData)
+                commit('BEGIN_ADDRESS_VALIDATION');
+                let postData = Helper.formatPostData(payload.formData);
+                return transport.postData(payload.validateAddressURL, postData)
 					.then( (validationResult: ValidationResult) => {
 						commit('FINISH_ADDRESS_VALIDATION', validationResult);
 					});

--- a/skins/cat17/address-form/src/types.ts
+++ b/skins/cat17/address-form/src/types.ts
@@ -33,6 +33,7 @@ export interface FormData {
 }
 
 export interface Payload {
+    transport: JQueryTransport,
 	validateAddressURL: String,
 	formData: FormData
 }
@@ -41,4 +42,7 @@ export interface PostData {
     [key: string]: string
 }
 
-
+export interface JQueryTransport {
+    getData: Function
+    postData: Function
+}

--- a/skins/cat17/address-form/src/types.ts
+++ b/skins/cat17/address-form/src/types.ts
@@ -37,4 +37,8 @@ export interface Payload {
 	formData: FormData
 }
 
+export interface PostData {
+    [key: string]: string
+}
+
 

--- a/skins/cat17/address-form/src/types.ts
+++ b/skins/cat17/address-form/src/types.ts
@@ -32,17 +32,17 @@ export interface FormData {
     [key: string]: InputField
 }
 
+export interface Transport {
+    getData: Function
+    postData: Function
+}
+
 export interface Payload {
-    transport: JQueryTransport,
+    transport: Transport,
 	validateAddressURL: String,
 	formData: FormData
 }
 
 export interface PostData {
     [key: string]: string
-}
-
-export interface JQueryTransport {
-    getData: Function
-    postData: Function
 }


### PR DESCRIPTION
Feature: [T215151](https://phabricator.wikimedia.org/T215151)
Define `JQueryTransport` interface and pass the library to the main `Vue` component.
This way we can easily test the behavior by passing a fake `JQueryTransport` in the unit tests.