### PR TITLE
Move endpoint URLs to template context

### DIFF
--- a/app/Controllers/IbanController.php
+++ b/app/Controllers/IbanController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App\Controllers;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
+use WMDE\Fundraising\PaymentContext\UseCases\GenerateIban\GenerateIbanRequest;
+
+/**
+ * @license GNU GPL v2+
+ */
+class IbanController {
+
+	public function validateIban( Request $request, FunFunFactory $ffFactory ): Response {
+		$useCase = $ffFactory->newCheckIbanUseCase();
+		$checkIbanResponse = $useCase->checkIban( new Iban( $request->query->get( 'iban', '' ) ) );
+		return new JsonResponse( $ffFactory->newIbanPresenter()->present( $checkIbanResponse ) );
+	}
+
+	public function convertBankDataToIban( Request $request, FunFunFactory $ffFactory ): Response {
+		$generateIbanRequest = new GenerateIbanRequest(
+			$request->query->get( 'accountNumber', '' ),
+			$request->query->get( 'bankCode', '' )
+		);
+
+		$generateIbanResponse = $ffFactory->newGenerateIbanUseCase()->generateIban( $generateIbanRequest );
+		return new JsonResponse( $ffFactory->newIbanPresenter()->present( $generateIbanResponse ) );
+
+	}
+}

--- a/app/Controllers/ShowDonationConfirmationController.php
+++ b/app/Controllers/ShowDonationConfirmationController.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WMDE\Fundraising\Frontend\App\AccessDeniedException;
 use WMDE\Fundraising\DonationContext\UseCases\GetDonation\GetDonationRequest;
+use WMDE\Fundraising\Frontend\App\Routes;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\PiwikVariableCollector;
 
@@ -37,7 +38,8 @@ class ShowDonationConfirmationController {
 				$responseModel->getDonation(),
 				$responseModel->getUpdateToken(),
 				$request->get( 'accessToken', '' ),
-				PiwikVariableCollector::newForDonation( $application['session']->get( 'piwikTracking', [] ), $responseModel->getDonation() )
+				PiwikVariableCollector::newForDonation( $application['session']->get( 'piwikTracking', [] ), $responseModel->getDonation() ),
+				Routes::getNamedRouteUrls( $ffFactory->getUrlGenerator() )
 			)
 		);
 

--- a/app/Controllers/ShowUpdateAddressController.php
+++ b/app/Controllers/ShowUpdateAddressController.php
@@ -6,6 +6,7 @@ namespace WMDE\Fundraising\Frontend\App\Controllers;
 
 use Symfony\Component\HttpFoundation\Response;
 use WMDE\Fundraising\Frontend\App\AccessDeniedException;
+use WMDE\Fundraising\Frontend\App\Routes;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 
 /**
@@ -26,7 +27,8 @@ class ShowUpdateAddressController {
 				[
 					'addressToken' => $addressToken,
 					'isCompany' => $addressChange->isCompanyAddress(),
-					'messages' => $ffFactory->getMessages()
+					'messages' => $ffFactory->getMessages(),
+					'urls' => Routes::getNamedRouteUrls( $ffFactory->getUrlGenerator() )
 				]
 			)
 		);

--- a/app/Controllers/ValidateDonationAmountController.php
+++ b/app/Controllers/ValidateDonationAmountController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App\Controllers;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use WMDE\Euro\Euro;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+
+/**
+ * @license GNU GPL v2+
+ */
+class ValidateDonationAmountController {
+
+	public function validate( Request $request, FunFunFactory $ffFactory ): Response {
+		$rawAmount = $request->request->get( 'amount', '' );
+
+		if( !ctype_digit( $rawAmount ) ) {
+			return new JsonResponse( [ 'status' => 'ERR', 'messages' => ['amount' => 'Amount must be in cents.'] ] );
+		}
+		$violations = $ffFactory->newPaymentDataValidator()->validateAmount( Euro::newFromCents( (int)$rawAmount ) );
+
+		if ( $violations != null ) {
+			return new JsonResponse( [ 'status' => 'ERR', 'messages' => ['amount' => $violations->getMessageIdentifier()] ] );
+		}
+
+		return new JsonResponse( [ 'status' => 'OK' ] );
+	}
+}

--- a/app/Controllers/ValidationController.php
+++ b/app/Controllers/ValidationController.php
@@ -21,6 +21,11 @@ class ValidationController {
 		] );
 	}
 
+	// phpcs:disable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessDocComment
+	/**
+	 * @deprecated This is not used by client side code
+	 */
+	// phpcs:enable SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessDocComment
 	public function validateDonationPayment( Request $request, FunFunFactory $ffFactory ): Response {
 		$amount = (float) $ffFactory->newDecimalNumberFormatter()->parse( $request->get( 'amount', '0' ) );
 		$validator = $ffFactory->newPaymentDataValidator();

--- a/app/UrlGeneratorAdapter.php
+++ b/app/UrlGeneratorAdapter.php
@@ -14,17 +14,17 @@ class UrlGeneratorAdapter implements UrlGenerator {
 		$this->urlGenerator = $urlGenerator;
 	}
 
-	public function generateAbsoluteUrl( string $name, array $parameters = [] ): string {
+	public function generateAbsoluteUrl( string $routeName, array $parameters = [] ): string {
 		return $this->urlGenerator->generate(
-			$name,
+			$routeName,
 			$parameters,
 			UrlGeneratorInterface::ABSOLUTE_URL
 		);
 	}
 
-	public function generateRelativeUrl( string $name, array $parameters = [] ): string {
+	public function generateRelativeUrl( string $routeName, array $parameters = [] ): string {
 		return $this->urlGenerator->generate(
-			$name,
+			$routeName,
 			$parameters,
 			UrlGeneratorInterface::ABSOLUTE_PATH
 		);

--- a/skins/10h16/templates/Donation_Confirmation.html.twig
+++ b/skins/10h16/templates/Donation_Confirmation.html.twig
@@ -206,7 +206,7 @@
 					Sie k&ouml;nnen Ihre Spende stornieren, bevor sie bei uns eingebucht wird. Dazu senden Sie eine Mail an uns.
 				</p>
 				<p>
-					<form action="{$ basepath $}/donation/cancel" method="post">
+					<form action="{$ urls.cancelDonation | e('html_attr') $}" method="post">
 						<input type="submit" name="go_storno" value="Jetzt stornieren." style="cursor: pointer; background: none; border-width: 0px; color: #9D9D9D; text-decoration: underline;" />
                                                 <input type="hidden" value="{$ donation.id $}" name="sid" />
                                                 <input type="hidden" name="utoken" value="{$ donation.updateToken $}">

--- a/skins/10h16/templates/Donation_Form.html.twig
+++ b/skins/10h16/templates/Donation_Form.html.twig
@@ -6,11 +6,11 @@
             data-initial-form-values="{% if initialFormValues %}{$ initialFormValues|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
             data-violated-fields="{% if violatedFields %}{$ violatedFields|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
             data-initial-validation-result="{% if validationResult %}{$ validationResult|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
-            data-validate-amount-url="{$ basepath|e('html_attr') $}/validate-payment-data"
-            data-validate-address-url="{$ basepath|e('html_attr') $}/validate-address"
-            data-validate-email-address-url="{$ basepath|e('html_attr') $}/validate-email"
-            data-validate-iban-url="{$ basepath|e('html_attr') $}/check-iban"
-            data-generate-iban-url="{$ basepath|e('html_attr') $}/generate-iban"
+            data-validate-amount-url="{$ urls.validateDonationAmount | e( 'html_attr' ) $}"
+            data-validate-address-url="{$ urls.validateAddress | e('html_attr') $}"
+            data-validate-email-address-url="{$ urls.validateEmail | e('html_attr') $}"
+            data-validate-iban-url="{$ urls.validateIban | e('html_attr') $}"
+            data-generate-iban-url="{$ urls.convertBankData | e('html_attr') $}"
     >
     </script>
 

--- a/skins/10h16/templates/Membership_Application.html.twig
+++ b/skins/10h16/templates/Membership_Application.html.twig
@@ -20,10 +20,10 @@
 	<script id="init-form" src="{$ basepath|e('html_attr') $}{$ '/skins/10h16/_js/membershipForm.js'|prefix_file $}"
 		data-initial-form-values="{% if initialFormValues %}{$ initialFormValues|merge({'paymentType': initialPaymentType})|json_encode|e('html_attr') $}{% else %}{$ {'paymentType': initialPaymentType}|json_encode|e('html_attr') $}{% endif %}"
 		data-violated-fields="{% if violatedFields %}{$ violatedFields|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
-		data-validate-fee-url="{$ basepath|e('html_attr') $}/validate-fee"
-		data-validate-address-url="{$ basepath|e('html_attr') $}/validate-address"
-		data-validate-email-address-url="{$ basepath|e('html_attr') $}/validate-email"
-		data-validate-iban-url="{$ basepath $}/check-iban"
-		data-generate-iban-url="{$ basepath $}/generate-iban"></script>
+		data-validate-address-url="{$ urls.validateAddress | e('html_attr') $}"
+		data-validate-email-address-url="{$ urls.validateEmail | e('html_attr') $}"
+		data-validate-iban-url="{$ urls.validateIban | e('html_attr') $}"
+		data-generate-iban-url="{$ urls.convertBankData | e('html_attr') $}"
+		data-validate-fee-url="{$ urls.validateMembershipFee | e('html_attr') $}"></script>
 
 {% endblock %}

--- a/skins/cat17/templates/Donation_Confirmation.html.twig
+++ b/skins/cat17/templates/Donation_Confirmation.html.twig
@@ -37,7 +37,7 @@
 			data-initial-form-values="{% if initialFormValues %}{$ initialFormValues|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
 			data-violated-fields="{% if violatedFields %}{$ violatedFields|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
 			data-initial-validation-result="{% if validationResult %}{$ validationResult|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
-			data-validate-address-url="{$ basepath|e('html_attr') $}/validate-address"
-			data-validate-email-address-url="{$ basepath|e('html_attr') $}/validate-email"
+			data-validate-address-url="{$ urls.validateAddress | e('html_attr') $}"
+			data-validate-email-address-url="{$ urls.validateEmail | e('html_attr') $}"
 	></script>
 {% endblock %}

--- a/skins/cat17/templates/Donation_Form.html.twig
+++ b/skins/cat17/templates/Donation_Form.html.twig
@@ -289,11 +289,11 @@
 			data-initial-form-values="{% if initialFormValues %}{$ initialFormValues|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
 			data-violated-fields="{% if violatedFields %}{$ violatedFields|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
 			data-initial-validation-result="{% if validationResult %}{$ validationResult|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
-			data-validate-amount-url="{$ basepath | e( 'html_attr' ) $}/validate-donation-amount"
-			data-validate-address-url="{$ basepath|e('html_attr') $}/validate-address"
-			data-validate-email-address-url="{$ basepath|e('html_attr') $}/validate-email"
-			data-validate-iban-url="{$ basepath|e('html_attr') $}/check-iban"
-			data-generate-iban-url="{$ basepath|e('html_attr') $}/generate-iban"
+			data-validate-amount-url="{$ urls.validateDonationAmount | e( 'html_attr' ) $}"
+			data-validate-address-url="{$ urls.validateAddress | e('html_attr') $}"
+			data-validate-email-address-url="{$ urls.validateEmail | e('html_attr') $}"
+			data-validate-iban-url="{$ urls.validateIban | e('html_attr') $}"
+			data-generate-iban-url="{$ urls.convertBankData | e('html_attr') $}"
 			data-messages="{$ messages $}"
 	></script>
 {% endblock %}

--- a/skins/cat17/templates/Membership_Application.html.twig
+++ b/skins/cat17/templates/Membership_Application.html.twig
@@ -366,10 +366,10 @@
 		data-initial-form-values="{$ initialFormValues | json_encode | e( 'html_attr' ) $}"
 		data-violated-fields="{% if violatedFields %}{$ violatedFields|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
 		data-initial-validation-result="{% if initialValidationResult %}{$ initialValidationResult|json_encode|e('html_attr') $}{% else %}{}{% endif %}"
-		data-validate-fee-url="{$ basepath|e('html_attr') $}/validate-fee"
-		data-validate-address-url="{$ basepath|e('html_attr') $}/validate-address"
-		data-validate-email-address-url="{$ basepath|e('html_attr') $}/validate-email"
-		data-validate-iban-url="{$ basepath $}/check-iban"
-		data-generate-iban-url="{$ basepath $}/generate-iban"
+		data-validate-address-url="{$ urls.validateAddress | e('html_attr') $}"
+		data-validate-email-address-url="{$ urls.validateEmail | e('html_attr') $}"
+		data-validate-iban-url="{$ urls.validateIban | e('html_attr') $}"
+		data-generate-iban-url="{$ urls.convertBankData | e('html_attr') $}"
+		data-validate-fee-url="{$ urls.validateMembershipFee | e('html_attr') $}"
 		data-messages="{$ messages $}"></script>
 {% endblock %}

--- a/skins/cat17/templates/Update_Address.html.twig
+++ b/skins/cat17/templates/Update_Address.html.twig
@@ -10,8 +10,8 @@
 {% block scripts %}
 	<script src="{$ basepath $}{$ '/skins/cat17/scripts/address-change/js/app.js' | prefix_file $}"
             id="address-form"
-            data-validate-address-url="{$ basepath|e('html_attr') $}/validate-address"
-            data-update-address-url="{$ basepath|e('html_attr') $}/update-address/"
+            data-validate-address-url="{$ urls.validateAddress | e('html_attr') $}"
+            data-update-address-url="{$ urls.updateAddress | e('html_attr') $}"
     ></script>
 	<script src="{$ basepath $}{$ '/skins/cat17/scripts/address-change/js/chunk-vendors.js' | prefix_file $}"></script>
 {% endblock %}

--- a/skins/cat17/templates/partials/donation_confirmation/direct_debit.html.twig
+++ b/skins/cat17/templates/partials/donation_confirmation/direct_debit.html.twig
@@ -74,13 +74,13 @@
 					'label': 'donation_confirmation_print_confirmation_debit' | trans
 				} only %}
                 <li class="cancel">
-                    <form action="{$ basepath $}/donation/cancel" method="post">
+                    <form action="{$ urls.cancelDonation | e('html_attr') $}" method="post">
                         <button type="submit" name="go_storno" class="btn-link">{$ 'cancel_donation' | trans $}</button>
                         <input type="hidden" name="sid" value="{$ donation.id $}" />
                         <input type="hidden" name="utoken" value="{$ donation.updateToken $}">
                     </form>
                 </li>
-                <li><a href="{$ commentUrl $}"><span>{$ "add_donation_comment" | trans $}</span></a></li>
+                <li><a href="{$ urls.addComment | e('html_attr') $}"><span>{$ "add_donation_comment" | trans $}</span></a></li>
 				{% include 'partials/share_on_social_networks.html.twig' %}
             </ul>
         </div>

--- a/skins/cat17/templates/partials/donation_confirmation/external_payment.html.twig
+++ b/skins/cat17/templates/partials/donation_confirmation/external_payment.html.twig
@@ -23,7 +23,7 @@
 				{% include 'partials/donation_confirmation/link_print.html.twig' with {
 					'label': 'donation_confirmation_print_confirmation' | trans
 				} only %}
-                <li><a href="{$ commentUrl $}"><span>{$ "add_donation_comment" | trans $}</span></a></li>
+                <li><a href="{$ urls.addComment | e('html_attr') $}"><span>{$ "add_donation_comment" | trans $}</span></a></li>
 				{% include 'partials/share_on_social_networks.html.twig' %}
             </ul>
         </div>

--- a/src/Infrastructure/UrlGenerator.php
+++ b/src/Infrastructure/UrlGenerator.php
@@ -5,13 +5,14 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Infrastructure;
 
 /**
+ * Convert route names to URLs
+ *
  * @licence GNU GPL v2+
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 interface UrlGenerator {
 
-	public function generateAbsoluteUrl( string $name, array $parameters = [] ): string;
+	public function generateAbsoluteUrl( string $routeName, array $parameters = [] ): string;
 
-	public function generateRelativeUrl( string $name, array $parameters = [] ): string;
+	public function generateRelativeUrl( string $routeName, array $parameters = [] ): string;
 
 }

--- a/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
+++ b/src/Presentation/Presenters/DonationConfirmationHtmlPresenter.php
@@ -30,14 +30,15 @@ class DonationConfirmationHtmlPresenter {
 		$this->donorDataFormatter = new DonorDataFormatter();
 	}
 
-	public function present( Donation $donation, string $updateToken, string $accessToken, PiwikEvents $piwikEvents ): string {
+	public function present( Donation $donation, string $updateToken, string $accessToken, PiwikEvents $piwikEvents,
+							 array $urlEndpoints ): string {
 		return $this->template->render(
-			$this->getConfirmationPageArguments( $donation, $updateToken, $accessToken, $piwikEvents )
+			$this->getConfirmationPageArguments( $donation, $updateToken, $accessToken, $piwikEvents, $urlEndpoints )
 		);
 	}
 
 	private function getConfirmationPageArguments( Donation $donation, string $updateToken, string $accessToken,
-		PiwikEvents $piwikEvents ): array {
+		PiwikEvents $piwikEvents, array $urlEndpoints ): array {
 
 		return [
 			'donation' => [
@@ -61,12 +62,17 @@ class DonationConfirmationHtmlPresenter {
 				$donation
 			),
 			'piwikEvents' => $piwikEvents->getEvents(),
-			'commentUrl' => $this->urlGenerator->generateRelativeUrl(
-				'AddCommentPage',
+			'urls' => array_merge(
+				$urlEndpoints,
 				[
-					'donationId' => $donation->getId(),
-					'updateToken' => $updateToken,
-					'accessToken' => $accessToken
+					'addComment'  => $this->urlGenerator->generateRelativeUrl(
+						'AddCommentPage',
+						[
+							'donationId' => $donation->getId(),
+							'updateToken' => $updateToken,
+							'accessToken' => $accessToken
+						]
+					)
 				]
 			)
 		];

--- a/src/Presentation/Presenters/DonationFormPresenter.php
+++ b/src/Presentation/Presenters/DonationFormPresenter.php
@@ -19,6 +19,7 @@ class DonationFormPresenter {
 	private $template;
 	private $amountFormatter;
 	private $isCustomDonationAmountValidator;
+	private $urlGenerator;
 
 	public function __construct(
 		TwigTemplate $template,
@@ -31,7 +32,7 @@ class DonationFormPresenter {
 	}
 
 	public function present( Euro $amount, string $paymentType, int $paymentInterval, bool $paymentDataIsValid,
-							 DonationTrackingInfo $trackingInfo, string $addressType ): string {
+							 DonationTrackingInfo $trackingInfo, string $addressType, array $urlEndpoints ): string {
 		return $this->template->render( [
 			'initialFormValues' => [
 				'amount' => $this->amountFormatter->format( $amount ),
@@ -46,8 +47,10 @@ class DonationFormPresenter {
 			'tracking' => [
 				'bannerImpressionCount' => $trackingInfo->getSingleBannerImpressionCount(),
 				'impressionCount' => $trackingInfo->getTotalImpressionCount()
-			]
+			],
+			'urls' => $urlEndpoints
 		] );
 	}
 
 }
+

--- a/tests/Fixtures/FakeUrlGenerator.php
+++ b/tests/Fixtures/FakeUrlGenerator.php
@@ -12,12 +12,12 @@ use WMDE\Fundraising\Frontend\Infrastructure\UrlGenerator;
  */
 class FakeUrlGenerator implements UrlGenerator {
 
-	public function generateRelativeUrl( string $name, array $parameters = [] ): string {
-		return '/such.a.url/' . $name . '?' . http_build_query( $parameters );
+	public function generateRelativeUrl( string $routeName, array $parameters = [] ): string {
+		return '/such.a.url/' . $routeName . '?' . http_build_query( $parameters );
 	}
 
-	public function generateAbsoluteUrl( string $name, array $parameters = [] ): string {
-		return 'https://such.a.url/' . $name . '?' . http_build_query( $parameters );
+	public function generateAbsoluteUrl( string $routeName, array $parameters = [] ): string {
+		return 'https://such.a.url/' . $routeName . '?' . http_build_query( $parameters );
 	}
 
 }

--- a/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
+++ b/tests/Integration/Presentation/Presenters/DonationConfirmationHtmlPresenterTest.php
@@ -4,9 +4,9 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Tests\Integration\Presentation\Presenters;
 
+use PHPUnit\Framework\TestCase;
 use WMDE\Fundraising\Frontend\Infrastructure\PiwikEvents;
 use WMDE\Fundraising\Frontend\Presentation\Presenters\DonationConfirmationHtmlPresenter;
-use WMDE\Fundraising\Frontend\Presentation\SelectedConfirmationPage;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 use WMDE\Fundraising\DonationContext\Tests\Data\ValidDonation;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\FakeUrlGenerator;
@@ -17,7 +17,7 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\FakeUrlGenerator;
  * @licence GNU GPL v2+
  * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
-class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase {
+class DonationConfirmationHtmlPresenterTest extends TestCase {
 
 	private const STATUS_BOOKED = 'status-booked';
 	private const STATUS_UNCONFIRMED = 'status-unconfirmed';
@@ -42,7 +42,8 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 			$donation,
 			self::UPDATE_TOKEN,
 			self::ACCESS_TOKEN,
-			$this->newPiwikEvents()
+			$this->newPiwikEvents(),
+			$this->newUrls()
 		);
 	}
 
@@ -70,7 +71,11 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 				[ 'setCustomVariable', 1, 'Payment', 'some value', PiwikEvents::SCOPE_VISIT ],
 				[ 'trackGoal', 4095 ]
 			],
-			'commentUrl' => '/such.a.url/AddCommentPage?donationId=42&updateToken=update_token&accessToken=access_token'
+			'urls' => [
+				'testUrl' => 'https://example.com/',
+				'addComment' => '/such.a.url/AddCommentPage?donationId=42&updateToken=update_token&accessToken=access_token'
+			]
+
 		];
 	}
 
@@ -105,8 +110,15 @@ class DonationConfirmationHtmlPresenterTest extends \PHPUnit\Framework\TestCase 
 			$donation,
 			self::UPDATE_TOKEN,
 			self::ACCESS_TOKEN,
-			$this->newPiwikEvents()
+			$this->newPiwikEvents(),
+			$this->newUrls()
 		);
+	}
+
+	private function newUrls(): array {
+		return [
+			'testUrl' => 'https://example.com/'
+		];
 	}
 
 }

--- a/tests/Integration/Presentation/TwigEnvironmentConfiguratorTest.php
+++ b/tests/Integration/Presentation/TwigEnvironmentConfiguratorTest.php
@@ -60,7 +60,8 @@ class TwigEnvironmentConfiguratorTest extends TestCase {
 		$environmentConfigurator = new TwigEnvironmentConfigurator(
 			[
 				'enable-cache' => false,
-				'web-basepath' => ''
+				'web-basepath' => '',
+				'assets-path' => ''
 			],
 			'/tmp/fun'
 		);


### PR DESCRIPTION
Move endpoint URLs from template markup to template context. This will enable the laika skin JavaScript to use those endpoints URL without adding data attributes to each template.

Also contains some cleanup in the routes.