### PR TITLE
Create membership type

### DIFF
--- a/skins/laika/src/components/pages/MembershipForm.vue
+++ b/skins/laika/src/components/pages/MembershipForm.vue
@@ -29,7 +29,6 @@ export default Vue.extend( {
 		validateAddressUrl: String,
 		validateAmountUrl: String,
 		paymentAmounts: Array as () => Array<String>,
-		paymentIntervals: Array as () => Array<Number>,
 		paymentTypes: Array as () => Array<String>,
 		addressCountries: Array as () => Array<String>,
 		trackingData: Object as () => TrackingData,

--- a/skins/laika/src/components/pages/MembershipForm.vue
+++ b/skins/laika/src/components/pages/MembershipForm.vue
@@ -1,0 +1,83 @@
+<template>
+    <form class="column is-full" ref="form" action="/apply-for-membership" method="post">
+		<keep-alive>
+			<component
+				ref="currentPage"
+				:is="currentFormComponent"
+				v-on:next-page="changePageIndex( 1 )"
+				v-on:previous-page="changePageIndex( -1 )"
+				v-on:submit-membership="submitMembershipForm"
+				v-bind="currentProperties">
+			</component>
+		</keep-alive>
+	</form>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { TrackingData } from '@/view_models/SubmitValues';
+import PaymentPage from '@/components/pages/membership_form/subpages/PaymentPage.vue';
+import AddressPage from '@/components/pages/membership_form/subpages/AddressPage.vue';
+
+export default Vue.extend( {
+	name: 'MembershipForm',
+	components: {
+		PaymentPage,
+		AddressPage,
+	},
+	props: {
+		validateAddressUrl: String,
+		validateAmountUrl: String,
+		paymentAmounts: Array as () => Array<String>,
+		paymentIntervals: Array as () => Array<Number>,
+		paymentTypes: Array as () => Array<String>,
+		addressCountries: Array as () => Array<String>,
+		trackingData: Object as () => TrackingData,
+	},
+	data: function () {
+		return {
+			pages: [ 'AddressPage', 'PaymentPage' ],
+			currentPageIndex: 0,
+		};
+	},
+	computed: {
+		currentFormComponent: {
+			get(): string {
+				return this.$data.pages[ this.$data.currentPageIndex ];
+			},
+		},
+		currentProperties: {
+			get(): object {
+				if ( this.currentFormComponent === 'AddressPage' ) {
+					return {
+						validateAddressUrl: this.$props.validateAddressUrl,
+						countries: this.$props.addressCountries,
+						trackingData: this.$props.trackingData,
+					};
+				}
+				return {
+					validateAmountUrl: this.$props.validateAmountUrl,
+					paymentAmounts: this.$props.paymentAmounts,
+					paymentIntervals: this.$props.paymentIntervals,
+					paymentTypes: this.$props.paymentTypes,
+				};
+			},
+		},
+	},
+	methods: {
+		changePageIndex( indexChange: number ): void {
+			const newIndex = this.$data.currentPageIndex + indexChange;
+			if ( newIndex >= 0 && newIndex < this.$data.pages.length ) {
+				this.$data.currentPageIndex = newIndex;
+				this.scrollToTop();
+			}
+		},
+		scrollToTop(): void {
+			window.scrollTo( 0, 0 );
+		},
+		submitMembershipForm(): void {
+			( this.$refs.form as HTMLFormElement ).submit();
+		},
+	},
+} );
+</script>

--- a/skins/laika/src/components/pages/membership_form/MembershipType.vue
+++ b/skins/laika/src/components/pages/membership_form/MembershipType.vue
@@ -1,0 +1,48 @@
+<template>
+    <fieldset class="has-margin-top-36">
+        <legend class="title is-size-5">{{ $t('membership_type_legend') }}</legend>
+        <div>
+            <b-radio :class="{ 'is-active': selectedType === 'sustaining' }"
+                    type="radio"
+                    id="sustaining"
+                    name="type"
+                    v-model="selectedType"
+                    native-value="sustaining"
+                    @change.native="setType">
+                {{ $t( 'membership_membershiptype_option_sustaining' ) }}
+            </b-radio>
+            <b-radio :class="{ 'is-active': selectedType === 'active' }"
+                    type="radio"
+                    id="active"
+                    name="type"
+                    v-model="selectedType"
+                    native-value="active"
+                    @change.native="setType">
+                {{ $t( 'membership_membershiptype_option_active' ) }}
+            </b-radio>
+        </div>
+    </fieldset>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend( {
+	name: 'MembershipType',
+	data: function () {
+		return {
+			selectedType: 'sustaining',
+		};
+	},
+	methods: {
+		setType(): void {
+			// TODO: store the chosen membership type in the membership address store once it exists
+		},
+	},
+} );
+</script>
+<style lang="scss" scoped>
+    .b-radio.radio {
+        margin-left: 0;
+    }
+</style>

--- a/skins/laika/src/components/pages/membership_form/MembershipType.vue
+++ b/skins/laika/src/components/pages/membership_form/MembershipType.vue
@@ -1,6 +1,6 @@
 <template>
     <fieldset class="has-margin-top-36">
-        <legend class="title is-size-5">{{ $t('membership_type_legend') }}</legend>
+        <legend class="title is-size-5">{{ $t('membership_membershiptype_legend') }}</legend>
         <div>
             <b-radio :class="{ 'is-active': selectedType === 'sustaining' }"
                     type="radio"
@@ -9,7 +9,8 @@
                     v-model="selectedType"
                     native-value="sustaining"
                     @change.native="setType">
-                {{ $t( 'membership_membershiptype_option_sustaining' ) }}
+                <span>{{ $t( 'membership_membershiptype_option_sustaining' ) }}</span>
+                <p class="has-text-dark-lighter">{{ $t( 'membership_membershiptype_option_sustaining_legend' ) }}</p>
             </b-radio>
             <b-radio :class="{ 'is-active': selectedType === 'active' }"
                     type="radio"
@@ -19,6 +20,7 @@
                     native-value="active"
                     @change.native="setType">
                 {{ $t( 'membership_membershiptype_option_active' ) }}
+                <p class="has-text-dark-lighter">{{ $t( 'membership_membershiptype_option_active_legend' ) }}</p>
             </b-radio>
         </div>
     </fieldset>
@@ -44,5 +46,6 @@ export default Vue.extend( {
 <style lang="scss" scoped>
     .b-radio.radio {
         margin-left: 0;
+        height: 6.5em;
     }
 </style>

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -9,7 +9,7 @@ import Vue from 'vue';
 import MembershipType from '@/components/pages/membership_form//MembershipType.vue';
 
 export default Vue.extend( {
-    name: 'AddressPage',
+	name: 'AddressPage',
 	components: {
 		MembershipType,
 	},

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -1,0 +1,17 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend( {
+
+} );
+</script>
+
+<style scoped>
+
+</style>

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -1,17 +1,17 @@
 <template>
-    <div>
-
+    <div class="column is-full">
+        <membership-type></membership-type>
     </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import MembershipType from '@/components/pages/membership_form//MembershipType.vue';
 
 export default Vue.extend( {
-
+    name: 'AddressPage',
+	components: {
+		MembershipType,
+	},
 } );
 </script>
-
-<style scoped>
-
-</style>

--- a/skins/laika/src/components/pages/membership_form/subpages/PaymentPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/PaymentPage.vue
@@ -1,0 +1,17 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend( {
+
+} );
+</script>
+
+<style scoped>
+
+</style>

--- a/skins/laika/src/pages/membership_application.ts
+++ b/skins/laika/src/pages/membership_application.ts
@@ -17,7 +17,6 @@ Vue.use( VueI18n );
 interface MembershipAmountModel {
 	presetAmounts: Array<string>,
 	paymentTypes: Array<string>,
-	paymentIntervals: Array<number>,
 	tracking: Array<number>,
 	urls: any
 }
@@ -47,7 +46,6 @@ new Vue( {
 				validateAddressUrl: pageData.applicationVars.urls.validateAddress,
 				validateAmountUrl: pageData.applicationVars.urls.validateDonationAmount,
 				paymentAmounts: pageData.applicationVars.presetAmounts,
-				paymentIntervals: pageData.applicationVars.paymentIntervals,
 				paymentTypes: pageData.applicationVars.paymentTypes,
 				addressCountries: COUNTRIES,
 				trackingData: pageData.applicationVars.tracking,

--- a/skins/laika/src/pages/membership_application.ts
+++ b/skins/laika/src/pages/membership_application.ts
@@ -3,20 +3,27 @@ import VueI18n from 'vue-i18n';
 import PageDataInitializer from '@/page_data_initializer';
 import { DEFAULT_LOCALE } from '@/locales';
 import App from '@/components/App.vue';
+import { createStore } from '@/store/membership_store';
 
-import Component from '@/components/pages/Placeholder.vue';
+import Component from '@/components/pages/MembershipForm.vue';
 import Sidebar from '@/components/layout/Sidebar.vue';
 
-const PAGE_IDENTIFIER = 'membership-application';
+const PAGE_IDENTIFIER = 'membership-application',
+	COUNTRIES = [ 'DE', 'AT', 'CH', 'BE', 'IT', 'LI', 'LU' ];
 
 Vue.config.productionTip = false;
 Vue.use( VueI18n );
 
-interface ErrorModel {
-	message: string
+interface MembershipAmountModel {
+	presetAmounts: Array<string>,
+	paymentTypes: Array<string>,
+	paymentIntervals: Array<number>,
+	tracking: Array<number>,
+	urls: any
 }
 
-const pageData = new PageDataInitializer<ErrorModel>( '#app' );
+const pageData = new PageDataInitializer<MembershipAmountModel>( '#app' );
+const store = createStore();
 
 const i18n = new VueI18n( {
 	locale: DEFAULT_LOCALE,
@@ -26,6 +33,7 @@ const i18n = new VueI18n( {
 } );
 
 new Vue( {
+	store,
 	i18n,
 	render: h => h( App, {
 		props: {
@@ -34,7 +42,17 @@ new Vue( {
 		},
 	},
 	[
-		h( Component, {} ),
+		h( Component, {
+			props: {
+				validateAddressUrl: pageData.applicationVars.urls.validateAddress,
+				validateAmountUrl: pageData.applicationVars.urls.validateDonationAmount,
+				paymentAmounts: pageData.applicationVars.presetAmounts,
+				paymentIntervals: pageData.applicationVars.paymentIntervals,
+				paymentTypes: pageData.applicationVars.paymentTypes,
+				addressCountries: COUNTRIES,
+				trackingData: pageData.applicationVars.tracking,
+			},
+		} ),
 		h( Sidebar, {
 			slot: 'sidebar',
 		} ),

--- a/skins/laika/src/store/membership_store.ts
+++ b/skins/laika/src/store/membership_store.ts
@@ -1,0 +1,12 @@
+import Vue from 'vue';
+import Vuex, { StoreOptions } from 'vuex';
+
+Vue.use( Vuex );
+
+export function createStore() {
+	const storeBundle: StoreOptions<any> = {
+		strict: process.env.NODE_ENV !== 'production',
+	};
+
+	return new Vuex.Store<any>( storeBundle );
+}


### PR DESCRIPTION
Feature: [T226928](https://phabricator.wikimedia.org/T226928)
- [x] Setup Membership structure (folders, parent vue component, store)
- [x] Create membership type page

Follow up PRs will cover the rest of the AC from the ticket, meaning adding address fields, birthday field and populating the form in case of coming from the donation confirmation page.