### PR TITLE
remove date from membership form and confirmation

### DIFF
--- a/skins/10h16/templates/Membership_Application.html.twig
+++ b/skins/10h16/templates/Membership_Application.html.twig
@@ -1,5 +1,5 @@
 {% set showMembershipTypeOption = showMembershipTypeOption is defined ? showMembershipTypeOption : 'true' %}
-{% set membershipAppeal = 'Werden Sie ab 2019 Mitglied für Freies Wissen!' %}
+{% set membershipAppeal = 'Werden Sie jetzt Mitglied für Freies Wissen!' %}
 {% set formSlideOpen = false %}
 {% set initialPaymentType = paymentTypes|length == 1 ? paymentTypes|first : '' %}
 

--- a/skins/10h16/templates/Membership_Application_Bank_Data_Confirmation.html.twig
+++ b/skins/10h16/templates/Membership_Application_Bank_Data_Confirmation.html.twig
@@ -39,7 +39,7 @@
 							<h2 class="f-left no-margin">SEPA-Lastschriftmandat</h2><br /><br />
 
 							<p class="title">
-								Sie zahlen ab 2019 <span id="membership-confirm-interval">{$ membershipAppl.payment.intervalText $}</span> einen
+								Sie zahlen <span id="membership-confirm-interval">{$ membershipAppl.payment.intervalText $}</span> einen
 								Mitgliedsbeitrag in H&ouml;he von <span id="membership-confirm-fee"><strong>{$ membershipAppl.payment.fee $} €</strong></span> an
 							</p>
 

--- a/skins/10h16/templates/Membership_Application_Confirmation.html.twig
+++ b/skins/10h16/templates/Membership_Application_Confirmation.html.twig
@@ -49,7 +49,7 @@
 
 							<h2 class="f-left no-margin">SEPA-Lastschriftmandat</h2><br /><br />
 
-							<p class="title">Sie zahlen ab 2019 {$ membershipApplication.paymentIntervalInMonths|trans({}, 'paymentIntervals') $} einen Mitgliedsbeitrag in H&ouml;he von <strong>{$ formattedAmount $}</strong> an Wikimedia Deutschland e. V., Tempelhofer Ufer 23-24, 10963 Berlin</p>
+							<p class="title">Sie zahlen {$ membershipApplication.paymentIntervalInMonths|trans({}, 'paymentIntervals') $} einen Mitgliedsbeitrag in H&ouml;he von <strong>{$ formattedAmount $}</strong> an Wikimedia Deutschland e. V., Tempelhofer Ufer 23-24, 10963 Berlin</p>
 
 							<p class="title">Sie zahlen per {$ membershipApplication.paymentType|trans({}, 'paymentTypes') $}.</p>
 	{% if membershipApplication.paymentType == 'PPL' %}

--- a/skins/10h16/templates/Membership_Application_Embedded.html.twig
+++ b/skins/10h16/templates/Membership_Application_Embedded.html.twig
@@ -3,9 +3,9 @@
 {% set initialPaymentType = paymentTypes|length == 1 ? paymentTypes|first : '' %}
 {% set trackOutgoingLinks = true %}
 {% if address.salutation and address.lastName %}
-	{% set membershipAppeal = "#{address.salutation} #{address.lastName}, werden Sie ab 2019 Fördermitglied!" %}
+	{% set membershipAppeal = "#{address.salutation} #{address.lastName}, werden Sie jetzt Fördermitglied!" %}
 {% else %}
-	{% set membershipAppeal = 'Werden Sie ab 2019 Fördermitglied!' %}
+	{% set membershipAppeal = 'Werden Sie jetzt Fördermitglied!' %}
 {% endif %}
 
 {% include 'Validation_Errors.html.twig' %}


### PR DESCRIPTION
As it is 2019 already, we can drop putting out the year on the form and the confirmation page.