### PR TITLE
Put all faq questions on one page and add styling

### DIFF
--- a/skins/laika/src/components/Question.vue
+++ b/skins/laika/src/components/Question.vue
@@ -1,31 +1,32 @@
 <template>
-    <div class="question space-above">
+    <div class="question">
         <div v-bind:class="[ isOpen ? 'border-secondary' : 'border-primary' ]">
             <div class="inline-icon" @click="toggle()"
                  :data-content-target="!isOpen ? '/page/Häufige Fragen' : ''"
                  :data-track-content="!isOpen"
                  :data-content-name="!isOpen ? 'Expand' : ''"
                  :data-content-piece="!isOpen ? content.question : ''">
-                <h5 v-bind:class="[ isOpen ? 'secondary-color' : 'title-primary-color' ]">
+                <h3 v-bind:class="[ isOpen ? 'has-text-primary has-text-weight-bold' : 'has-text-dark' ] "
+                        class = "has-padding-20" >
                     {{ content.question }}
-                </h5>
+                </h3>
                 <i v-bind:class="[ isOpen ? 'icon-keyboard_arrow_up secondary-color' : 'icon-keyboard_arrow_down primary-color' ]">
                 </i>
             </div>
-            <div v-show="isOpen" v-html="content.visibleText" class="space-below"></div>
+            <div v-show="isOpen" v-html="content.visibleText" class="has-padding-left-20" ></div>
         </div>
     </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { Question } from '@/view_models/faq';
+import { QuestionModel } from '@/view_models/faq';
 
 export default Vue.extend( {
 	name: 'question',
 	props: {
 		content: {
-			type: Object as () => Question,
+			type: Object as () => QuestionModel,
 		},
 		visibleQuestionId: String,
 		questionId: String,

--- a/skins/laika/src/components/Question.vue
+++ b/skins/laika/src/components/Question.vue
@@ -1,21 +1,23 @@
 <template>
-    <div class="question">
-        <div v-bind:class="[ isOpen ? 'border-secondary' : 'border-primary' ]">
-            <div class="inline-icon" @click="toggle()"
-                 :data-content-target="!isOpen ? '/page/Häufige Fragen' : ''"
-                 :data-track-content="!isOpen"
-                 :data-content-name="!isOpen ? 'Expand' : ''"
-                 :data-content-piece="!isOpen ? content.question : ''">
-                <h3 v-bind:class="[ isOpen ? 'has-text-primary has-text-weight-bold' : 'has-text-dark' ] "
-                        class = "has-padding-20" >
-                    {{ content.question }}
-                </h3>
-                <i v-bind:class="[ isOpen ? 'icon-keyboard_arrow_up secondary-color' : 'icon-keyboard_arrow_down primary-color' ]">
-                </i>
-            </div>
-            <div v-show="isOpen" v-html="content.visibleText" class="has-padding-left-20" ></div>
-        </div>
-    </div>
+	<div class="question">
+		<div v-bind:class="[ isOpen ? 'accordion' : '' ]" >
+
+			<div class="inline-icon" @click="toggle()"
+				:data-content-target="!isOpen ? '/page/Häufige Fragen' : ''"
+				:data-track-content="!isOpen"
+				:data-content-name="!isOpen ? 'Expand' : ''"
+				:data-content-piece="!isOpen ? content.question : ''">
+				<h3 v-bind:class="[ isOpen ? 'has-text-primary has-text-weight-bold ' : 'accordion-heading' ] ">
+					{{ content.question }}
+				</h3>
+				<i v-bind:class="[ isOpen ? 'icon-keyboard_arrow_up secondary-color' : 'icon-keyboard_arrow_down primary-color' ]">
+				</i>
+			</div>
+
+			<div v-show="isOpen" v-html="content.visibleText" class="accordion-content"></div>
+
+		</div>
+	</div>
 </template>
 
 <script lang="ts">

--- a/skins/laika/src/components/pages/Faq.vue
+++ b/skins/laika/src/components/pages/Faq.vue
@@ -1,11 +1,11 @@
 <template>
 	<div id="faq" class="column">
-		<h1 class="title">{{ $t('page_title') }}</h1>
+		<h1 class="title is-size-1">{{ $t('page_title') }}</h1>
 		<ul>
-			<li v-bind:class="[ 'link', 'underlined' ]"
-				v-for="( topic, index ) in content.topics"
+			<li v-for="( topic, index ) in content.topics"
 				:key="index">
-				<h2 class="title is-size-5">{{ topic.name }}</h2>
+
+				<h2 class="title is-size-2">{{ topic.name }}</h2>
 
 				<question
 						v-for="(content, index) in getQuestionsByTopic(topic)"

--- a/skins/laika/src/components/pages/Faq.vue
+++ b/skins/laika/src/components/pages/Faq.vue
@@ -1,58 +1,30 @@
 <template>
-    <div id="faq" class="container">
-        <h2>{{ $t('page_title') }}</h2>
-        <h5>{{ $t('page_subtitle') }}</h5>
-        <div class="row">
-            <div class="col-xs-12 col-sm-8">
-                <div class="form-shadow-wrap">
-                    <h2 class="title">{{ topicTitle }}</h2>
-                    <question v-for="(content, index) in page" v-bind:class="[ isOverview ? 'preview' : 'topic' ]"
-                              v-on:question-opened="setOpenQuestionId( $event )"
-                              :content="content"
-                              :key="index"
-                              :visible-question-id="openQuestionId"
-                              :question-id="index.toString()">
-                    </question>
-                </div>
-                <footer>
-                    <h5>{{ $t('no_answer_found') }}</h5>
-                    <p>
-                        {{ $t('contact_way') }} <a href="/contact/get-in-touch">{{ $t('contact_link') }}</a> {{ $t('reply_by_email') }}<br>
-                        {{ $t('you_can_too') }}<br>
-                        {{ $t('send_email')}} <a :href="'mailto:' + $t('email_address')">{{ $t('email_address') }}</a> {{ $t('or') }}<br>
-                        {{ $t('call_phone') }} {{ $t('phone') }}
-                    </p>
-                </footer>
-            </div>
-            <div class="sidebar">
-                <h5>{{ $t('about') }}</h5>
-                <ul>
-                    <li @click="populatePageByTopic( topic ); isOverview = false;"
-                        v-bind:class="[ 'link', 'underlined' ]"
-                        v-for="( topic, index ) in content.topics"
-                        :key="index">
-                        <a
-                                data-content-target="/page/Häufige Fragen"
-                                data-track-content
-                                data-content-name="Topic"
-                                :data-content-piece="topic.name">
-                            {{ topic.name }}
-                        </a>
-                    </li>
-                </ul>
-                <h5 class="second-menu">{{ $t('no_answer') }}</h5>
-                <ul class="second-menu">
-                    <li><a href="/contact/get-in-touch">{{ $t('contact_link') }}</a></li>
-                </ul>
-            </div>
-        </div>
-    </div>
+	<div id="faq" class="column">
+		<h1 class="title">{{ $t('page_title') }}</h1>
+		<ul>
+			<li v-bind:class="[ 'link', 'underlined' ]"
+				v-for="( topic, index ) in content.topics"
+				:key="index">
+				<h2 class="title is-size-5">{{ topic.name }}</h2>
+
+				<question
+						v-for="(content, index) in getQuestionsByTopic(topic)"
+						v-on:question-opened="setOpenQuestionId( $event )"
+						:content="content"
+						:key="topic.id+index"
+						:visible-question-id="openQuestionId"
+						:question-id="topic.id+index.toString()">
+				</question>
+
+			</li>
+		</ul>
+	</div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import Question from '@/components/Question.vue';
-import { FaqContent, Topic, FaqData } from '@/view_models/faq';
+import { FaqContent, Topic, FaqData, QuestionModel } from '@/view_models/faq';
 
 export default Vue.extend( {
 	name: 'faq',
@@ -66,31 +38,16 @@ export default Vue.extend( {
 	},
 	data: function (): FaqData {
 		return {
-			page: [],
-			isOverview: true,
-			topicTitle: '',
 			openQuestionId: '',
 		};
 	},
-	mounted: function () {
-		this.populatePageOnInitialLoad();
-	},
 	methods: {
-		populatePageByTopic: function ( topic: Topic ): void {
-			this.page = this.content.questions.filter( question => question.topic.split( ',' ).indexOf( topic.id ) !== -1 );
-			this.setTopicTitle( topic.name );
-			this.setOpenQuestionId( '' );
-		},
-		populatePageOnInitialLoad: function (): void {
-			this.setOpenQuestionId( '' );
-			this.page = this.content.questions.filter( question => question.topic.split( ',' ).indexOf( '1' ) !== -1 );
-			this.setTopicTitle( this.content.topics[ 0 ].name );
-		},
-		setTopicTitle: function ( name: string ): void {
-			this.topicTitle = name;
-		},
 		setOpenQuestionId: function ( id: string ): void {
 			this.openQuestionId = id;
+		},
+
+		getQuestionsByTopic: function ( topic: Topic ): QuestionModel[] {
+			return this.content.questions.filter( question => question.topic.split( ',' ).indexOf( topic.id ) !== -1 );
 		},
 	},
 } );

--- a/skins/laika/src/scss/custom.scss
+++ b/skins/laika/src/scss/custom.scss
@@ -53,6 +53,27 @@
 	}
 }
 
+//FAQ page accordions
+
+.accordion {
+	border: 1px solid $fun-color-gray-light-transparency;
+	padding: 1.4rem;
+	box-sizing: content-box;
+	h3 {
+		cursor: pointer;
+	}
+}
+
+.accordion-heading {
+	padding: 1.4rem;
+	border-bottom: 2px solid $fun-color-gray-light-transparency;
+	cursor: pointer;
+}
+
+.accordion-content {
+	padding-top: 2.8rem;
+	padding-right: 0.6rem;
+}
 // Import Bulma's core
 @import "~bulma/sass/utilities/_all";
 

--- a/skins/laika/src/scss/variables.scss
+++ b/skins/laika/src/scss/variables.scss
@@ -9,6 +9,13 @@ $fun-color-primary-lightest: #dce4e8;
 $fun-color-footer: #c7d1d8;
 $fun-color-error: #812923;
 $fun-color-error-light: #e6d4d3;
+$fun-color-gray-dark: #808080;
+$fun-color-gray-mid: #B7B7B7;
+$fun-color-gray-light-solid: #E5E5E5;
+$fun-color-gray-light-transparency: rgba(0, 0, 0, 0.14);
+$fun-color-gray-very-light: rgba(0, 0, 0, 0.07);
+
+
 
 // Used for selectors like ".has-background-primary"
 $custom-colors: (
@@ -22,6 +29,11 @@ $custom-colors: (
 		"footer": ($fun-color-footer),
 		"error": ($fun-color-error),
 		"error-light": ($fun-color-error-light),
+		"gray-dark": ($fun-color-gray-dark),
+		"gray-mid": ($fun-color-gray-mid),
+		"gray-light-solid": ($fun-color-gray-light-solid),
+		"gray-light-transparency": ($fun-color-gray-light-transparency),
+		"gray-very-light": ($fun-color-gray-very-light),
 );
 
 //

--- a/skins/laika/src/view_models/faq.ts
+++ b/skins/laika/src/view_models/faq.ts
@@ -1,11 +1,8 @@
 export interface FaqData {
-	page : Question[],
-	isOverview: boolean,
-	topicTitle: string,
 	openQuestionId: string
 }
 
-export interface Question {
+export interface QuestionModel {
 	question : string,
 	visibleText : string,
 	topic : string,
@@ -18,7 +15,7 @@ export interface Topic {
 
 export interface FaqContent {
 	topics : Topic[],
-	questions : Question[],
+	questions : QuestionModel[],
 }
 
 /**


### PR DESCRIPTION
As by the new design decision, all questions in all topics
are shown on the faq page now. They can be opened and closed and
only one question is open at a time.