### PR TITLE
Fix namespace in covers tag of some tests

### DIFF
--- a/tests/EdgeToEdge/Routes/GenerateIbanRouteTest.php
+++ b/tests/EdgeToEdge/Routes/GenerateIbanRouteTest.php
@@ -7,7 +7,7 @@ namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge\Routes;
 use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Presentation\Presenters\IbanPresenter
+ * @covers \WMDE\Fundraising\Frontend\Presentation\Presenters\IbanPresenter
  *
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/Integration/Presentation/Presenters/ConfirmSubscriptionHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/ConfirmSubscriptionHtmlPresenterTest.php
@@ -12,7 +12,7 @@ use WMDE\FunValidators\ValidationResponse;
 use WMDE\FunValidators\ConstraintViolation;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Presentation\Presenters\ConfirmSubscriptionHtmlPresenter
+ * @covers \WMDE\Fundraising\Frontend\Presentation\Presenters\ConfirmSubscriptionHtmlPresenter
  *
  * @license GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >

--- a/tests/Unit/Infrastructure/BestEffortDonationEventLoggerTest.php
+++ b/tests/Unit/Infrastructure/BestEffortDonationEventLoggerTest.php
@@ -11,7 +11,7 @@ use WMDE\Fundraising\DonationContext\Infrastructure\DonationEventLogger;
 use WMDE\Fundraising\DonationContext\Tests\Fixtures\DonationEventLoggerSpy;
 
 /**
- * @covers WMDE\Fundraising\DonationContext\Infrastructure\BestEffortDonationEventLogger
+ * @covers \WMDE\Fundraising\DonationContext\Infrastructure\BestEffortDonationEventLogger
  *
  * @licence GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >

--- a/tests/Unit/Infrastructure/Cache/AuthorizedCachePurgerTest.php
+++ b/tests/Unit/Infrastructure/Cache/AuthorizedCachePurgerTest.php
@@ -9,7 +9,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\Cache\CachePurgingException;
 use WMDE\Fundraising\Frontend\Infrastructure\Cache\AuthorizedCachePurger;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Infrastructure\Cache\AuthorizedCachePurger
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\Cache\AuthorizedCachePurger
  *
  * @license GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >

--- a/tests/Unit/Infrastructure/MessengerTest.php
+++ b/tests/Unit/Infrastructure/MessengerTest.php
@@ -10,7 +10,7 @@ use WMDE\Fundraising\Frontend\Infrastructure\Message;
 use WMDE\Fundraising\Frontend\Infrastructure\Messenger;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Infrastructure\Messenger
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\Messenger
  *
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >

--- a/tests/Unit/Infrastructure/PageViewTrackerTest.php
+++ b/tests/Unit/Infrastructure/PageViewTrackerTest.php
@@ -8,7 +8,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\ServerSideTrackerSpy;
 use WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\PageViewTracker
  *
  * @licence GNU GPL v2+
  * @author Leszek Manicki <leszek.manicki@wikimedia.de>

--- a/tests/Unit/Infrastructure/PiwikEventsTest.php
+++ b/tests/Unit/Infrastructure/PiwikEventsTest.php
@@ -7,7 +7,7 @@ namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
 use WMDE\Fundraising\Frontend\Infrastructure\PiwikEvents;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Infrastructure\PiwikEvents
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\PiwikEvents
  *
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >

--- a/tests/Unit/Presentation/AmountFormatterTest.php
+++ b/tests/Unit/Presentation/AmountFormatterTest.php
@@ -8,7 +8,7 @@ use WMDE\Euro\Euro;
 use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Presentation\AmountFormatter
+ * @covers \WMDE\Fundraising\Frontend\Presentation\AmountFormatter
  *
  * @licence GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >

--- a/tests/Unit/Presentation/HonorificsTest.php
+++ b/tests/Unit/Presentation/HonorificsTest.php
@@ -7,7 +7,7 @@ namespace WMDE\Fundraising\Frontend\Tests\Unit\Presentation;
 use WMDE\Fundraising\Frontend\Presentation\Honorifics;
 
 /**
- * @covers WMDE\Fundraising\Frontend\Presentation\Honorifics
+ * @covers \WMDE\Fundraising\Frontend\Presentation\Honorifics
  *
  * @license GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >


### PR DESCRIPTION
Without the backslash at the start, PHPStorm does not recognize the
covered classes. Not entirely sure if this has any effect on the code
coverage data.