### PR TITLE
Add minimumAmount property to AmountSelection

### DIFF
--- a/skins/laika/src/components/shared/AmountSelection.vue
+++ b/skins/laika/src/components/shared/AmountSelection.vue
@@ -2,12 +2,16 @@
 	<fieldset>
 		<legend class="title is-size-5">{{ title }}</legend>
 		<div class="amount-wrapper">
-			<div class="amount-selector is-form-input" v-for="amount in paymentAmounts" :key="'amount-' + toCents( amount )">
+			<div v-for="amount in paymentAmounts"
+				:key="'amount-' + toCents( amount )"
+				:class="['amount-selector', 'is-form-input', amount < minimumAmount ? 'inactive' : '']"
+				>
 				<input type="radio"
 					:id="'amount-' + amount "
 					name="amount-grp"
 					:value="amount"
 					:checked="amount == selectedAmount"
+					:disabled="amount < minimumAmount"
 					@change="amountSelected( amount )"
 					class="is-sr-only">
 				<label class="has-border-rounded" :for="'amount-' + amount ">
@@ -16,7 +20,7 @@
 			</div>
 			<div class="amount-custom-wrapper">
 				<div class="amount-custom is-form-input">
-					<input v-bind:class="[customAmount ? 'is-valid' : '', 'input', 'is-large', 'input-amount', 'has-border-rounded' ]"
+					<input :class="[customAmount ? 'is-valid' : '', 'input', 'is-large', 'input-amount', 'has-border-rounded' ]"
 							type="text"
 							id="amount-custom"
 							@blur="customAmountEntered"
@@ -38,6 +42,10 @@ export default Vue.extend( {
 	name: 'AmountSelection',
 	props: {
 		amount: String,
+		minimumAmount: {
+			type: Number,
+			default: 0,
+		},
 		paymentAmounts: Array,
 		title: String,
 		error: {
@@ -129,6 +137,10 @@ export default Vue.extend( {
 				color: $fun-color-bright;
 				font-weight: bold;
 				background-color: $fun-color-primary;
+			}
+			&.inactive label {
+				color: $fun-color-gray-mid;
+				cursor: default;
 			}
 		}
 		&-custom {

--- a/skins/laika/tests/unit/components/shared/AmountSelection.spec.ts
+++ b/skins/laika/tests/unit/components/shared/AmountSelection.spec.ts
@@ -197,4 +197,30 @@ describe( 'AmountSelection', () => {
 
 		expect( ( wrapper.vm as any ).customAmount ).toBe( '' );
 	} );
+
+	it( 'prevents amount selection for choices that are below minimum amount', () => {
+		const wrapper = mount( AmountSelection, {
+			propsData: {
+				amount: '',
+				minimumAmount: 1000,
+				paymentAmounts: [ 500, 1000, 10000, 29900 ],
+				validateAmountUrl: 'https://example.com/amount-check',
+			},
+			mocks: {
+				$t: () => {},
+			},
+		} );
+
+		const belowChoice = wrapper.find( '#amount-500' );
+
+		expect( belowChoice.element.getAttribute( 'disabled' ) ).toBeTruthy();
+		expect( belowChoice.element.parentElement!.className ).toContain( 'inactive' );
+
+		[ 1000, 10000, 29900 ].forEach( amount => {
+			const aboveChoice = wrapper.find( `#amount-${amount}` );
+			expect( aboveChoice.element.getAttribute( 'disabled' ) ).toBeFalsy();
+			expect( aboveChoice.element.parentElement!.className ).not.toContain( 'inactive' );
+		} );
+
+	} );
 } );


### PR DESCRIPTION
This is for the membership page, where some choices need to be inactive
if the interval*amount is below the yearly minimum amount.

The server does the actual validation, minimumAmount is a property that
only affects the component behavior/display.