### PR TITLE
Fix address update salutation field validation

### DIFF
--- a/skins/cat17/address-form/src/__tests__/components/Name.spec.ts
+++ b/skins/cat17/address-form/src/__tests__/components/Name.spec.ts
@@ -74,7 +74,6 @@ describe('Name.vue', () => {
 		});
 		let salutation = wrapper.find('#salutation');
 		salutation.setValue('Herr');
-		salutation.trigger('blur');
 		expect(props.validateInput.mock.calls.length).toBe(1);
 		expect(props.validateInput.mock.calls[0][0].salutation.value).toBe('Herr');
 	});
@@ -87,7 +86,6 @@ describe('Name.vue', () => {
 		});
 		let salutation = wrapper.find('#salutation');
 		salutation.setValue('');
-		salutation.trigger('blur');
 		expect(props.validateInput.mock.calls.length).toBe(1);
 		expect(props.validateInput.mock.calls[0][0].salutation.value).toBe('');
 	});

--- a/skins/cat17/address-form/src/components/Name.vue
+++ b/skins/cat17/address-form/src/components/Name.vue
@@ -18,6 +18,7 @@
 					v-model="salutation"
 					name="salutation"
 					data-jcf='{"wrapNative": false,  "wrapNativeOnMobile": true  }'
+					@change="updateJcfDropdown('salutation')"
 					@blur="updateJcfDropdown('salutation')">
 				<option hidden class="hideme" value="">{{ messages.salutation_label }}</option>
 				<option value="Herr">{{ messages.salutation_option_mr }}</option>
@@ -31,6 +32,7 @@
 					v-model="title"
 					name="title"
 					data-jcf='{"wrapNative": false, "wrapNativeOnMobile": true}'
+					@change="updateJcfDropdown('salutation')"
 					@blur="updateJcfDropdown('title')">
 				<option value="">{{ messages.title_option_none }}</option>
 				<option value="Dr.">Dr.</option>


### PR DESCRIPTION
Add `change` event handler to input field to remove the "please choose a
value" error message as soon as the user selects a value, not waiting
for the blur event.

This is for https://phabricator.wikimedia.org/T225481