### PR TITLE
fix error message showing up too early

### DIFF
--- a/skins/cat17/src/scripts/membershipForm.js
+++ b/skins/cat17/src/scripts/membershipForm.js
@@ -324,7 +324,7 @@ $( function () {
 		{
 			viewHandler: WMDE.View.createElementClassSwitcher(
 				$( '.wrap-membership-type .error-container' ),
-				/^(|null)$/,
+				/^$/,
 				'invalid'
 			),
 			stateKey: 'membershipFormContent.membershipType'


### PR DESCRIPTION
The membership type selection showed an error without the user
having interacted with the form yet, now it stays quiet until
the user does something.

Bug: T214491