### PR TITLE
Change the mutation data type for amount validity

### DIFF
--- a/skins/laika/src/store/ValidationResponse.ts
+++ b/skins/laika/src/store/ValidationResponse.ts
@@ -1,0 +1,12 @@
+// These types encapusaltes the types of JSOn responses that come from the server when calling a validation route
+
+export interface SuccessResponse {
+    status: 'OK';
+}
+
+export interface ErrorResponse {
+    status: 'ERR';
+    messages: Array<string>;
+}
+
+export type ValidationResponse = SuccessResponse | ErrorResponse;

--- a/skins/laika/src/store/payment/actions.ts
+++ b/skins/laika/src/store/payment/actions.ts
@@ -13,6 +13,8 @@ import {
 	SET_AMOUNT_VALIDITY, SET_TYPE_VALIDITY,
 	SET_AMOUNT, SET_INTERVAL, SET_TYPE,
 } from '@/store/payment/mutationTypes';
+import { ValidationResponse } from '@/store/ValidationResponse';
+import { Validity } from "@/view_models/Validity";
 
 export const actions = {
 	[ checkIfEmptyAmount ]( context: ActionContext<Payment, any>, amountData: AmountData ): void {
@@ -32,8 +34,10 @@ export const actions = {
 			method: 'post',
 			data: bodyFormData,
 			headers: { 'Content-Type': 'multipart/form-data' },
-		} ).then( ( validationResult: AxiosResponse ) => {
-			context.commit( SET_AMOUNT_VALIDITY, validationResult );
+		} ).then( ( validationResult: AxiosResponse<ValidationResponse> ) => {
+			const validity = validationResult.data.status === 'ERR' ?
+				Validity.INVALID : Validity.VALID;
+			context.commit( SET_AMOUNT_VALIDITY, validity );
 		} );
 	},
 	[ setInterval ]( context: ActionContext<Payment, any>, payload: IntervalData ): void {

--- a/skins/laika/src/store/payment/mutations.ts
+++ b/skins/laika/src/store/payment/mutations.ts
@@ -10,7 +10,6 @@ import {
 	SET_INTERVAL,
 	SET_TYPE,
 } from '@/store/payment/mutationTypes';
-import { AxiosResponse } from 'axios';
 
 export const mutations: MutationTree<Payment> = {
 	[ MARK_EMPTY_AMOUNT_INVALID ]( state: Payment, fields: AmountData ) {
@@ -24,9 +23,8 @@ export const mutations: MutationTree<Payment> = {
 			}
 		}
 	},
-	[ SET_AMOUNT_VALIDITY ]( state: Payment, validationResult: AxiosResponse ) {
-		state.validity.amount = validationResult.data.status === 'ERR' ?
-			Validity.INVALID : Validity.VALID;
+	[ SET_AMOUNT_VALIDITY ]( state: Payment, validity: Validity ) {
+		state.validity.amount = validity
 	},
 	[ SET_TYPE_VALIDITY ]( state: Payment ) {
 		state.validity.type = state.values.type === '' ?

--- a/skins/laika/tests/unit/store/payment_store.spec.ts
+++ b/skins/laika/tests/unit/store/payment_store.spec.ts
@@ -6,7 +6,7 @@ import { Validity } from '@/view_models/Validity';
 import { checkIfEmptyAmount, markEmptyValuesAsInvalid } from '@/store/payment/actionTypes';
 import each from 'jest-each';
 import moxios from 'moxios';
-import { SET_AMOUNT } from '@/store/payment/mutationTypes';
+import {SET_AMOUNT, SET_AMOUNT_VALIDITY} from '@/store/payment/mutationTypes';
 
 function newMinimalStore( overrides: Object ): Payment {
 	return Object.assign(
@@ -164,18 +164,13 @@ describe( 'Payment', () => {
 				expect( store.validity.amount ).toStrictEqual( isValid );
 			} );
 
-		const serverResponseStates = [
-			[ { data: { status: 'OK' } }, Validity.VALID ],
-			[ { data: { status: 'ERR' } }, Validity.INVALID ],
-		];
-
-		each( serverResponseStates ).it(
-			'mutates the state with the correct validity for a given server response (test index %#)',
-			( inputData, isValid ) => {
-				const store = newMinimalStore( {} );
-				mutations.SET_AMOUNT_VALIDITY( store, inputData );
-				expect( store.validity.amount ).toStrictEqual( isValid );
-			} );
+		it('mutates the amount validity', () => {
+			const store = newMinimalStore( {} );
+			mutations.SET_AMOUNT_VALIDITY( store, Validity.VALID );
+			expect( store.validity.amount ).toStrictEqual( Validity.VALID );
+			mutations.SET_AMOUNT_VALIDITY( store, Validity.INVALID );
+			expect( store.validity.amount ).toStrictEqual( Validity.INVALID );
+		} );
 
 		it( 'mutates the amount', () => {
 			const store = newMinimalStore( {} );


### PR DESCRIPTION
Change the return type of the AxiosRequest to a specified interface.

This change increases type safety inside the action and isolates the
store mutation parameters from the used HTTP transport library.