### PR TITLE
Fix for IE11 footer positioning

### DIFF
--- a/skins/laika/src/scss/overrides.scss
+++ b/skins/laika/src/scss/overrides.scss
@@ -35,14 +35,17 @@ $spacing-interval: 18;
 // Ensure footer always sticks to the bottom of the page
 // by setting min-height of the root elements to 100vh
 // and ensuring the main element is set to flex: 1
+// When in doubt, it's probably a workaround to make something work in IE11 :D
 body {
+	display: flex;
 	min-height: 100vh;
 	> div {
 		display: flex;
 		min-height: 100vh;
 		flex-direction: column;
+		flex: 1;
 	}
 }
 main {
-	flex: 1;
+	flex: 1 0 auto;
 }


### PR DESCRIPTION
Had to sprinkle some more flex-related rules into the mix until IE11 respected the min-height.