### PR TITLE
Revert AddressType to not be a shared component

### DIFF
--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import AddressType from '@/components/shared/AddressType.vue';
+import AddressType from '@/components/pages/donation_form/AddressType.vue';
 import Name from '@/components/shared/Name.vue';
 import Postal from '@/components/shared/Postal.vue';
 import ReceiptOptOut from '@/components/shared/ReceiptOptOut.vue';

--- a/skins/laika/src/components/pages/donation_form/AddressType.vue
+++ b/skins/laika/src/components/pages/donation_form/AddressType.vue
@@ -1,0 +1,60 @@
+<template>
+	<fieldset>
+		<legend class="subtitle">{{ $t( 'donation_form_section_address_header_type' ) }}</legend>
+		<div>
+			<b-radio type="radio"
+					id="personal"
+					name="addressTypeInternal"
+					v-model="type"
+					:native-value="AddressTypeModel.PERSON"
+					@change.native="setAddressType()">{{ $t( 'donation_form_addresstype_option_private' ) }}
+			</b-radio>
+		</div>
+		<div>
+			<b-radio type="radio"
+					id="company"
+					name="addressTypeInternal"
+					v-model="type"
+					:native-value="AddressTypeModel.COMPANY"
+					@change.native="setAddressType()">
+				{{ $t( 'donation_form_addresstype_option_company' ) }}
+			</b-radio>
+		</div>
+		<div>
+			<b-radio type="radio"
+					id="anonymous"
+					name="addressTypeInternal"
+					v-model="type"
+					:native-value="AddressTypeModel.ANON"
+					@change.native="setAddressType()">
+				{{ $t( 'donation_form_addresstype_option_anonymous' ) }}
+			</b-radio>
+		</div>
+    </fieldset>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { AddressTypeModel } from '@/view_models/AddressTypeModel';
+
+export default Vue.extend( {
+	name: 'AddressType',
+	data: function () {
+		return {
+			type: AddressTypeModel.PERSON,
+		};
+	},
+	computed: {
+		AddressTypeModel: {
+			get: function () {
+				return AddressTypeModel;
+			},
+		},
+	},
+	methods: {
+		setAddressType: function () {
+			this.$emit( 'addressType', this.$data.type );
+		},
+	},
+} );
+</script>

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -18,7 +18,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { mapGetters } from 'vuex';
-import AddressType from '@/components/shared/AddressType.vue';
+import AddressType from '@/components/pages/membership_form/AddressType.vue';
 import Name from '@/components/shared/Name.vue';
 import Postal from '@/components/shared/Postal.vue';
 import DateOfBirth from '@/components/pages/membership_form/DateOfBirth.vue';

--- a/skins/laika/src/components/pages/membership_form/AddressType.vue
+++ b/skins/laika/src/components/pages/membership_form/AddressType.vue
@@ -1,6 +1,6 @@
 <template>
 	<fieldset>
-		<legend class="subtitle">{{ $t( 'donation_form_section_address_header_type' ) }}</legend>
+		<legend class="subtitle">{{ $t( 'membership_section_address_header_type' ) }}</legend>
 		<div>
 			<b-radio type="radio"
 					id="personal"
@@ -20,25 +20,12 @@
 				{{ $t( 'donation_form_addresstype_option_company' ) }}
 			</b-radio>
 		</div>
-		<div>
-			<b-radio type="radio"
-					id="anonymous"
-					name="addressTypeInternal"
-					v-model="type"
-					:native-value="AddressTypeModel.ANON"
-					@change.native="setAddressType()">
-				{{ $t( 'donation_form_addresstype_option_anonymous' ) }}
-			</b-radio>
-		</div>
     </fieldset>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { AddressTypeModel } from '@/view_models/AddressTypeModel';
-import { NS_ADDRESS } from '@/store/namespaces';
-import { action } from '@/store/util';
-import { setAddressType } from '@/store/address/actionTypes';
 
 export default Vue.extend( {
 	name: 'AddressType',


### PR DESCRIPTION
`AddressType` can't be shared between donation and membership contexts, because `ANON` type does not exist for membership.