### PR TITLE
Load donation form pages dynamically

### DIFF
--- a/skins/laika/src/components/pages/DonationForm.vue
+++ b/skins/laika/src/components/pages/DonationForm.vue
@@ -55,29 +55,28 @@ export default Vue.extend( {
 	data: function () {
 		return {
 			currentFormComponent: 'Payment',
-			buttonsVisibility: { 
-				previous: false, 
-				next: true, 
-				submit: false, 
+			buttonsVisibility: {
+				previous: false,
+				next: true,
+				submit: false,
 			},
 		};
 	},
 	computed: {
 		currentProperties: {
-			get() {
-				if ( this.$data.currentFormComponent === 'Payment' ) {
-					return {
-						validateAmountUrl: this.$props.validateAmountUrl,
-						paymentAmounts: this.$props.paymentAmounts,
-						paymentIntervals: this.$props.paymentIntervals,
-						paymentTypes: this.$props.paymentTypes,
-					};
-				} else if ( this.$data.currentFormComponent === 'AddressForm' ) {
+			get(): object {
+				if ( this.$data.currentFormComponent === 'AddressForm' ) {
 					return {
 						validateAddressUrl: this.$props.validateAddressUrl,
 						countries: this.$props.addressCountries,
 					};
 				}
+				return {
+					validateAmountUrl: this.$props.validateAmountUrl,
+					paymentAmounts: this.$props.paymentAmounts,
+					paymentIntervals: this.$props.paymentIntervals,
+					paymentTypes: this.$props.paymentTypes,
+				};
 			},
 		},
 	},
@@ -86,7 +85,7 @@ export default Vue.extend( {
 			this.$data.currentFormComponent = newComponent;
 			this.scrollToTop();
 		},
-		scrollToTop(): void {
+		scrollToTop: function (): void {
 			window.scrollTo( 0, 0 );
 		},
 		next(): void {
@@ -102,7 +101,7 @@ export default Vue.extend( {
 			this.$data.buttonsVisibility.submit = false;
 		},
 		submit() {
-			//TODO
+			// TODO
 		},
 	},
 } );

--- a/skins/laika/src/components/pages/DonationForm.vue
+++ b/skins/laika/src/components/pages/DonationForm.vue
@@ -37,6 +37,13 @@
 import Vue from 'vue';
 import Payment from '@/components/pages/donation_form/Payment.vue';
 import AddressForm from '@/components/pages/donation_form/Address.vue';
+import { mapGetters } from 'vuex';
+import { action } from '@/store/util';
+import {
+	NS_PAYMENT,
+	NS_ADDRESS,
+} from '@/store/namespaces';
+import { markEmptyValuesAsInvalid } from '@/store/payment/actionTypes';
 
 export default Vue.extend( {
 	name: 'DonationForm',
@@ -89,10 +96,13 @@ export default Vue.extend( {
 			window.scrollTo( 0, 0 );
 		},
 		next(): void {
-			this.changeCurrentFormComponent( 'AddressForm' );
-			this.$data.buttonsVisibility.next = false;
-			this.$data.buttonsVisibility.previous = true;
-			this.$data.buttonsVisibility.submit = true;
+			this.$store.dispatch( action( NS_PAYMENT, markEmptyValuesAsInvalid ) );
+			if ( this.$store.getters[ NS_PAYMENT + '/paymentDataIsValid' ] ) {
+				this.changeCurrentFormComponent( 'AddressForm' );
+				this.$data.buttonsVisibility.next = false;
+				this.$data.buttonsVisibility.previous = true;
+				this.$data.buttonsVisibility.submit = true;
+			}
 		},
 		previous(): void {
 			this.changeCurrentFormComponent( 'Payment' );

--- a/skins/laika/src/components/pages/DonationForm.vue
+++ b/skins/laika/src/components/pages/DonationForm.vue
@@ -5,7 +5,7 @@
 			<component
 				:is="currentFormComponent"
 				v-bind="currentProperties"
-				v-on:change-component="changeCurrentFormComponent( $event )">
+				v-on:change-component="changeCurrentFormComponent( $event ); scrollToTop()">
 			</component>
 		</keep-alive>
 		</form>
@@ -16,6 +16,7 @@
 import Vue from 'vue';
 import Payment from '@/components/pages/donation_form/Payment.vue';
 import AddressForm from '@/components/pages/donation_form/Address.vue';
+Vue.prototype.scrollTo = window.scrollTo;
 
 export default Vue.extend( {
 	name: 'DonationForm',
@@ -59,6 +60,9 @@ export default Vue.extend( {
 		changeCurrentFormComponent( newComponent: string ) {
 			this.$data.currentFormComponent = newComponent;
 		},
+		scrollToTop() {
+			window.scrollTo( 0, 0 );
+		}
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/DonationForm.vue
+++ b/skins/laika/src/components/pages/DonationForm.vue
@@ -1,22 +1,42 @@
 <template>
-	<div class="column is-full">
-		<form>
+	<form class="column is-full">
 		<keep-alive>
 			<component
 				:is="currentFormComponent"
-				v-bind="currentProperties"
-				v-on:change-component="changeCurrentFormComponent( $event ); scrollToTop()">
+				v-bind="currentProperties">
 			</component>
 		</keep-alive>
-		</form>
-	</div>
+		<div class="level has-margin-top-36">
+			<div class="level-left">
+				<b-button class="level-item"
+					v-if="buttonsVisibility.next"
+					@click="next()"
+					type="is-primary is-main">
+					{{ $t('donation_section_continue') }}
+				</b-button>
+				<b-button class="level-item"
+					v-if="buttonsVisibility.previous"
+					@click="previous()"
+					type="is-primary is-main">
+					{{ $t('donation_section_back') }}
+				</b-button>
+			</div>
+			<div class="level-right">
+				<b-button class="level-item"
+					v-if="buttonsVisibility.submit"
+					@click="submit()"
+					type="is-primary is-main">
+					{{ $t('donation_banner_anchor') }}
+				</b-button>
+			</div>
+		</div>
+	</form>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import Payment from '@/components/pages/donation_form/Payment.vue';
 import AddressForm from '@/components/pages/donation_form/Address.vue';
-Vue.prototype.scrollTo = window.scrollTo;
 
 export default Vue.extend( {
 	name: 'DonationForm',
@@ -35,6 +55,11 @@ export default Vue.extend( {
 	data: function () {
 		return {
 			currentFormComponent: 'Payment',
+			buttonsVisibility: { 
+				previous: false, 
+				next: true, 
+				submit: false, 
+			},
 		};
 	},
 	computed: {
@@ -57,12 +82,28 @@ export default Vue.extend( {
 		},
 	},
 	methods: {
-		changeCurrentFormComponent( newComponent: string ) {
+		changeCurrentFormComponent( newComponent: string ): void {
 			this.$data.currentFormComponent = newComponent;
+			this.scrollToTop();
 		},
-		scrollToTop() {
+		scrollToTop(): void {
 			window.scrollTo( 0, 0 );
-		}
+		},
+		next(): void {
+			this.changeCurrentFormComponent( 'AddressForm' );
+			this.$data.buttonsVisibility.next = false;
+			this.$data.buttonsVisibility.previous = true;
+			this.$data.buttonsVisibility.submit = true;
+		},
+		previous(): void {
+			this.changeCurrentFormComponent( 'Payment' );
+			this.$data.buttonsVisibility.next = true;
+			this.$data.buttonsVisibility.previous = false;
+			this.$data.buttonsVisibility.submit = false;
+		},
+		submit() {
+			//TODO
+		},
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/DonationForm.vue
+++ b/skins/laika/src/components/pages/DonationForm.vue
@@ -8,13 +8,13 @@
 		</keep-alive>
 		<div class="level has-margin-top-36">
 			<div class="level-left">
-				<b-button class="level-item"
+				<b-button id="next" class="level-item"
 					v-if="buttonsVisibility.next"
 					@click="next()"
 					type="is-primary is-main">
 					{{ $t('donation_section_continue') }}
 				</b-button>
-				<b-button class="level-item"
+				<b-button id="previous" class="level-item"
 					v-if="buttonsVisibility.previous"
 					@click="previous()"
 					type="is-primary is-main">
@@ -22,7 +22,7 @@
 				</b-button>
 			</div>
 			<div class="level-right">
-				<b-button class="level-item"
+				<b-button id="submit" class="level-item"
 					v-if="buttonsVisibility.submit"
 					@click="submit()"
 					type="is-primary is-main">
@@ -92,7 +92,7 @@ export default Vue.extend( {
 			this.$data.currentFormComponent = newComponent;
 			this.scrollToTop();
 		},
-		scrollToTop: function (): void {
+		scrollToTop(): void {
 			window.scrollTo( 0, 0 );
 		},
 		next(): void {

--- a/skins/laika/src/components/pages/DonationForm.vue
+++ b/skins/laika/src/components/pages/DonationForm.vue
@@ -1,21 +1,13 @@
 <template>
 	<div class="column is-full">
 		<form>
-			<payment
-				:validate-amount-url="validateAmountUrl"
-				:payment-amounts="paymentAmounts"
-				:payment-intervals="paymentIntervals"
-				:payment-types="paymentTypes">
-			</payment>
-			<address-form
-				:validate-address-url="validateAddressUrl"
-				:countries="addressCountries">
-			</address-form>
-			<!--
-				Vue component for an overview of the donation (Zusammenfassung in the design).
-				It will contain the final Donate button.
-				validateForm() should be called upon clicking that button.
-			-->
+		<keep-alive>
+			<component
+				:is="currentFormComponent"
+				v-bind="currentProperties"
+				v-on:change-component="changeCurrentFormComponent( $event )">
+			</component>
+		</keep-alive>
 		</form>
 	</div>
 </template>
@@ -38,6 +30,35 @@ export default Vue.extend( {
 		paymentIntervals: Array as () => Array<Number>,
 		paymentTypes: Array as () => Array<String>,
 		addressCountries: Array as () => Array<String>,
+	},
+	data: function () {
+		return {
+			currentFormComponent: 'Payment',
+		};
+	},
+	computed: {
+		currentProperties: {
+			get() {
+				if ( this.$data.currentFormComponent === 'Payment' ) {
+					return {
+						validateAmountUrl: this.$props.validateAmountUrl,
+						paymentAmounts: this.$props.paymentAmounts,
+						paymentIntervals: this.$props.paymentIntervals,
+						paymentTypes: this.$props.paymentTypes,
+					};
+				} else if ( this.$data.currentFormComponent === 'AddressForm' ) {
+					return {
+						validateAddressUrl: this.$props.validateAddressUrl,
+						countries: this.$props.addressCountries,
+					};
+				}
+			},
+		},
+	},
+	methods: {
+		changeCurrentFormComponent( newComponent: string ) {
+			this.$data.currentFormComponent = newComponent;
+		},
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -11,14 +11,6 @@
 			<email></email>
 		</div>
 		<newsletter-opt-in></newsletter-opt-in>
-		<div class="level has-margin-top-36">
-			<div class="level-left">
-        		<b-button class="level-item" @click="previous()" type="is-primary is-main">{{ $t('donation_section_back') }}</b-button>
-			</div>
-			<div class="level-right">
-        		<b-button class="level-item" @click="submit()" type="is-primary is-main">{{ $t('donation_banner_anchor') }}</b-button>
-        	</div>
-        </div>
 	</div>
 </template>
 
@@ -135,12 +127,6 @@ export default Vue.extend( {
 		},
 		validateInput( formData: FormData, fieldName: string ) {
 			this.$store.dispatch( action( NS_ADDRESS, validateInput ), formData[ fieldName ] );
-		},
-		previous() {
-			this.$emit( 'change-component', 'Payment' );
-		},
-		submit() {
-			//TODO
 		}
 	},
 } );

--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -11,6 +11,14 @@
 			<email></email>
 		</div>
 		<newsletter-opt-in></newsletter-opt-in>
+		<div class="level has-margin-top-36">
+			<div class="level-left">
+        		<b-button class="level-item" @click="previous()" type="is-primary is-main">{{ $t('donation_section_back') }}</b-button>
+			</div>
+			<div class="level-right">
+        		<b-button class="level-item" @click="submit()" type="is-primary is-main">{{ $t('donation_banner_anchor') }}</b-button>
+        	</div>
+        </div>
 	</div>
 </template>
 
@@ -115,7 +123,7 @@ export default Vue.extend( {
 		},
 		...mapGetters( NS_ADDRESS, [
 			'addressType',
-			'addressTypeIsNotAnon',
+			'addressTypeIsNotAnon',																																																																																																						
 		] ),
 	},
 	methods: {
@@ -128,6 +136,28 @@ export default Vue.extend( {
 		validateInput( formData: FormData, fieldName: string ) {
 			this.$store.dispatch( action( NS_ADDRESS, validateInput ), formData[ fieldName ] );
 		},
+		previous() {
+			this.$emit( 'change-component', 'Payment' );
+		},
+		submit() {
+			//TODO
+		}
 	},
 } );
 </script>
+<style lang="scss" scoped>
+    @import "../../../scss/custom";
+
+    button.is-main {
+        height: 54px;
+        font-size: 1em;
+        font-weight: bold;
+        width: 250px;
+        border-radius: 0;
+    }
+    @include until($tablet) {
+        button.is-main {
+            width: 100%;
+        }
+    }
+</style>

--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -115,7 +115,7 @@ export default Vue.extend( {
 		},
 		...mapGetters( NS_ADDRESS, [
 			'addressType',
-			'addressTypeIsNotAnon',																																																																																																						
+			'addressTypeIsNotAnon',
 		] ),
 	},
 	methods: {
@@ -127,7 +127,7 @@ export default Vue.extend( {
 		},
 		validateInput( formData: FormData, fieldName: string ) {
 			this.$store.dispatch( action( NS_ADDRESS, validateInput ), formData[ fieldName ] );
-		}
+		},
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/donation_form/Payment.vue
+++ b/skins/laika/src/components/pages/donation_form/Payment.vue
@@ -26,7 +26,7 @@ export default Vue.extend( {
 	methods: {
 		validatePaymentData(): void {
 			this.$store.dispatch( action( NS_PAYMENT, markEmptyValuesAsInvalid ) );
-		}
+		},
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/donation_form/Payment.vue
+++ b/skins/laika/src/components/pages/donation_form/Payment.vue
@@ -1,13 +1,8 @@
 <template>
     <div class="column is-full">
-        <form>
-            <payment-amount :payment-amounts="paymentAmounts" :validate-amount-url="validateAmountUrl"></payment-amount>
-            <payment-interval :payment-intervals="paymentIntervals"></payment-interval>
-            <payment-type :payment-types="paymentTypes"></payment-type>
-            <div class="has-margin-top-36">
-                <b-button @click="next()" type="is-primary is-main">{{ $t('donation_section_continue') }}</b-button>
-            </div>
-        </form>
+        <payment-amount :payment-amounts="paymentAmounts" :validate-amount-url="validateAmountUrl"></payment-amount>
+        <payment-interval :payment-intervals="paymentIntervals"></payment-interval>
+        <payment-type :payment-types="paymentTypes"></payment-type>
     </div>
 </template>
 
@@ -31,10 +26,7 @@ export default Vue.extend( {
 	methods: {
 		validatePaymentData(): void {
 			this.$store.dispatch( action( NS_PAYMENT, markEmptyValuesAsInvalid ) );
-		},
-		next(): void {
-			this.$emit( 'change-component', 'AddressForm' );
-		},
+		}
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/donation_form/Payment.vue
+++ b/skins/laika/src/components/pages/donation_form/Payment.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="column is-full">
+    <div id="payment" class="column is-full">
         <payment-amount :payment-amounts="paymentAmounts" :validate-amount-url="validateAmountUrl"></payment-amount>
         <payment-interval :payment-intervals="paymentIntervals"></payment-interval>
         <payment-type :payment-types="paymentTypes"></payment-type>
@@ -11,9 +11,6 @@ import Vue from 'vue';
 import PaymentAmount from '@/components/pages/donation_form/PaymentAmount.vue';
 import PaymentInterval from '@/components/pages/donation_form/PaymentInterval.vue';
 import PaymentType from '@/components/pages/donation_form/PaymentType.vue';
-import { markEmptyValuesAsInvalid } from '@/store/payment/actionTypes';
-import { action } from '@/store/util';
-import { NS_PAYMENT } from '@/store/namespaces';
 
 export default Vue.extend( {
 	name: 'Payment',
@@ -23,11 +20,6 @@ export default Vue.extend( {
 		PaymentType,
 	},
 	props: [ 'validateAmountUrl', 'paymentAmounts', 'paymentIntervals', 'paymentTypes' ],
-	methods: {
-		validatePaymentData(): void {
-			this.$store.dispatch( action( NS_PAYMENT, markEmptyValuesAsInvalid ) );
-		},
-	},
 } );
 </script>
 

--- a/skins/laika/src/components/pages/donation_form/Payment.vue
+++ b/skins/laika/src/components/pages/donation_form/Payment.vue
@@ -4,8 +4,8 @@
             <payment-amount :payment-amounts="paymentAmounts" :validate-amount-url="validateAmountUrl"></payment-amount>
             <payment-interval :payment-intervals="paymentIntervals"></payment-interval>
             <payment-type :payment-types="paymentTypes"></payment-type>
-           <div class="has-margin-top-36">
-                <b-button type="is-primary is-main">{{ $t('donation_section_continue') }}</b-button>
+            <div class="has-margin-top-36">
+                <b-button @click="next()" type="is-primary is-main">{{ $t('donation_section_continue') }}</b-button>
             </div>
         </form>
     </div>
@@ -31,6 +31,9 @@ export default Vue.extend( {
 	methods: {
 		validatePaymentData(): void {
 			this.$store.dispatch( action( NS_PAYMENT, markEmptyValuesAsInvalid ) );
+		},
+		next(): void {
+			this.$emit( 'change-component', 'AddressForm' );
 		},
 	},
 } );

--- a/skins/laika/tests/unit/components/pages/donation_form/DonationForm.spec.ts
+++ b/skins/laika/tests/unit/components/pages/donation_form/DonationForm.spec.ts
@@ -1,0 +1,97 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import Buefy from 'buefy';
+import DonationForm from '@/components/pages/DonationForm.vue';
+import { action } from '@/store/util';
+import { NS_PAYMENT } from '@/store/namespaces';
+import { markEmptyValuesAsInvalid } from '@/store/payment/actionTypes';
+
+declare global {
+	namespace NodeJS {
+		interface Global {
+			window: Window;
+		}
+	}
+}
+describe( 'DonationForm', () => {
+	let wrapper: any;
+	const actions = {
+		'payment/markEmptyValuesAsInvalid': jest.fn(),
+	};
+	const getters = {
+		'payment/paymentDataIsValid': jest.fn()
+			.mockReturnValueOnce( true )
+			.mockReturnValueOnce( true )
+			.mockReturnValueOnce( true )
+			.mockReturnValueOnce( true )
+			.mockReturnValueOnce( false )
+	};
+	beforeEach( () => {
+		global.window.scrollTo = jest.fn();
+		const localVue = createLocalVue();
+		localVue.use( Vuex );
+		localVue.use( Buefy );
+		wrapper = mount( DonationForm, {
+			localVue,
+			propsData: {
+				paymentAmounts: [ 5 ],
+				paymentIntervals: [ 0, 1, 3, 6, 12 ],
+				paymentTypes: [ 'BEZ', 'PPL', 'UEB', 'BTC' ],
+				validateAmountUrl: 'https://example.com/amount-check',
+				validateAddressUrl: 'https://example.com/address-check',
+				addressCountries: [ 'DE' ],
+			},
+			store: new Vuex.Store( {
+				actions,
+				getters,
+			} ),
+			mocks: {
+				$t: jest.fn(),
+			},
+			stubs: {
+				Payment: '<div class="i-am-payment" />',
+				AddressForm: '<div class="i-am-address-form" />',
+			},
+		} );
+	} );
+
+	it( 'displays Payment component by default ', () => {
+		expect( wrapper.contains( '.i-am-payment' ) ).toBe( true );
+	} );
+
+	it( 'shows next button on Payment page', () => {
+		expect( wrapper.html() ).toContain( '<button type="button" id="next" class="button level-item is-primary is-main">' );
+	} );
+
+	it( 'loads Address component on the next page', () => {
+		wrapper.find( '#next' ).trigger( 'click' );
+		expect( wrapper.contains( '.i-am-address-form' ) ).toBe( true );
+	} );
+
+	it( 'shows previous and submit button on Address page', () => {
+		wrapper.find( '#next' ).trigger( 'click' );
+		expect( wrapper.html() ).toContain( '<button type="button" id="previous" class="button level-item is-primary is-main">' );
+		expect( wrapper.html() ).toContain( '<button type="button" id="submit" class="button level-item is-primary is-main">' );
+	} );
+
+	it( 'loads Payment component on the previous page', () => {
+		wrapper.find( '#next' ).trigger( 'click' );
+		wrapper.find( '#previous' ).trigger( 'click' );
+		expect( wrapper.contains( '.i-am-payment' ) ).toBe( true );
+	} );
+
+	it( 'validates the input before going to the next page', () => {
+		const store = wrapper.vm.$store;
+		store.dispatch = jest.fn();
+		const expectedAction = action( NS_PAYMENT, markEmptyValuesAsInvalid );
+		wrapper.find( '#next' ).trigger( 'click' );
+		expect( store.dispatch ).toHaveBeenCalledWith( expectedAction );
+	} );
+
+	it( 'doesn\'t load the next page if there are validation errors', () => {
+		wrapper.find( '#next' ).trigger( 'click' );
+		expect( wrapper.contains( '.i-am-address-form' ) ).toBe( false );
+		expect( wrapper.contains( '.i-am-payment' ) ).toBe( true );
+	} );
+
+} );


### PR DESCRIPTION
:heavy_check_mark:  [T224115](https://phabricator.wikimedia.org/T224115)
:page_facing_up: Split the donation form into pages and load them dynamically when `next` or `previous` buttons are clicked. Make `next` button disabled in case of invalid fields.
:memo: Implementing the Overview Component and the Submit functionality will be in separate PRs.
