### PR TITLE
Make empty JCF dropdowns compatible with Vue

### DIFF
--- a/skins/cat17/address-form/src/__tests__/components/AddressForm.spec.ts
+++ b/skins/cat17/address-form/src/__tests__/components/AddressForm.spec.ts
@@ -200,6 +200,7 @@ describe('AddressForm.vue', () => {
 		});
 		let title = wrapper.find('#title');
 		title.setValue('Prof. Dr.');
+		title.trigger('blur');
 		let firstName = wrapper.find('#first-name');
 		firstName.setValue('Testina');
 		let lastName = wrapper.find('#last-name');

--- a/skins/cat17/address-form/src/__tests__/components/Name.spec.ts
+++ b/skins/cat17/address-form/src/__tests__/components/Name.spec.ts
@@ -1,0 +1,94 @@
+import { shallowMount } from '@vue/test-utils'
+import Name from '../../components/Name.vue'
+
+function newTestProperties(overrides: Object) {
+	return Object.assign(
+		{
+			showError: {
+				salutation: false,
+				companyName: false,
+				firstName: false,
+				lastName: false,
+			},
+			formData: {
+				salutation: {
+					name: 'salutation',
+					value: '',
+					pattern: '^(Herr|Frau)$',
+					optionalField: false
+				},
+				title: {
+					name: 'title',
+					value: '',
+					pattern: '',
+					optionalField: true
+				},
+				companyName: {
+					name: 'companyName',
+					value: '',
+					pattern: '^.+$',
+					optionalField: true
+				},
+				firstName: {
+					name: 'firstName',
+					value: '',
+					pattern: '^.+$',
+					optionalField: false
+				},
+				lastName: {
+					name: 'lastName',
+					value: '',
+					pattern: '^.+$',
+					optionalField: false
+				},
+				addressType: {
+					name: 'addressType',
+					value: false ? 'firma' : 'person',
+					pattern: '',
+					optionalField: false
+				}
+			},
+			validateInput: jest.fn(),
+			messages: {},
+			countries: []
+		},
+		overrides
+	);
+}
+
+describe('Name.vue', () => {
+	it('does not send any value when the new salutation field is blurred', () => {
+		const props = newTestProperties( {} );
+		const wrapper = shallowMount( Name, {
+			propsData: props
+		});
+		let salutation = wrapper.find('#salutation');
+		salutation.trigger('blur');
+		expect(props.validateInput.mock.calls.length).toBe(0);
+	});
+
+	it('sends the value when the salutation field is blurred after a change', () => {
+		const props = newTestProperties( {} );
+		const wrapper = shallowMount( Name, {
+			propsData: props
+		});
+		let salutation = wrapper.find('#salutation');
+		salutation.setValue('Herr');
+		salutation.trigger('blur');
+		expect(props.validateInput.mock.calls.length).toBe(1);
+		expect(props.validateInput.mock.calls[0][0].salutation.value).toBe('Herr');
+	});
+
+	it('sends the value when the empty salutation field is blurred from a previous value', () => {
+		const props = newTestProperties( {} );
+		props.formData.salutation.value = 'Frau';
+		const wrapper = shallowMount( Name, {
+			propsData: props
+		});
+		let salutation = wrapper.find('#salutation');
+		salutation.setValue('');
+		salutation.trigger('blur');
+		expect(props.validateInput.mock.calls.length).toBe(1);
+		expect(props.validateInput.mock.calls[0][0].salutation.value).toBe('');
+	});
+});

--- a/skins/cat17/address-form/src/components/Name.vue
+++ b/skins/cat17/address-form/src/components/Name.vue
@@ -15,10 +15,10 @@
 			<label for="salutation">{{ messages.salutation_label }}</label>
 			<select class="salutation col-xs-12 col-md-6"
 					id="salutation"
-					v-model="formData.salutation.value"
+					v-model="salutation"
 					name="salutation"
 					data-jcf='{"wrapNative": false,  "wrapNativeOnMobile": true  }'
-					@blur="validateInput(formData, 'salutation')">
+					@blur="updateJcfDropdown('salutation')">
 				<option hidden class="hideme" value="">{{ messages.salutation_label }}</option>
 				<option value="Herr">{{ messages.salutation_option_mr }}</option>
 				<option value="Frau">{{ messages.salutation_option_mrs }}</option>
@@ -28,10 +28,10 @@
 			<label for="title">{{ messages.academic_title_label }}</label>
 			<select class="personal-title col-xs-12 col-md-6"
 					id="title"
-					v-model="formData.title.value"
+					v-model="title"
 					name="title"
 					data-jcf='{"wrapNative": false, "wrapNativeOnMobile": true}'
-					@blur="validateInput(formData, 'title')">
+					@blur="updateJcfDropdown('title')">
 				<option value="">{{ messages.title_option_none }}</option>
 				<option value="Dr.">Dr.</option>
 				<option value="Prof.">Prof.</option>
@@ -67,6 +67,28 @@
 	import Vue from 'vue';
 	export default Vue.extend( {
 		name: 'name',
-		props: [ 'showError', 'formData', 'validateInput', 'isCompany', 'messages' ]
+		data: function () {
+			return {
+				salutation: '',
+				title: ''
+			}
+		},
+		props: [ 'showError', 'formData', 'validateInput', 'isCompany', 'messages' ],
+		methods: {
+			/**
+			 * Circumvent the early triggering of the "blur" event that leads to premature error messages
+			 * When the user selects a dropdown that's empty by default.
+			 *
+			 * @param fieldName
+			 */
+			updateJcfDropdown( fieldName: string) {
+				if ( this.$data[ fieldName ] === '' && this.$props.formData[ fieldName ].value === '' ) {
+					return;
+				}
+
+				this.$props.formData[ fieldName ].value = this.$data[ fieldName ];
+				this.$props.validateInput( this.$props.formData, fieldName );
+			}
+		}
 	} );
 </script>


### PR DESCRIPTION
Our validation was triggered by blur events, which were triggered
prematurely by JCF, leading to erronous validation when the user
selected the dropdown with an empty default value. Now the dropdown
fields sned the value only when it's either not empty or there was a
previous value.

This fixes https://phabricator.wikimedia.org/T225481