### PR TITLE
Membership address form

### DIFF
--- a/skins/laika/src/components/pages/donation_form/DateOfBirth.vue
+++ b/skins/laika/src/components/pages/donation_form/DateOfBirth.vue
@@ -1,0 +1,17 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend( {
+
+} );
+</script>
+
+<style scoped>
+
+</style>

--- a/skins/laika/src/components/pages/donation_form/DateOfBirth.vue
+++ b/skins/laika/src/components/pages/donation_form/DateOfBirth.vue
@@ -1,17 +1,50 @@
 <template>
-    <div>
-
-    </div>
+    <fieldset>
+		<label for="birthDate" class="subtitle has-margin-top-36">{{ $t( 'membership_birth_date_label' ) }}</label>
+		<b-input type="text"
+			id="birthDate"
+			:placeholder="$t( 'membership_birth_date_placeholder' )"
+			v-model="date"
+			@blur="validateDate">
+		</b-input>
+		<span v-if="dateHasError" class="help is-danger">{{ $t( 'membership_birth_date_error' ) }}</span>
+    </fieldset>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import { NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
+import { action } from '@/store/util';
+import { setDate } from '@/store/membership_address/actionTypes';
 
 export default Vue.extend( {
-
+	name: 'DateOfBirth',
+	data: function () {
+		return {
+			date: '',
+			datePattern: new RegExp( [
+				'^(?:(?:31(\\.)',
+				'(?:0?[13578]|1[02]))\\1|(?:(?:29|30)(\\.)',
+				'(?:0?[13-9]|1[0-2])\\2))(?:(?:1[6-9]|[2-9]\\d)?\\d{2})$|^(?:29(\\.)',
+				'0?2\\3(?:(?:(?:1[6-9]|[2-9]\\d)?(?:0[48]|[2468][048]|[13579][26])|(?:(?:16|[2468][048]|[3579][26])00))))$',
+				'|^(?:0?[1-9]|1\\d|2[0-8])(\\.)(?:(?:0?[1-9])|(?:1[0-2]))\\4(?:(?:1[6-9]|[2-9]\\d)?\\d{2})$',
+			].join( '' ) ),
+			dateHasError: false,
+		};
+	},
+	methods: {
+		setDate: function () {
+			this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setDate ), this.$data.date );
+		},
+		validateDate: function () {
+			this.dateHasError = !this.dateIsValid();
+			if ( !this.dateHasError ) {
+				this.setDate();
+			}
+		},
+		dateIsValid: function () {
+			return this.datePattern.test( this.$data.date );
+		},
+	},
 } );
 </script>
-
-<style scoped>
-
-</style>

--- a/skins/laika/src/components/pages/donation_form/ReceiptOptOut.vue
+++ b/skins/laika/src/components/pages/donation_form/ReceiptOptOut.vue
@@ -1,17 +1,38 @@
 <template>
-    <div>
-
+    <div class="has-margin-top-18">
+        <b-checkbox type="checkbox" class="is-inline-checkbox"
+			id="donation_receipt"
+			name="receiptOptOut"
+			v-model="optedOut"
+            @change.native="setReceiptOptOut()">
+		</b-checkbox>
+		<label class="news" for="donation_receipt">
+            {{  $t( 'receipt_opt_out' ) }}
+        </label>
+        <div class="explanation">
+            {{ $t( 'receipt_opt_out_explanation' ) }}
+        </div>
     </div>
+
 </template>
 
-<script lang="ts">
+<script>
 import Vue from 'vue';
+import { NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
+import { action } from '@/store/util';
+import { setReceiptOptOut } from '@/store/membership_address/actionTypes';
 
 export default Vue.extend( {
-
+	name: 'ReceiptOptOut',
+	data: function () {
+		return {
+			optedOut: false,
+		};
+	},
+	methods: {
+		setReceiptOptOut: function () {
+			this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setReceiptOptOut ), this.$data.optedOut );
+		},
+	},
 } );
 </script>
-
-<style scoped>
-
-</style>

--- a/skins/laika/src/components/pages/donation_form/ReceiptOptOut.vue
+++ b/skins/laika/src/components/pages/donation_form/ReceiptOptOut.vue
@@ -1,0 +1,17 @@
+<template>
+    <div>
+
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend( {
+
+} );
+</script>
+
+<style scoped>
+
+</style>

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -28,7 +28,7 @@ import Email from '@/components/pages/donation_form/Email.vue';
 import NewsletterOptIn from '@/components/pages/donation_form/NewsletterOptIn.vue';
 import { AddressValidity, FormData, ValidationResult } from '@/view_models/Address';
 import { Validity } from '@/view_models/Validity';
-import { NS_ADDRESS } from '@/store/namespaces';
+import { NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
 import { setAddressField, validateAddress } from '@/store/address/actionTypes';
 import { action } from '@/store/util';
 
@@ -36,9 +36,9 @@ export default Vue.extend( {
 	name: 'Address',
 	components: {
 		Name,
-        Postal,
-        DateOfBirth,
-        ReceiptOptOut,
+		Postal,
+		DateOfBirth,
+		ReceiptOptOut,
 		AddressType,
 		Email,
 		NewsletterOptIn,
@@ -110,29 +110,25 @@ export default Vue.extend( {
 	computed: {
 		fieldErrors: {
 			get: function (): AddressValidity {
-                /*uncomment when membership store is developed
 				return Object.keys( this.formData ).reduce( ( validity: AddressValidity, fieldName: string ) => {
 					if ( !this.formData[ fieldName ].optionalField ) {
-						validity[ fieldName ] = this.$store.state.address.validity[ fieldName ] === Validity.INVALID;
+						validity[ fieldName ] = this.$store.state.membership_address.validity[ fieldName ] === Validity.INVALID;
 					}
 					return validity;
                 }, ( {} as AddressValidity ) );
-                */
 			},
-        },
-        ...mapGetters( NS_ADDRESS, [
+		},
+		...mapGetters( NS_MEMBERSHIP_ADDRESS, [
 			'addressType',
 		] ),
 	},
 	methods: {
-        /* uncomment when membership store is developed
 		validateForm(): Promise<ValidationResult> {
-			return this.$store.dispatch( action( NS_ADDRESS, validateAddress ), this.$props.validateAddressUrl );
+			return this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, validateAddress ), this.$props.validateAddressUrl );
 		},
 		onFieldChange( fieldName: string ): void {
-			//this.$store.dispatch( action( NS_ADDRESS, setAddressField ), this.formData[ fieldName ] );
+			this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setAddressField ), this.formData[ fieldName ] );
         },
-        */
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -6,13 +6,13 @@
 		</div>
 		<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
 		<postal :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"></postal>
-		<date-of-birth></date-of-birth>
-        <receipt-opt-out></receipt-opt-out>
+		<date-of-birth/>
+        <receipt-opt-out/>
         <div class="has-margin-top-36">
 			<h1 class="title is-size-1">{{ $t( 'donation_form_section_email_title' ) }}</h1>
 			<email></email>
 		</div>
-		<newsletter-opt-in></newsletter-opt-in>
+		<newsletter-opt-in/>
 	</div>
 </template>
 
@@ -115,7 +115,7 @@ export default Vue.extend( {
 						validity[ fieldName ] = this.$store.state.membership_address.validity[ fieldName ] === Validity.INVALID;
 					}
 					return validity;
-                }, ( {} as AddressValidity ) );
+				}, ( {} as AddressValidity ) );
 			},
 		},
 		...mapGetters( NS_MEMBERSHIP_ADDRESS, [
@@ -128,7 +128,7 @@ export default Vue.extend( {
 		},
 		onFieldChange( fieldName: string ): void {
 			this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setAddressField ), this.formData[ fieldName ] );
-        },
+		},
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -12,7 +12,6 @@
 			<h1 class="title is-size-1">{{ $t( 'donation_form_section_email_title' ) }}</h1>
 			<email></email>
 		</div>
-		<newsletter-opt-in/>
 	</div>
 </template>
 
@@ -25,7 +24,6 @@ import Postal from '@/components/pages/donation_form/Postal.vue';
 import DateOfBirth from '@/components/pages/donation_form/DateOfBirth.vue';
 import ReceiptOptOut from '@/components/pages/donation_form/ReceiptOptOut.vue';
 import Email from '@/components/pages/donation_form/Email.vue';
-import NewsletterOptIn from '@/components/pages/donation_form/NewsletterOptIn.vue';
 import { AddressValidity, FormData, ValidationResult } from '@/view_models/Address';
 import { Validity } from '@/view_models/Validity';
 import { NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
@@ -41,7 +39,6 @@ export default Vue.extend( {
 		ReceiptOptOut,
 		AddressType,
 		Email,
-		NewsletterOptIn,
 	},
 	data: function (): { formData: FormData } {
 		return {

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -1,0 +1,154 @@
+<template>
+	<div id="addressForm" class="column is-full">
+		<div class="has-margin-top-18">
+			<h1 class="title is-size-1">{{ $t( 'donation_form_section_address_title' ) }}</h1>
+			<address-type></address-type>
+		</div>
+		<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
+		<postal :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"></postal>
+		<date-of-birth></date-of-birth>
+        <receipt-opt-out></receipt-opt-out>
+        <div class="has-margin-top-36">
+			<h1 class="title is-size-1">{{ $t( 'donation_form_section_email_title' ) }}</h1>
+			<email></email>
+		</div>
+		<newsletter-opt-in></newsletter-opt-in>
+	</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { mapGetters } from 'vuex';
+import AddressType from '@/components/pages/donation_form/AddressType.vue';
+import Name from '@/components/pages/donation_form/Name.vue';
+import Postal from '@/components/pages/donation_form/Postal.vue';
+import DateOfBirth from '@/components/pages/donation_form/DateOfBirth.vue';
+import ReceiptOptOut from '@/components/pages/donation_form/ReceiptOptOut.vue';
+import Email from '@/components/pages/donation_form/Email.vue';
+import NewsletterOptIn from '@/components/pages/donation_form/NewsletterOptIn.vue';
+import { AddressValidity, FormData, ValidationResult } from '@/view_models/Address';
+import { Validity } from '@/view_models/Validity';
+import { NS_ADDRESS } from '@/store/namespaces';
+import { setAddressField, validateAddress } from '@/store/address/actionTypes';
+import { action } from '@/store/util';
+
+export default Vue.extend( {
+	name: 'Address',
+	components: {
+		Name,
+        Postal,
+        DateOfBirth,
+        ReceiptOptOut,
+		AddressType,
+		Email,
+		NewsletterOptIn,
+	},
+	data: function (): { formData: FormData } {
+		return {
+			formData: {
+				salutation: {
+					name: 'salutation',
+					value: '',
+					pattern: '^(Herr|Frau)$',
+					optionalField: false,
+				},
+				title: {
+					name: 'title',
+					value: '',
+					pattern: '',
+					optionalField: true,
+				},
+				companyName: {
+					name: 'companyName',
+					value: '',
+					pattern: '^.+$',
+					optionalField: false,
+				},
+				firstName: {
+					name: 'firstName',
+					value: '',
+					pattern: '^.+$',
+					optionalField: false,
+				},
+				lastName: {
+					name: 'lastName',
+					value: '',
+					pattern: '^.+$',
+					optionalField: false,
+				},
+				street: {
+					name: 'street',
+					value: '',
+					pattern: '^.+$',
+					optionalField: false,
+				},
+				city: {
+					name: 'city',
+					value: '',
+					pattern: '^.+$',
+					optionalField: false,
+				},
+				postcode: {
+					name: 'postcode',
+					value: '',
+					pattern: '^[0-9]{4,5}$',
+					optionalField: false,
+				},
+				country: {
+					name: 'country',
+					value: 'DE',
+					pattern: '',
+					optionalField: false,
+				},
+			},
+		};
+	},
+	props: {
+		validateAddressUrl: String,
+		countries: Array as () => Array<String>,
+	},
+	computed: {
+		fieldErrors: {
+			get: function (): AddressValidity {
+                /*uncomment when membership store is developed
+				return Object.keys( this.formData ).reduce( ( validity: AddressValidity, fieldName: string ) => {
+					if ( !this.formData[ fieldName ].optionalField ) {
+						validity[ fieldName ] = this.$store.state.address.validity[ fieldName ] === Validity.INVALID;
+					}
+					return validity;
+                }, ( {} as AddressValidity ) );
+                */
+			},
+        },
+        ...mapGetters( NS_ADDRESS, [
+			'addressType',
+		] ),
+	},
+	methods: {
+        /* uncomment when membership store is developed
+		validateForm(): Promise<ValidationResult> {
+			return this.$store.dispatch( action( NS_ADDRESS, validateAddress ), this.$props.validateAddressUrl );
+		},
+		onFieldChange( fieldName: string ): void {
+			//this.$store.dispatch( action( NS_ADDRESS, setAddressField ), this.formData[ fieldName ] );
+        },
+        */
+	},
+} );
+</script>
+<style lang="scss" scoped>
+    @import "../../../scss/custom";
+
+    button.is-main {
+        height: 54px;
+        font-size: 1em;
+        font-weight: bold;
+        width: 250px;
+        border-radius: 0;
+    }
+    @include until($tablet) {
+        button.is-main {
+            width: 100%;
+        }
+    }
+</style>

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -15,7 +15,7 @@ export default Vue.extend( {
 	name: 'AddressPage',
 	components: {
 		MembershipType,
-		AddressFields
+		AddressFields,
 	},
 	props: {
 		validateAddressUrl: String,

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -1,17 +1,26 @@
 <template>
     <div class="column is-full">
         <membership-type></membership-type>
+		<address-fields v-bind="$props" ref="address"></address-fields>
     </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import MembershipType from '@/components/pages/membership_form//MembershipType.vue';
+import AddressFields from '@/components/pages/membership_form/Address.vue';
+import { TrackingData } from '@/view_models/SubmitValues';
 
 export default Vue.extend( {
 	name: 'AddressPage',
 	components: {
 		MembershipType,
+		AddressFields
+	},
+	props: {
+		validateAddressUrl: String,
+		countries: Array as () => Array<String>,
+		trackingData: Object as () => TrackingData,
 	},
 } );
 </script>

--- a/skins/laika/src/store/membership_address/actionTypes.ts
+++ b/skins/laika/src/store/membership_address/actionTypes.ts
@@ -2,5 +2,6 @@ export const validateAddress = 'validateAddress';
 export const setAddressField = 'setAddressField';
 export const setAddressType = 'setAddressType';
 export const setEmail = 'setEmail';
+export const setDate = 'setDate';
 export const setNewsletterOptIn = 'setNewsletterOptIn';
 export const setReceiptOptOut = 'setReceiptOptOut';

--- a/skins/laika/src/store/membership_address/actionTypes.ts
+++ b/skins/laika/src/store/membership_address/actionTypes.ts
@@ -1,0 +1,6 @@
+export const validateAddress = 'validateAddress';
+export const setAddressField = 'setAddressField';
+export const setAddressType = 'setAddressType';
+export const setEmail = 'setEmail';
+export const setNewsletterOptIn = 'setNewsletterOptIn';
+export const setReceiptOptOut = 'setReceiptOptOut';

--- a/skins/laika/src/store/membership_address/actionTypes.ts
+++ b/skins/laika/src/store/membership_address/actionTypes.ts
@@ -3,5 +3,4 @@ export const setAddressField = 'setAddressField';
 export const setAddressType = 'setAddressType';
 export const setEmail = 'setEmail';
 export const setDate = 'setDate';
-export const setNewsletterOptIn = 'setNewsletterOptIn';
 export const setReceiptOptOut = 'setReceiptOptOut';

--- a/skins/laika/src/store/membership_address/actions.ts
+++ b/skins/laika/src/store/membership_address/actions.ts
@@ -1,0 +1,51 @@
+import { ActionContext } from 'vuex';
+import axios, { AxiosResponse } from 'axios';
+import {
+	validateAddress,
+	setAddressType,
+	setEmail,
+	setNewsletterOptIn, setAddressField,
+} from '@/store/address/actionTypes';
+import { AddressState, InputField, Payload } from '@/view_models/Address';
+import { ValidationResponse } from '@/store/ValidationResponse';
+import { AddressTypeModel, addressTypeName } from '@/view_models/AddressTypeModel';
+import { MARK_EMPTY_FIELDS_INVALID } from '@/store/address/mutationTypes';
+
+export const actions = {
+	[ setAddressField ]( context: ActionContext<AddressState, any>, field: InputField ) {
+		context.commit( 'SET_ADDRESS_FIELD', field );
+		context.commit( 'VALIDATE_INPUT', field );
+	},
+	[ validateAddress ]( context: ActionContext<AddressState, any>, validateAddressUrl: string ) {
+		context.commit( MARK_EMPTY_FIELDS_INVALID );
+		if ( !context.getters.requiredFieldsAreValid ) {
+			return Promise.resolve( { status: 'ERR', messages: [] } );
+		}
+
+		context.commit( 'BEGIN_ADDRESS_VALIDATION' );
+		const bodyFormData = new FormData();
+		Object.keys( context.state.values ).forEach(
+			field => bodyFormData.append( field, context.state.values[ field ] )
+		);
+		bodyFormData.append( 'addressType', addressTypeName( context.state.addressType ) );
+		return axios( validateAddressUrl, {
+			method: 'post',
+			data: bodyFormData,
+			headers: { 'Content-Type': 'multipart/form-data' },
+		} ).then( ( validationResult: AxiosResponse<ValidationResponse> ) => {
+			context.commit( 'FINISH_ADDRESS_VALIDATION', validationResult.data );
+			return validationResult.data;
+		} );
+
+	},
+	[ setAddressType ]( context: ActionContext<AddressState, any>, type: AddressTypeModel ) {
+		context.commit( 'SET_ADDRESS_TYPE', type );
+	},
+	[ setEmail ]( context: ActionContext<AddressState, any>, email: string ) {
+		context.commit( 'SET_EMAIL', email );
+	},
+	[ setNewsletterOptIn ]( context: ActionContext<AddressState, any>, optIn: boolean ) {
+		context.commit( 'SET_NEWSLETTER_OPTIN', optIn );
+	},
+
+};

--- a/skins/laika/src/store/membership_address/actions.ts
+++ b/skins/laika/src/store/membership_address/actions.ts
@@ -9,17 +9,17 @@ import {
 	setReceiptOptOut,
 	setDate,
 } from '@/store/membership_address/actionTypes';
-import { AddressState, InputField, Payload } from '@/view_models/Address';
+import { MembershipAddressState, InputField, Payload } from '@/view_models/Address';
 import { ValidationResponse } from '@/store/ValidationResponse';
 import { AddressTypeModel, addressTypeName } from '@/view_models/AddressTypeModel';
 import { MARK_EMPTY_FIELDS_INVALID } from '@/store/membership_address/mutationTypes';
 
 export const actions = {
-	[ setAddressField ]( context: ActionContext<AddressState, any>, field: InputField ) {
+	[ setAddressField ]( context: ActionContext<MembershipAddressState, any>, field: InputField ) {
 		context.commit( 'SET_ADDRESS_FIELD', field );
 		context.commit( 'VALIDATE_INPUT', field );
 	},
-	[ validateAddress ]( context: ActionContext<AddressState, any>, validateAddressUrl: string ) {
+	[ validateAddress ]( context: ActionContext<MembershipAddressState, any>, validateAddressUrl: string ) {
 		context.commit( MARK_EMPTY_FIELDS_INVALID );
 		if ( !context.getters.requiredFieldsAreValid ) {
 			return Promise.resolve( { status: 'ERR', messages: [] } );
@@ -41,19 +41,19 @@ export const actions = {
 		} );
 
 	},
-	[ setAddressType ]( context: ActionContext<AddressState, any>, type: AddressTypeModel ) {
+	[ setAddressType ]( context: ActionContext<MembershipAddressState, any>, type: AddressTypeModel ) {
 		context.commit( 'SET_ADDRESS_TYPE', type );
 	},
-	[ setEmail ]( context: ActionContext<AddressState, any>, email: string ) {
+	[ setEmail ]( context: ActionContext<MembershipAddressState, any>, email: string ) {
 		context.commit( 'SET_EMAIL', email );
 	},
-	[ setDate ]( context: ActionContext<AddressState, any>, date: string ) {
+	[ setDate ]( context: ActionContext<MembershipAddressState, any>, date: string ) {
 		context.commit( 'SET_DATE', date );
 	},
-	[ setNewsletterOptIn ]( context: ActionContext<AddressState, any>, optIn: boolean ) {
+	[ setNewsletterOptIn ]( context: ActionContext<MembershipAddressState, any>, optIn: boolean ) {
 		context.commit( 'SET_NEWSLETTER_OPTIN', optIn );
 	},
-	[ setReceiptOptOut ]( context: ActionContext<AddressState, any>, optOut: boolean ) {
+	[ setReceiptOptOut ]( context: ActionContext<MembershipAddressState, any>, optOut: boolean ) {
 		context.commit( 'SET_RECEIPT_OPTOUT', optOut );
 	},
 

--- a/skins/laika/src/store/membership_address/actions.ts
+++ b/skins/laika/src/store/membership_address/actions.ts
@@ -4,12 +4,14 @@ import {
 	validateAddress,
 	setAddressType,
 	setEmail,
-	setNewsletterOptIn, setAddressField,
-} from '@/store/address/actionTypes';
+	setNewsletterOptIn,
+	setAddressField,
+	setReceiptOptOut,
+} from '@/store/membership_address/actionTypes';
 import { AddressState, InputField, Payload } from '@/view_models/Address';
 import { ValidationResponse } from '@/store/ValidationResponse';
 import { AddressTypeModel, addressTypeName } from '@/view_models/AddressTypeModel';
-import { MARK_EMPTY_FIELDS_INVALID } from '@/store/address/mutationTypes';
+import { MARK_EMPTY_FIELDS_INVALID } from '@/store/membership_address/mutationTypes';
 
 export const actions = {
 	[ setAddressField ]( context: ActionContext<AddressState, any>, field: InputField ) {
@@ -46,6 +48,9 @@ export const actions = {
 	},
 	[ setNewsletterOptIn ]( context: ActionContext<AddressState, any>, optIn: boolean ) {
 		context.commit( 'SET_NEWSLETTER_OPTIN', optIn );
+	},
+	[ setReceiptOptOut ]( context: ActionContext<AddressState, any>, optOut: boolean ) {
+		context.commit( 'SET_RECEIPT_OPTOUT', optOut );
 	},
 
 };

--- a/skins/laika/src/store/membership_address/actions.ts
+++ b/skins/laika/src/store/membership_address/actions.ts
@@ -4,7 +4,6 @@ import {
 	validateAddress,
 	setAddressType,
 	setEmail,
-	setNewsletterOptIn,
 	setAddressField,
 	setReceiptOptOut,
 	setDate,
@@ -49,9 +48,6 @@ export const actions = {
 	},
 	[ setDate ]( context: ActionContext<MembershipAddressState, any>, date: string ) {
 		context.commit( 'SET_DATE', date );
-	},
-	[ setNewsletterOptIn ]( context: ActionContext<MembershipAddressState, any>, optIn: boolean ) {
-		context.commit( 'SET_NEWSLETTER_OPTIN', optIn );
 	},
 	[ setReceiptOptOut ]( context: ActionContext<MembershipAddressState, any>, optOut: boolean ) {
 		context.commit( 'SET_RECEIPT_OPTOUT', optOut );

--- a/skins/laika/src/store/membership_address/actions.ts
+++ b/skins/laika/src/store/membership_address/actions.ts
@@ -7,6 +7,7 @@ import {
 	setNewsletterOptIn,
 	setAddressField,
 	setReceiptOptOut,
+	setDate,
 } from '@/store/membership_address/actionTypes';
 import { AddressState, InputField, Payload } from '@/view_models/Address';
 import { ValidationResponse } from '@/store/ValidationResponse';
@@ -45,6 +46,9 @@ export const actions = {
 	},
 	[ setEmail ]( context: ActionContext<AddressState, any>, email: string ) {
 		context.commit( 'SET_EMAIL', email );
+	},
+	[ setDate ]( context: ActionContext<AddressState, any>, date: string ) {
+		context.commit( 'SET_DATE', date );
 	},
 	[ setNewsletterOptIn ]( context: ActionContext<AddressState, any>, optIn: boolean ) {
 		context.commit( 'SET_NEWSLETTER_OPTIN', optIn );

--- a/skins/laika/src/store/membership_address/constants.ts
+++ b/skins/laika/src/store/membership_address/constants.ts
@@ -1,0 +1,7 @@
+import { AddressTypeModel } from '@/view_models/AddressTypeModel';
+
+export const REQUIRED_FIELDS: {[key: number]: string[]} = {
+	[ AddressTypeModel.PERSON ]: [ 'salutation', 'firstName', 'lastName', 'street', 'postcode', 'city', 'email' ],
+	[ AddressTypeModel.COMPANY ]: [ 'companyName', 'street', 'postcode', 'city', 'email' ],
+	[ AddressTypeModel.ANON ]: [],
+};

--- a/skins/laika/src/store/membership_address/getters.ts
+++ b/skins/laika/src/store/membership_address/getters.ts
@@ -1,0 +1,24 @@
+import { GetterTree } from 'vuex';
+import { AddressState } from '@/view_models/Address';
+import { Validity } from '@/view_models/Validity';
+import { AddressTypeModel } from '@/view_models/AddressTypeModel';
+import { REQUIRED_FIELDS } from '@/store/address/constants';
+
+export const getters: GetterTree<AddressState, any> = {
+	invalidFields: ( state: AddressState ): Array<string> => {
+		return REQUIRED_FIELDS[ state.addressType ].filter( fieldName => state.validity[ fieldName ] !== Validity.VALID );
+	},
+	requiredFieldsAreValid: ( state: AddressState, getters: GetterTree<AddressState, any> ): boolean => {
+		return getters.invalidFields.length === 0;
+	},
+	addressType: ( state: AddressState ): AddressTypeModel => state.addressType,
+	fullName: ( state: AddressState ): string => {
+		// Duplicating code from DonorName PHP class
+		const address = state.values;
+		const nonEmpty = ( v: string ): boolean => !!v;
+		const companyName = state.addressType === AddressTypeModel.COMPANY ? address.companyName : '';
+		// remove ternary operator in the following line when we implement contact person, https://phabricator.wikimedia.org/T220366
+		const privateName = state.addressType === AddressTypeModel.PERSON ? [ address.title, address.firstName, address.lastName ].filter( nonEmpty ).join( ' ' ) : '';
+		return [ companyName, privateName ].filter( nonEmpty ).join( ', ' );
+	},
+};

--- a/skins/laika/src/store/membership_address/getters.ts
+++ b/skins/laika/src/store/membership_address/getters.ts
@@ -1,18 +1,18 @@
 import { GetterTree } from 'vuex';
-import { AddressState } from '@/view_models/Address';
+import { MembershipAddressState } from '@/view_models/Address';
 import { Validity } from '@/view_models/Validity';
 import { AddressTypeModel } from '@/view_models/AddressTypeModel';
 import { REQUIRED_FIELDS } from '@/store/address/constants';
 
-export const getters: GetterTree<AddressState, any> = {
-	invalidFields: ( state: AddressState ): Array<string> => {
+export const getters: GetterTree<MembershipAddressState, any> = {
+	invalidFields: ( state: MembershipAddressState ): Array<string> => {
 		return REQUIRED_FIELDS[ state.addressType ].filter( fieldName => state.validity[ fieldName ] !== Validity.VALID );
 	},
-	requiredFieldsAreValid: ( state: AddressState, getters: GetterTree<AddressState, any> ): boolean => {
+	requiredFieldsAreValid: ( state: MembershipAddressState, getters: GetterTree<MembershipAddressState, any> ): boolean => {
 		return getters.invalidFields.length === 0;
 	},
-	addressType: ( state: AddressState ): AddressTypeModel => state.addressType,
-	fullName: ( state: AddressState ): string => {
+	addressType: ( state: MembershipAddressState ): AddressTypeModel => state.addressType,
+	fullName: ( state: MembershipAddressState ): string => {
 		// Duplicating code from DonorName PHP class
 		const address = state.values;
 		const nonEmpty = ( v: string ): boolean => !!v;

--- a/skins/laika/src/store/membership_address/index.ts
+++ b/skins/laika/src/store/membership_address/index.ts
@@ -11,6 +11,7 @@ export default function (): Module<AddressState, any> {
 		isValidating: false,
 		addressType: AddressTypeModel.PERSON,
 		newsletterOptIn: false,
+		receiptOptOut: false,
 		values: {
 			salutation: '',
 			title: '',

--- a/skins/laika/src/store/membership_address/index.ts
+++ b/skins/laika/src/store/membership_address/index.ts
@@ -23,6 +23,7 @@ export default function (): Module<AddressState, any> {
 			city: '',
 			country: 'DE',
 			email: '',
+			date: '',
 		},
 		validity: {
 			salutation: Validity.INCOMPLETE,
@@ -35,6 +36,7 @@ export default function (): Module<AddressState, any> {
 			city: Validity.INCOMPLETE,
 			country: Validity.VALID,
 			email: Validity.INCOMPLETE,
+			date: Validity.VALID,
 			addressType: Validity.VALID,
 		},
 	};

--- a/skins/laika/src/store/membership_address/index.ts
+++ b/skins/laika/src/store/membership_address/index.ts
@@ -10,7 +10,6 @@ export default function (): Module<MembershipAddressState, any> {
 	const state: MembershipAddressState = {
 		isValidating: false,
 		addressType: AddressTypeModel.PERSON,
-		newsletterOptIn: false,
 		receiptOptOut: false,
 		values: {
 			salutation: '',

--- a/skins/laika/src/store/membership_address/index.ts
+++ b/skins/laika/src/store/membership_address/index.ts
@@ -1,13 +1,13 @@
 import { Module } from 'vuex';
-import { AddressState } from '@/view_models/Address';
+import { MembershipAddressState } from '@/view_models/Address';
 import { Validity } from '@/view_models/Validity';
 import { actions } from '@/store/membership_address/actions';
 import { getters } from '@/store/membership_address/getters';
 import { mutations } from '@/store/membership_address/mutations';
 import { AddressTypeModel } from '@/view_models/AddressTypeModel';
 
-export default function (): Module<AddressState, any> {
-	const state: AddressState = {
+export default function (): Module<MembershipAddressState, any> {
+	const state: MembershipAddressState = {
 		isValidating: false,
 		addressType: AddressTypeModel.PERSON,
 		newsletterOptIn: false,

--- a/skins/laika/src/store/membership_address/index.ts
+++ b/skins/laika/src/store/membership_address/index.ts
@@ -1,0 +1,50 @@
+import { Module } from 'vuex';
+import { AddressState } from '@/view_models/Address';
+import { Validity } from '@/view_models/Validity';
+import { actions } from '@/store/membership_address/actions';
+import { getters } from '@/store/membership_address/getters';
+import { mutations } from '@/store/membership_address/mutations';
+import { AddressTypeModel } from '@/view_models/AddressTypeModel';
+
+export default function (): Module<AddressState, any> {
+	const state: AddressState = {
+		isValidating: false,
+		addressType: AddressTypeModel.PERSON,
+		newsletterOptIn: false,
+		values: {
+			salutation: '',
+			title: '',
+			firstName: '',
+			lastName: '',
+			companyName: '',
+			street: '',
+			postcode: '',
+			city: '',
+			country: 'DE',
+			email: '',
+		},
+		validity: {
+			salutation: Validity.INCOMPLETE,
+			title: Validity.VALID,
+			firstName: Validity.INCOMPLETE,
+			lastName: Validity.INCOMPLETE,
+			companyName: Validity.INCOMPLETE,
+			street: Validity.INCOMPLETE,
+			postcode: Validity.INCOMPLETE,
+			city: Validity.INCOMPLETE,
+			country: Validity.VALID,
+			email: Validity.INCOMPLETE,
+			addressType: Validity.VALID,
+		},
+	};
+
+	const namespaced = true;
+
+	return {
+		namespaced,
+		state,
+		getters,
+		mutations,
+		actions,
+	};
+}

--- a/skins/laika/src/store/membership_address/mutationTypes.ts
+++ b/skins/laika/src/store/membership_address/mutationTypes.ts
@@ -7,5 +7,4 @@ export const SET_ADDRESS_FIELDS: string = 'SET_ADDRESS_FIELDS';
 export const SET_ADDRESS_FIELD: string = 'SET_ADDRESS_FIELD';
 export const SET_EMAIL: string = 'SET_EMAIL';
 export const SET_DATE: string = 'SET_DATE';
-export const SET_NEWSLETTER_OPTIN: string = 'SET_NEWSLETTER_OPTIN';
 export const SET_RECEIPT_OPTOUT: string = 'SET_RECEIPT_OPTOUT';

--- a/skins/laika/src/store/membership_address/mutationTypes.ts
+++ b/skins/laika/src/store/membership_address/mutationTypes.ts
@@ -6,5 +6,6 @@ export const SET_ADDRESS_TYPE: string = 'SET_ADDRESS_TYPE';
 export const SET_ADDRESS_FIELDS: string = 'SET_ADDRESS_FIELDS';
 export const SET_ADDRESS_FIELD: string = 'SET_ADDRESS_FIELD';
 export const SET_EMAIL: string = 'SET_EMAIL';
+export const SET_DATE: string = 'SET_DATE';
 export const SET_NEWSLETTER_OPTIN: string = 'SET_NEWSLETTER_OPTIN';
 export const SET_RECEIPT_OPTOUT: string = 'SET_RECEIPT_OPTOUT';

--- a/skins/laika/src/store/membership_address/mutationTypes.ts
+++ b/skins/laika/src/store/membership_address/mutationTypes.ts
@@ -1,0 +1,10 @@
+export const VALIDATE_INPUT: string = 'VALIDATE_INPUT';
+export const MARK_EMPTY_FIELDS_INVALID: string = 'MARK_EMPTY_FIELDS_INVALID';
+export const BEGIN_ADDRESS_VALIDATION: string = 'BEGIN_ADDRESS_VALIDATION';
+export const FINISH_ADDRESS_VALIDATION: string = 'FINISH_ADDRESS_VALIDATION';
+export const SET_ADDRESS_TYPE: string = 'SET_ADDRESS_TYPE';
+export const SET_ADDRESS_FIELDS: string = 'SET_ADDRESS_FIELDS';
+export const SET_ADDRESS_FIELD: string = 'SET_ADDRESS_FIELD';
+export const SET_EMAIL: string = 'SET_EMAIL';
+export const SET_NEWSLETTER_OPTIN: string = 'SET_NEWSLETTER_OPTIN';
+export const SET_RECEIPT_OPTOUT: string = 'SET_RECEIPT_OPTOUT';

--- a/skins/laika/src/store/membership_address/mutations.ts
+++ b/skins/laika/src/store/membership_address/mutations.ts
@@ -10,6 +10,7 @@ import {
 	SET_ADDRESS_FIELD,
 	SET_ADDRESS_FIELDS,
 	SET_EMAIL,
+	SET_DATE,
 	SET_NEWSLETTER_OPTIN,
 	SET_RECEIPT_OPTOUT,
 } from '@/store/membership_address/mutationTypes';
@@ -62,6 +63,10 @@ export const mutations: MutationTree<AddressState> = {
 	[ SET_EMAIL ]( state: AddressState, email ) {
 		state.values.email = email;
 		state.validity.email = Validity.VALID;
+	},
+	[ SET_DATE ]( state: AddressState, date ) {
+		state.values.date = date;
+		state.validity.date = Validity.VALID;
 	},
 	[ SET_NEWSLETTER_OPTIN ]( state: AddressState, optIn ) {
 		state.newsletterOptIn = optIn;

--- a/skins/laika/src/store/membership_address/mutations.ts
+++ b/skins/laika/src/store/membership_address/mutations.ts
@@ -1,0 +1,68 @@
+import { MutationTree } from 'vuex';
+import { Validity } from '@/view_models/Validity';
+import { Helper } from '@/store/util';
+import {
+	VALIDATE_INPUT,
+	MARK_EMPTY_FIELDS_INVALID,
+	BEGIN_ADDRESS_VALIDATION,
+	FINISH_ADDRESS_VALIDATION,
+	SET_ADDRESS_TYPE,
+	SET_ADDRESS_FIELD,
+	SET_ADDRESS_FIELDS,
+	SET_EMAIL,
+	SET_NEWSLETTER_OPTIN,
+} from '@/store/address/mutationTypes';
+import { AddressState, InputField } from '@/view_models/Address';
+import { REQUIRED_FIELDS } from '@/store/address/constants';
+
+export const mutations: MutationTree<AddressState> = {
+	[ VALIDATE_INPUT ]( state: AddressState, field: InputField ) {
+		if ( field.value === '' && field.optionalField ) {
+			state.validity[ field.name ] = Validity.INCOMPLETE;
+		} else {
+			state.validity[ field.name ] = Helper.inputIsValid( field.value, field.pattern );
+		}
+	},
+	[ MARK_EMPTY_FIELDS_INVALID ]( state: AddressState ) {
+		REQUIRED_FIELDS[ state.addressType ].forEach( ( fieldName: string ) => {
+			if ( state.validity[ fieldName ] === Validity.INCOMPLETE ) {
+				state.validity[ fieldName ] = Validity.INVALID;
+			}
+		} );
+	},
+	[ BEGIN_ADDRESS_VALIDATION ]( state: AddressState ) {
+		state.isValidating = true;
+	},
+	[ FINISH_ADDRESS_VALIDATION ]( state: AddressState, payload ) {
+		state.isValidating = false;
+		if ( payload.status === 'OK' ) {
+			return;
+		}
+		REQUIRED_FIELDS[ state.addressType ].forEach( name => {
+			if ( payload.messages[ name ] ) {
+				state.validity[ name ] = Validity.INVALID;
+			}
+		} );
+	},
+	[ SET_ADDRESS_TYPE ]( state: AddressState, type ) {
+		state.addressType = type;
+	},
+	[ SET_ADDRESS_FIELDS ]( state: AddressState, fields ) {
+		Object.keys( fields ).forEach( ( field: string ) => {
+			const fieldName = fields[ field ];
+			if ( state.validity[ fieldName.name ] !== Validity.INVALID ) {
+				state.values[ fieldName.name ] = fieldName.value;
+			}
+		} );
+	},
+	[ SET_ADDRESS_FIELD ]( state: AddressState, field: InputField ) {
+		state.values[ field.name ] = field.value;
+	},
+	[ SET_EMAIL ]( state: AddressState, email ) {
+		state.values.email = email;
+		state.validity.email = Validity.VALID;
+	},
+	[ SET_NEWSLETTER_OPTIN ]( state: AddressState, optIn ) {
+		state.newsletterOptIn = optIn;
+	},
+};

--- a/skins/laika/src/store/membership_address/mutations.ts
+++ b/skins/laika/src/store/membership_address/mutations.ts
@@ -14,28 +14,28 @@ import {
 	SET_NEWSLETTER_OPTIN,
 	SET_RECEIPT_OPTOUT,
 } from '@/store/membership_address/mutationTypes';
-import { AddressState, InputField } from '@/view_models/Address';
+import { MembershipAddressState, InputField } from '@/view_models/Address';
 import { REQUIRED_FIELDS } from '@/store/membership_address/constants';
 
-export const mutations: MutationTree<AddressState> = {
-	[ VALIDATE_INPUT ]( state: AddressState, field: InputField ) {
+export const mutations: MutationTree<MembershipAddressState> = {
+	[ VALIDATE_INPUT ]( state: MembershipAddressState, field: InputField ) {
 		if ( field.value === '' && field.optionalField ) {
 			state.validity[ field.name ] = Validity.INCOMPLETE;
 		} else {
 			state.validity[ field.name ] = Helper.inputIsValid( field.value, field.pattern );
 		}
 	},
-	[ MARK_EMPTY_FIELDS_INVALID ]( state: AddressState ) {
+	[ MARK_EMPTY_FIELDS_INVALID ]( state: MembershipAddressState ) {
 		REQUIRED_FIELDS[ state.addressType ].forEach( ( fieldName: string ) => {
 			if ( state.validity[ fieldName ] === Validity.INCOMPLETE ) {
 				state.validity[ fieldName ] = Validity.INVALID;
 			}
 		} );
 	},
-	[ BEGIN_ADDRESS_VALIDATION ]( state: AddressState ) {
+	[ BEGIN_ADDRESS_VALIDATION ]( state: MembershipAddressState ) {
 		state.isValidating = true;
 	},
-	[ FINISH_ADDRESS_VALIDATION ]( state: AddressState, payload ) {
+	[ FINISH_ADDRESS_VALIDATION ]( state: MembershipAddressState, payload ) {
 		state.isValidating = false;
 		if ( payload.status === 'OK' ) {
 			return;
@@ -46,10 +46,10 @@ export const mutations: MutationTree<AddressState> = {
 			}
 		} );
 	},
-	[ SET_ADDRESS_TYPE ]( state: AddressState, type ) {
+	[ SET_ADDRESS_TYPE ]( state: MembershipAddressState, type ) {
 		state.addressType = type;
 	},
-	[ SET_ADDRESS_FIELDS ]( state: AddressState, fields ) {
+	[ SET_ADDRESS_FIELDS ]( state: MembershipAddressState, fields ) {
 		Object.keys( fields ).forEach( ( field: string ) => {
 			const fieldName = fields[ field ];
 			if ( state.validity[ fieldName.name ] !== Validity.INVALID ) {
@@ -57,21 +57,21 @@ export const mutations: MutationTree<AddressState> = {
 			}
 		} );
 	},
-	[ SET_ADDRESS_FIELD ]( state: AddressState, field: InputField ) {
+	[ SET_ADDRESS_FIELD ]( state: MembershipAddressState, field: InputField ) {
 		state.values[ field.name ] = field.value;
 	},
-	[ SET_EMAIL ]( state: AddressState, email ) {
+	[ SET_EMAIL ]( state: MembershipAddressState, email ) {
 		state.values.email = email;
 		state.validity.email = Validity.VALID;
 	},
-	[ SET_DATE ]( state: AddressState, date ) {
+	[ SET_DATE ]( state: MembershipAddressState, date ) {
 		state.values.date = date;
 		state.validity.date = Validity.VALID;
 	},
-	[ SET_NEWSLETTER_OPTIN ]( state: AddressState, optIn ) {
+	[ SET_NEWSLETTER_OPTIN ]( state: MembershipAddressState, optIn ) {
 		state.newsletterOptIn = optIn;
 	},
-	[ SET_RECEIPT_OPTOUT ]( state: AddressState, optOut ) {
+	[ SET_RECEIPT_OPTOUT ]( state: MembershipAddressState, optOut ) {
 		state.receiptOptOut = optOut;
 	},
 };

--- a/skins/laika/src/store/membership_address/mutations.ts
+++ b/skins/laika/src/store/membership_address/mutations.ts
@@ -11,7 +11,6 @@ import {
 	SET_ADDRESS_FIELDS,
 	SET_EMAIL,
 	SET_DATE,
-	SET_NEWSLETTER_OPTIN,
 	SET_RECEIPT_OPTOUT,
 } from '@/store/membership_address/mutationTypes';
 import { MembershipAddressState, InputField } from '@/view_models/Address';
@@ -67,9 +66,6 @@ export const mutations: MutationTree<MembershipAddressState> = {
 	[ SET_DATE ]( state: MembershipAddressState, date ) {
 		state.values.date = date;
 		state.validity.date = Validity.VALID;
-	},
-	[ SET_NEWSLETTER_OPTIN ]( state: MembershipAddressState, optIn ) {
-		state.newsletterOptIn = optIn;
 	},
 	[ SET_RECEIPT_OPTOUT ]( state: MembershipAddressState, optOut ) {
 		state.receiptOptOut = optOut;

--- a/skins/laika/src/store/membership_address/mutations.ts
+++ b/skins/laika/src/store/membership_address/mutations.ts
@@ -11,9 +11,10 @@ import {
 	SET_ADDRESS_FIELDS,
 	SET_EMAIL,
 	SET_NEWSLETTER_OPTIN,
-} from '@/store/address/mutationTypes';
+	SET_RECEIPT_OPTOUT,
+} from '@/store/membership_address/mutationTypes';
 import { AddressState, InputField } from '@/view_models/Address';
-import { REQUIRED_FIELDS } from '@/store/address/constants';
+import { REQUIRED_FIELDS } from '@/store/membership_address/constants';
 
 export const mutations: MutationTree<AddressState> = {
 	[ VALIDATE_INPUT ]( state: AddressState, field: InputField ) {
@@ -64,5 +65,8 @@ export const mutations: MutationTree<AddressState> = {
 	},
 	[ SET_NEWSLETTER_OPTIN ]( state: AddressState, optIn ) {
 		state.newsletterOptIn = optIn;
+	},
+	[ SET_RECEIPT_OPTOUT ]( state: AddressState, optOut ) {
+		state.receiptOptOut = optOut;
 	},
 };

--- a/skins/laika/src/store/membership_store.ts
+++ b/skins/laika/src/store/membership_store.ts
@@ -1,10 +1,17 @@
 import Vue from 'vue';
 import Vuex, { StoreOptions } from 'vuex';
+import createAddress from '@/store/membership_address';
+import {
+	NS_MEMBERSHIP_ADDRESS,
+} from './namespaces';
 
 Vue.use( Vuex );
 
 export function createStore() {
 	const storeBundle: StoreOptions<any> = {
+		modules: {
+			[ NS_MEMBERSHIP_ADDRESS ]: createAddress(),
+		},
 		strict: process.env.NODE_ENV !== 'production',
 	};
 

--- a/skins/laika/src/store/namespaces.ts
+++ b/skins/laika/src/store/namespaces.ts
@@ -1,2 +1,3 @@
 export const NS_PAYMENT = 'payment';
 export const NS_ADDRESS = 'address';
+export const NS_MEMBERSHIP_ADDRESS = 'membership_address';

--- a/skins/laika/src/view_models/Address.ts
+++ b/skins/laika/src/view_models/Address.ts
@@ -35,7 +35,6 @@ export interface AddressState {
 export interface MembershipAddressState {
     isValidating: boolean,
     addressType: AddressTypeModel,
-    newsletterOptIn: boolean,
     receiptOptOut: boolean,
     values: FormValues,
     validity: FormValidity,

--- a/skins/laika/src/view_models/Address.ts
+++ b/skins/laika/src/view_models/Address.ts
@@ -32,6 +32,15 @@ export interface AddressState {
     validity: FormValidity,
 }
 
+export interface MembershipAddressState {
+    isValidating: boolean,
+    addressType: AddressTypeModel,
+    newsletterOptIn: boolean,
+    receiptOptOut: boolean,
+    values: FormValues,
+    validity: FormValidity,
+}
+
 export interface InputField {
     name: string,
     value: string,


### PR DESCRIPTION
Feature: [T226928](https://phabricator.wikimedia.org/T226928)

- [x] Create Address parent component for membership and add all the needed address subcomponents to it
- [x] Create membership address store module and connect it to membership address form
- [x] Create Date of Birth component
- [x] Create Receipt Opt Out component

It'd be better if I do this last step in a separate PR as it will require a lot of files being moved to a new directory. That will bump the number of `Files changed` by a lot and will make this PR hard to review.
- [ ] Extract the components used both in donation and membership into a new shared folder
