### PR TITLE
Combine CSS into one file

### DIFF
--- a/skins/wmde19/templates/Base_Layout.html.twig
+++ b/skins/wmde19/templates/Base_Layout.html.twig
@@ -20,7 +20,11 @@
 
     <link rel="shortcut icon" href="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/wmde19{% endif %}/images/favicon.ico" />
     <link rel="apple-touch-icon" href="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/wmde19{% endif %}/images/apple-touch-icon.png" />
-    {% block styles %}{% endblock %}
+    {% block styles %}
+        {% if not assets_path %}
+            <link rel="stylesheet" href="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/wmde19{% endif %}/css/styles.css">
+        {% endif %}
+    {% endblock %}
 </head>
 <body>
 {% block main %}
@@ -33,7 +37,19 @@
 {% endblock %}
 
 {% block scripts %}
-{# TODO Add vendor and common chunks #}
+    {% if not assets_path %}
+        <script src="{$ basepath $}/skins/wmde19/js/chunk-vendors.js"></script>
+        {#
+           The file `styles.js` is needed due to a webpack error that propagates to the CSS-extract plugin.
+           Hopefully, the error gets fixed before this skin is released, so we can remove this silly dependency.
+           Otherwise, we must integrate the contents of styles.js into chunk-vendors.js during the build process.
+           See
+           https://github.com/webpack/webpack/issues/7300
+           https://github.com/webpack-contrib/mini-css-extract-plugin/issues/85
+           https://github.com/webpack-contrib/mini-css-extract-plugin/issues/113
+        #}
+        <script src="{$ basepath $}/skins/wmde19/js/styles.js"></script>
+    {% endif %}
 {% endblock %}
 
 {# TODO add Piwik tracking #}

--- a/skins/wmde19/templates/Error_Page.html.twig
+++ b/skins/wmde19/templates/Error_Page.html.twig
@@ -1,12 +1,6 @@
 {% extends 'Base_Layout.html.twig' %}
 
-{% block styles %}
-	<link rel="stylesheet" href="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/wmde19{% endif %}/css/error.css">
-{% endblock %}
-
 {% block scripts %}
 	{$ parent() $}
-
-	{% if not assets_path %}<script src="{$ basepath $}/skins/wmde19/js/chunk-vendors.js"></script>{% endif %}
 	<script src="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/wmde19{% endif %}/js/error.js"></script>
 {% endblock %}

--- a/skins/wmde19/vue.config.js
+++ b/skins/wmde19/vue.config.js
@@ -34,6 +34,25 @@ module.exports = {
 					chunkFilename: 'css/[name].css',
 				} ] );
 			}
+			// Preliminary solution for combining all CSS into one file
+			// see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/113
+			config.optimization.splitChunks( {
+				cacheGroups: {
+					commons: {
+						test: /node_modules/,
+						chunks: 'initial',
+						name: 'chunk-vendors',
+					},
+					'styles-compiled': {
+						name: 'styles',
+						test: module =>
+							module.nameForCondition &&
+							/\.(s?css|vue)$/.test( module.nameForCondition() ) && !/^javascript/.test( module.type ),
+						chunks: 'all',
+						enforce: true,
+					},
+				},
+			} );
 		}
 		config.module
 			.rule( 'vue' )


### PR DESCRIPTION
Configure webpack to combine the CSS from all entry points into one
file.

Unfortunately, due to a [webpack bug][1], this also generates an
additional JS file that must be included.

This is for https://phabricator.wikimedia.org/T220997

[1]: https://github.com/webpack/webpack/issues/7300