### PR TITLE
Improve credit card handling controller

### DIFF
--- a/app/Controllers/CreditCardPaymentNotificationController.php
+++ b/app/Controllers/CreditCardPaymentNotificationController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\App\Controllers;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use WMDE\Euro\Euro;
+use WMDE\Fundraising\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardPaymentNotificationRequest;
+use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+
+/**
+ * @license GNU GPL v2+
+ */
+class CreditCardPaymentNotificationController {
+
+	public function handleNotification( FunFunFactory $ffFactory, Request $request ): Response {
+		$donationId = $request->query->get( 'donation_id', '' );
+
+		$response = $ffFactory->newCreditCardNotificationUseCase( $request->query->get( 'utoken', '' ) )
+			->handleNotification(
+				( new CreditCardPaymentNotificationRequest() )
+					->setTransactionId( $request->query->get( 'transactionId', '' ) )
+					->setDonationId( (int)$donationId )
+					->setAmount( Euro::newFromCents( (int)$request->query->get( 'amount' ) ) )
+					->setCustomerId( $request->query->get( 'customerId', '' ) )
+					->setSessionId( $request->query->get( 'sessionId', '' ) )
+					->setAuthId( $request->query->get( 'auth', '' ) )
+					->setTitle( $request->query->get( 'title', '' ) )
+					->setCountry( $request->query->get( 'country', '' ) )
+					->setCurrency( $request->query->get( 'currency', '' ) )
+			);
+
+		$loggingContext = $response->getLowLevelError() === null ? [] : [ 'exception' => $response->getLowLevelError() ];
+		if ( !$response->isSuccessful() ) {
+			$ffFactory->getLogger()->error( 'Credit Card Notification Error: ' . $response->getErrorMessage(), $loggingContext );
+		} elseif ( $loggingContext !== [] ) {
+			$ffFactory->getLogger()->warning( 'Failed to send conformation email for credit card notification', $loggingContext );
+		}
+
+		return new Response( $ffFactory->newCreditCardNotificationPresenter()->present(
+			$response,
+			$donationId,
+			$request->query->get( 'token', '' )
+		) );
+	}
+
+}

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -19,6 +19,7 @@ use WMDE\Fundraising\DonationContext\UseCases\ListComments\CommentListingRequest
 use WMDE\Fundraising\Frontend\App\Controllers\AddDonationController;
 use WMDE\Fundraising\Frontend\App\Controllers\ApplyForMembershipController;
 use WMDE\Fundraising\Frontend\App\Controllers\IbanController;
+use WMDE\Fundraising\Frontend\App\Controllers\CreditCardPaymentNotificationController;
 use WMDE\Fundraising\Frontend\App\Controllers\ShowDonationConfirmationController;
 use WMDE\Fundraising\Frontend\App\Controllers\ShowUpdateAddressController;
 use WMDE\Fundraising\Frontend\App\Controllers\UpdateAddressController;
@@ -490,33 +491,7 @@ class Routes {
 
 		$app->get(
 			'handle-creditcard-payment-notification',
-			function ( Request $request ) use ( $ffFactory ) {
-				try {
-					$ffFactory->newCreditCardNotificationUseCase( $request->query->get( 'utoken', '' ) )
-						->handleNotification(
-							( new CreditCardPaymentNotificationRequest() )
-								->setTransactionId( $request->query->get( 'transactionId', '' ) )
-								->setDonationId( (int)$request->query->get( 'donation_id', '' ) )
-								->setAmount( Euro::newFromCents( (int)$request->query->get( 'amount' ) ) )
-								->setCustomerId( $request->query->get( 'customerId', '' ) )
-								->setSessionId( $request->query->get( 'sessionId', '' ) )
-								->setAuthId( $request->query->get( 'auth', '' ) )
-								->setTitle( $request->query->get( 'title', '' ) )
-								->setCountry( $request->query->get( 'country', '' ) )
-								->setCurrency( $request->query->get( 'currency', '' ) )
-						);
-
-					$response = CreditCardNotificationResponse::newSuccessResponse(
-						(int)$request->query->get( 'donation_id', '' ),
-						$request->query->get( 'token', '' )
-					);
-				}
-				catch ( CreditCardPaymentHandlerException $e ) {
-					$response = CreditCardNotificationResponse::newFailureResponse( $e->getMessage() );
-				}
-
-				return new Response( $ffFactory->newCreditCardNotificationPresenter()->present( $response ) );
-			}
+			CreditCardPaymentNotificationController::class . '::handleNotification'
 		);
 
 		$app->get(

--- a/composer.lock
+++ b/composer.lock
@@ -3151,7 +3151,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -5262,7 +5262,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "? Nette Finder: find files and directories with an intuitive API.",
+            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
             "homepage": "https://nette.org",
             "keywords": [
                 "filesystem",
@@ -5322,7 +5322,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "? Nette NEON: encodes and decodes NEON file format.",
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1470,7 +1470,6 @@ class FunFunFactory implements ServiceProviderInterface {
 			$this->newDonationAuthorizer( $updateToken ),
 			$this->getCreditCardService(),
 			$this->newDonationConfirmationMailer(),
-			$this->getLogger(),
 			$this->newDonationEventLogger()
 		);
 	}

--- a/src/Presentation/Presenters/CreditCardNotificationPresenter.php
+++ b/src/Presentation/Presenters/CreditCardNotificationPresenter.php
@@ -21,7 +21,7 @@ class CreditCardNotificationPresenter {
 		$this->returnUrl = $returnUrl;
 	}
 
-	public function present( CreditCardNotificationResponse $response ): string {
+	public function present( CreditCardNotificationResponse $response, string $donationId, string $accessToken ): string {
 		if ( !$response->isSuccessful() ) {
 			return $this->render( [
 				'status' => 'error',
@@ -32,8 +32,8 @@ class CreditCardNotificationPresenter {
 		return $this->render( [
 			'status' => 'ok',
 			'url' => $this->returnUrl . '?' . http_build_query( [
-					'id' => $response->getDonationId(),
-					'accessToken' => $response->getAccessToken()
+					'id' => $donationId,
+					'accessToken' => $accessToken
 				] ),
 			'target' => '_top',
 			'forward' => '1',


### PR DESCRIPTION
Move Credit Card notification handling in a controller class

Adapt to new "return model" of the CreditCardNotificationUseCase: Check
Response instead of catching "Response Exceptions".

This also corrects an architecture violation where a use case Response
object was initialized in the controller.

Log errors that occurred while handling the request. Unsuccessful
sending of an email only counts as warning.

This is a cherry-pick of 5e9254bc688734a149a2ac3baf15b07dde7ab831, to avoid larger merge/rebase conflicts. 
