### PR TITLE
Fix Address Update URL generation

### DIFF
--- a/app/Controllers/ShowUpdateAddressController.php
+++ b/app/Controllers/ShowUpdateAddressController.php
@@ -28,7 +28,12 @@ class ShowUpdateAddressController {
 					'addressToken' => $addressToken,
 					'isCompany' => $addressChange->isCompanyAddress(),
 					'messages' => $ffFactory->getMessages(),
-					'urls' => Routes::getNamedRouteUrls( $ffFactory->getUrlGenerator() )
+					'urls' => array_merge(
+						Routes::getNamedRouteUrls( $ffFactory->getUrlGenerator() ),
+						[
+							'updateAddress' => $ffFactory->getUrlGenerator()->generateAbsoluteUrl( Routes::UPDATE_ADDRESS, [ 'addressToken' => $addressToken ] )
+						]
+					)
 				]
 			)
 		);

--- a/app/Routes.php
+++ b/app/Routes.php
@@ -634,12 +634,11 @@ class Routes {
 			'validateDonationAmount' => $urlGenerator->generateAbsoluteUrl( self::VALIDATE_DONATION_AMOUNT ),
 			'validateAddress' => $urlGenerator->generateAbsoluteUrl( self::VALIDATE_ADDRESS ),
 			'validateEmail' => $urlGenerator->generateAbsoluteUrl( self::VALIDATE_EMAIL ),
-			'markEmptyValuesAsInvalid' => $urlGenerator->generateAbsoluteUrl( self::VALIDATE_DONATION_PAYMENT ),
+			'validatePayment' => $urlGenerator->generateAbsoluteUrl( self::VALIDATE_DONATION_PAYMENT ),
 			'validateIban' => $urlGenerator->generateAbsoluteUrl( self::VALIDATE_IBAN ),
 			'validateMembershipFee' => $urlGenerator->generateAbsoluteUrl( self::VALIDATE_MEMBERSHIP_FEE ),
 			'convertBankData' => $urlGenerator->generateAbsoluteUrl( self::CONVERT_BANKDATA ),
 			'cancelDonation' => $urlGenerator->generateAbsoluteUrl( self::CANCEL_DONATION ),
-			// TODO FIXME 'updateAddress' => $urlGenerator->generateAbsoluteUrl( self::UPDATE_ADDRESS )
 		];
 	}
 }


### PR DESCRIPTION
The address update URL can't be generated independently from the current
route in Routes.php, as it needs the parameter addressToken, which is
only available when the address-update route is active.

Undo the rename of a deprecated route.

This is a followup to #1488