### PR TITLE
fix division by zero in UI validation

### DIFF
--- a/skins/cat17/src/app/lib/form_validation.js
+++ b/skins/cat17/src/app/lib/form_validation.js
@@ -73,7 +73,7 @@ var objectAssign = require( 'object-assign' ),
 			return this.transport.postData( this.validationUrl, postData );
 		},
 		formValuesHaveEmptyRequiredFields: function ( formValues ) {
-			return formValues.amount === 0 || !formValues.addressType || !formValues.paymentIntervalInMonths;
+			return formValues.amount === 0 || !formValues.addressType || !formValues.paymentIntervalInMonths || formValues.paymentIntervalInMonths === -1;
 		}
 	},
 


### PR DESCRIPTION
The paymenIntervalInMonths value being 0 is currently not reproducable
as its initial value is -1 and the UI validation prevents it from entering
a state where it could become 0.

This additional check will prevent the interval field from being validated
before it was selected because there is a check now for its correct
default value (-1).

https://phabricator.wikimedia.org/T215163