### PR TITLE
Update kontocheck PHP extension

### DIFF
--- a/build/app/Dockerfile
+++ b/build/app/Dockerfile
@@ -17,26 +17,21 @@ RUN apt-get update \
     #&& docker-php-ext-install -j$(nproc) pdo_sqlite \
     && docker-php-ext-install -j$(nproc) intl curl xml pdo_mysql mbstring
 
-ENV KONTOCHECK_VERSION 5.8
+ENV KONTOCHECK_VERSION 6.08
 
 RUN \
 	docker-php-source extract && \
 	cd /tmp && \
 	curl -Ls -o konto_check-$KONTOCHECK_VERSION.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/konto_check-$KONTOCHECK_VERSION.zip/download && \
-	curl -Ls -o php7.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/php7.zip/download && \
 	unzip konto_check-*.zip && \
-	unzip php7.zip && \
-	cd konto_check-5.* && \
+	cd konto_check-$KONTOCHECK_VERSION && \
 	cp blz.lut2f /etc/blz.lut && \
 	unzip php.zip && \
 	cd php && \
-	cp /tmp/php/konto_check.c . && \
-	# see https://sourceforge.net/p/kontocheck/bugs/17/
-	sed -i -e 's/Z_TYPE_PP/Z_TYPE_P/g' konto_check.c && \
-	sed -i -e 's/Z_LVAL_PP/Z_LVAL_P/g' konto_check.c && \
 	docker-php-ext-configure /tmp/konto_check-$KONTOCHECK_VERSION/php && \
 	docker-php-ext-install /tmp/konto_check-$KONTOCHECK_VERSION/php && \
-	docker-php-source delete
+	docker-php-source delete && \
+	rm -rf /tmp/konto_check-*
 
 RUN apt-get install -y ssmtp \
     && echo "mailhub=mailhog:1025" >> /etc/ssmtp/ssmtp.conf

--- a/build/phpstan/Dockerfile
+++ b/build/phpstan/Dockerfile
@@ -13,26 +13,21 @@ RUN \
 	docker-php-ext-configure intl --enable-intl && \
 	docker-php-ext-install intl curl xml pdo_mysql mbstring
 
-ENV KONTOCHECK_VERSION 5.8
+ENV KONTOCHECK_VERSION 6.08
 
 RUN \
 	docker-php-source extract && \
 	cd /tmp && \
 	curl -Ls -o konto_check-$KONTOCHECK_VERSION.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/konto_check-$KONTOCHECK_VERSION.zip/download && \
-	curl -Ls -o php7.zip https://sourceforge.net/projects/kontocheck/files/konto_check-de/$KONTOCHECK_VERSION/php7.zip/download && \
 	unzip konto_check-*.zip && \
-	unzip php7.zip && \
-	cd konto_check-5.* && \
+	cd konto_check-$KONTOCHECK_VERSION && \
 	cp blz.lut2f /etc/blz.lut && \
 	unzip php.zip && \
 	cd php && \
-	cp /tmp/php/konto_check.c . && \
-	# see https://sourceforge.net/p/kontocheck/bugs/17/
-	sed -i -e 's/Z_TYPE_PP/Z_TYPE_P/g' konto_check.c && \
-	sed -i -e 's/Z_LVAL_PP/Z_LVAL_P/g' konto_check.c && \
 	docker-php-ext-configure /tmp/konto_check-$KONTOCHECK_VERSION/php && \
 	docker-php-ext-install /tmp/konto_check-$KONTOCHECK_VERSION/php && \
-	docker-php-source delete
+	docker-php-source delete && \
+	rm -rf /tmp/konto_check-*
 
 RUN composer global require phpstan/phpstan ^0.11
 ENTRYPOINT [ "/tmp/vendor/bin/phpstan" ]


### PR DESCRIPTION
Update extension to 6.08. The version jump from 5 to 6 does not mean BC
break, the version was incremented due to CPAN versioning problems in
the Perl version.

The newer versions of kontocheck don't need manual patching and error
removal in the Dockerfile.