### PR TITLE
Add missing membership address form specifics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#65c89b",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#945bc4",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "titleBar.activeBackground": "#42b882",
+        "titleBar.inactiveBackground": "#42b88299",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveForeground": "#15202b99",
+        "statusBar.background": "#42b882",
+        "statusBarItem.hoverBackground": "#359267",
+        "statusBar.foreground": "#15202b"
+    }
+}

--- a/app/Controllers/ApplyForMembershipController.php
+++ b/app/Controllers/ApplyForMembershipController.php
@@ -36,10 +36,7 @@ class ApplyForMembershipController {
 		$params = [
 			'urls' => Routes::getNamedRouteUrls( $ffFactory->getUrlGenerator() )
 		];
-
-		if ( $httpRequest->query->get( 'type' ) === 'sustaining' ) {
-			$params['showMembershipTypeOption'] = false;
-		}
+		$params['showMembershipTypeOption'] = ( $httpRequest->query->get( 'type' ) === 'sustaining' ? false : true );
 
 		$useCase = $ffFactory->newGetDonationUseCase( $httpRequest->query->get( 'donationAccessToken', '' ) );
 		$responseModel = $useCase->showConfirmation(

--- a/app/Controllers/ApplyForMembershipController.php
+++ b/app/Controllers/ApplyForMembershipController.php
@@ -36,7 +36,7 @@ class ApplyForMembershipController {
 		$params = [
 			'urls' => Routes::getNamedRouteUrls( $ffFactory->getUrlGenerator() )
 		];
-		$params['showMembershipTypeOption'] = ( $httpRequest->query->get( 'type' ) === 'sustaining' ? false : true );
+		$params['showMembershipTypeOption'] = $httpRequest->query->get( 'type' ) !== 'sustaining';
 
 		$useCase = $ffFactory->newGetDonationUseCase( $httpRequest->query->get( 'donationAccessToken', '' ) );
 		$responseModel = $useCase->showConfirmation(

--- a/skins/laika/src/components/pages/MembershipForm.vue
+++ b/skins/laika/src/components/pages/MembershipForm.vue
@@ -55,6 +55,7 @@ export default Vue.extend( {
 						countries: this.$props.addressCountries,
 						trackingData: this.$props.trackingData,
 						showMembershipTypeOption: this.$props.showMembershipTypeOption,
+						initialFormValues: this.$props.initialFormValues,
 					};
 				}
 				return {

--- a/skins/laika/src/components/pages/MembershipForm.vue
+++ b/skins/laika/src/components/pages/MembershipForm.vue
@@ -32,6 +32,8 @@ export default Vue.extend( {
 		paymentTypes: Array as () => Array<String>,
 		addressCountries: Array as () => Array<String>,
 		trackingData: Object as () => TrackingData,
+		showMembershipTypeOption: Boolean,
+		initialFormValues: Object,
 	},
 	data: function () {
 		return {
@@ -52,6 +54,7 @@ export default Vue.extend( {
 						validateAddressUrl: this.$props.validateAddressUrl,
 						countries: this.$props.addressCountries,
 						trackingData: this.$props.trackingData,
+						showMembershipTypeOption: this.$props.showMembershipTypeOption,
 					};
 				}
 				return {

--- a/skins/laika/src/components/pages/MembershipForm.vue
+++ b/skins/laika/src/components/pages/MembershipForm.vue
@@ -33,7 +33,7 @@ export default Vue.extend( {
 		addressCountries: Array as () => Array<String>,
 		trackingData: Object as () => TrackingData,
 		showMembershipTypeOption: Boolean,
-		initialFormValues: Object,
+		initialFormValues: [ Object, String ],
 	},
 	data: function () {
 		return {

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -2,7 +2,7 @@
 	<div id="addressForm" class="column is-full">
 		<div class="has-margin-top-18">
 			<h1 class="title is-size-1">{{ $t( 'donation_form_section_address_title' ) }}</h1>
-			<address-type :initial-value="addressTypeFromName(initialFormValues.addressType)" v-on:address-type="setAddressType( $event )"></address-type>
+			<address-type :initial-value="initialFormValues.addressType | addressTypeFromName" v-on:address-type="setAddressType( $event )"></address-type>
 		</div>
 		<h1 class="has-margin-top-36 title is-size-5">{{ $t( 'donation_form_section_address_title' ) }}</h1>
 		<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
@@ -118,14 +118,12 @@ export default Vue.extend( {
 				}, ( {} as AddressValidity ) );
 			},
 		},
-		addressTypeFromName: {
-			get: function () {
-				return addressTypeFromName;
-			},
-		},
 		...mapGetters( NS_MEMBERSHIP_ADDRESS, [
 			'addressType',
 		] ),
+	},
+	filters: {
+		addressTypeFromName,
 	},
 	mounted() {
 		const initialFormValues = this.$props.initialFormValues;

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -2,7 +2,8 @@
 	<div id="addressForm" class="column is-full">
 		<div class="has-margin-top-18">
 			<h1 class="title is-size-1">{{ $t( 'donation_form_section_address_title' ) }}</h1>
-			<address-type :initial-value="initialFormValues.addressType | addressTypeFromName" v-on:address-type="setAddressType( $event )"></address-type>
+			<address-type :initial-value="initialFormValues !== '' ? ( initialFormValues.addressType | addressTypeFromName ) : ''"
+			v-on:address-type="setAddressType( $event )"/>
 		</div>
 		<h1 class="has-margin-top-36 title is-size-5">{{ $t( 'donation_form_section_address_title' ) }}</h1>
 		<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
@@ -11,7 +12,8 @@
         <receipt-opt-out v-on:opted-out="setReceiptOptedOut( $event )"/>
         <div class="has-margin-top-36">
 			<h1 class="title is-size-1">{{ $t( 'donation_form_section_email_title' ) }}</h1>
-			<email :initial-value="initialFormValues.email" v-on:email="setEmail( $event )"></email>
+			<email :initial-value="initialFormValues !== '' ? initialFormValues.email : ''"
+				v-on:email="setEmail( $event )"/>
 		</div>
 	</div>
 </template>
@@ -105,7 +107,7 @@ export default Vue.extend( {
 	props: {
 		validateAddressUrl: String,
 		countries: Array as () => Array<String>,
-		initialFormValues: Object,
+		initialFormValues: [ Object, String ],
 	},
 	computed: {
 		fieldErrors: {

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -104,6 +104,7 @@ export default Vue.extend( {
 	props: {
 		validateAddressUrl: String,
 		countries: Array as () => Array<String>,
+		initialFormValues: Object,
 	},
 	computed: {
 		fieldErrors: {
@@ -119,6 +120,14 @@ export default Vue.extend( {
 		...mapGetters( NS_MEMBERSHIP_ADDRESS, [
 			'addressType',
 		] ),
+	},
+	mounted() {
+		const initialFormValues = this.$props.initialFormValues;
+		if ( initialFormValues !== undefined ) {
+			Object.keys( this.$data.formData ).forEach( ( fieldName: string ) => {
+				this.formData[ fieldName ].value = initialFormValues[ fieldName ];
+			} );
+		}
 	},
 	methods: {
 		validateForm(): Promise<ValidationResult> {

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -1,7 +1,8 @@
 <template>
 	<div id="addressForm" class="column is-full">
 		<div class="has-margin-top-18">
-			<address-type v-on:address-type="setAddressType( $event )"></address-type>
+			<h1 class="title is-size-1">{{ $t( 'donation_form_section_address_title' ) }}</h1>
+			<address-type :initial-value="addressTypeFromName(initialFormValues.addressType)" v-on:address-type="setAddressType( $event )"></address-type>
 		</div>
 		<h1 class="has-margin-top-36 title is-size-5">{{ $t( 'donation_form_section_address_title' ) }}</h1>
 		<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
@@ -9,8 +10,8 @@
 		<date-of-birth/>
         <receipt-opt-out v-on:opted-out="setReceiptOptedOut( $event )"/>
         <div class="has-margin-top-36">
-			<h1 class="title is-size-5">{{ $t( 'donation_form_section_email_title' ) }}</h1>
-			<email v-on:email="setEmail( $event )"></email>
+			<h1 class="title is-size-1">{{ $t( 'donation_form_section_email_title' ) }}</h1>
+			<email :initial-value="initialFormValues.email" v-on:email="setEmail( $event )"></email>
 		</div>
 	</div>
 </template>
@@ -25,7 +26,7 @@ import DateOfBirth from '@/components/pages/membership_form/DateOfBirth.vue';
 import ReceiptOptOut from '@/components/shared/ReceiptOptOut.vue';
 import Email from '@/components/shared/Email.vue';
 import { AddressValidity, FormData, ValidationResult } from '@/view_models/Address';
-import { AddressTypeModel } from '@/view_models/AddressTypeModel';
+import { AddressTypeModel, addressTypeFromName } from '@/view_models/AddressTypeModel';
 import { Validity } from '@/view_models/Validity';
 import { NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
 import { setAddressField, validateAddress, setReceiptOptOut, setAddressType, setEmail } from '@/store/membership_address/actionTypes';
@@ -115,6 +116,11 @@ export default Vue.extend( {
 					}
 					return validity;
 				}, ( {} as AddressValidity ) );
+			},
+		},
+		addressTypeFromName: {
+			get: function () {
+				return addressTypeFromName;
 			},
 		},
 		...mapGetters( NS_MEMBERSHIP_ADDRESS, [

--- a/skins/laika/src/components/pages/membership_form/AddressType.vue
+++ b/skins/laika/src/components/pages/membership_form/AddressType.vue
@@ -31,8 +31,11 @@ export default Vue.extend( {
 	name: 'AddressType',
 	data: function () {
 		return {
-			type: AddressTypeModel.PERSON,
+			type: this.$props.initialValue !== '' ? this.$props.initialValue : AddressTypeModel.PERSON,
 		};
+	},
+	props: {
+		initialValue: Number as () => AddressTypeModel,
 	},
 	computed: {
 		AddressTypeModel: {

--- a/skins/laika/src/components/pages/membership_form/AddressType.vue
+++ b/skins/laika/src/components/pages/membership_form/AddressType.vue
@@ -35,7 +35,7 @@ export default Vue.extend( {
 		};
 	},
 	props: {
-		initialValue: Number as () => AddressTypeModel,
+		initialValue: [ Number as () => AddressTypeModel, String ],
 	},
 	computed: {
 		AddressTypeModel: {

--- a/skins/laika/src/components/pages/membership_form/MembershipType.vue
+++ b/skins/laika/src/components/pages/membership_form/MembershipType.vue
@@ -59,12 +59,6 @@ export default Vue.extend( {
 			get: function (): boolean {
 				return this.$store.getters[ NS_MEMBERSHIP_ADDRESS + '/addressType' ] === AddressTypeModel.COMPANY;
 			},
-			set: function (): void {
-				if ( this.$store.getters[ NS_MEMBERSHIP_ADDRESS + '/addressType' ] === AddressTypeModel.COMPANY ) {
-					this.$data.selectedType = MembershipTypeModel.SUSTAINING;
-					this.setType();
-				}
-			},
 		},
 	},
 	methods: {

--- a/skins/laika/src/components/pages/membership_form/MembershipType.vue
+++ b/skins/laika/src/components/pages/membership_form/MembershipType.vue
@@ -18,6 +18,7 @@
                     name="type"
                     v-model="selectedType"
                     :native-value="MembershipTypeModel.ACTIVE"
+                    :disabled="isActiveTypeDisabled"
                     @change.native="setType">
                 {{ $t( 'membership_membershiptype_option_active' ) }}
                 <p class="has-text-dark-lighter">{{ $t( 'membership_membershiptype_option_active_legend' ) }}</p>
@@ -29,9 +30,11 @@
 <script lang="ts">
 import Vue from 'vue';
 import { MembershipTypeModel } from '@/view_models/MembershipTypeModel';
+import { AddressTypeModel } from '@/view_models/AddressTypeModel';
 import { NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
 import { setMembershipType } from '@/store/membership_address/actionTypes';
 import { action } from '@/store/util';
+import { mapGetters } from 'vuex';
 
 export default Vue.extend( {
 	name: 'MembershipType',
@@ -44,6 +47,22 @@ export default Vue.extend( {
 		MembershipTypeModel: {
 			get: function () {
 				return MembershipTypeModel;
+			},
+		},
+		AddressTypeModel: {
+			get: function () {
+				return AddressTypeModel;
+			},
+		},
+		...mapGetters( NS_MEMBERSHIP_ADDRESS, [ 'addressType' ] ),
+		isActiveTypeDisabled: {
+			get: function () {
+				if ( this.$store.getters[ NS_MEMBERSHIP_ADDRESS + '/addressType' ] === AddressTypeModel.COMPANY ) {
+					this.$data.selectedType = MembershipTypeModel.SUSTAINING;
+					this.setType();
+					return true;
+				}
+				return false;
 			},
 		},
 	},

--- a/skins/laika/src/components/pages/membership_form/MembershipType.vue
+++ b/skins/laika/src/components/pages/membership_form/MembershipType.vue
@@ -56,13 +56,14 @@ export default Vue.extend( {
 		},
 		...mapGetters( NS_MEMBERSHIP_ADDRESS, [ 'addressType' ] ),
 		isActiveTypeDisabled: {
-			get: function () {
+			get: function (): boolean {
+				return this.$store.getters[ NS_MEMBERSHIP_ADDRESS + '/addressType' ] === AddressTypeModel.COMPANY;
+			},
+			set: function (): void {
 				if ( this.$store.getters[ NS_MEMBERSHIP_ADDRESS + '/addressType' ] === AddressTypeModel.COMPANY ) {
 					this.$data.selectedType = MembershipTypeModel.SUSTAINING;
 					this.setType();
-					return true;
 				}
-				return false;
 			},
 		},
 	},

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -22,6 +22,7 @@ export default Vue.extend( {
 		countries: Array as () => Array<String>,
 		trackingData: Object as () => TrackingData,
 		showMembershipTypeOption: Boolean,
+		initialFormValues: Object,
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -22,7 +22,7 @@ export default Vue.extend( {
 		countries: Array as () => Array<String>,
 		trackingData: Object as () => TrackingData,
 		showMembershipTypeOption: Boolean,
-		initialFormValues: Object,
+		initialFormValues: [ Object, String ],
 	},
 } );
 </script>

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="column is-full">
-        <membership-type></membership-type>
+        <membership-type v-if="showMembershipTypeOption"></membership-type>
 		<address-fields v-bind="$props" ref="address"></address-fields>
     </div>
 </template>
@@ -21,6 +21,7 @@ export default Vue.extend( {
 		validateAddressUrl: String,
 		countries: Array as () => Array<String>,
 		trackingData: Object as () => TrackingData,
+		showMembershipTypeOption: Boolean,
 	},
 } );
 </script>

--- a/skins/laika/src/components/shared/Email.vue
+++ b/skins/laika/src/components/shared/Email.vue
@@ -13,18 +13,18 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { NS_ADDRESS } from '@/store/namespaces';
-import { action } from '@/store/util';
-import { setEmail } from '@/store/address/actionTypes';
 
 export default Vue.extend( {
 	name: 'Email',
 	data: function () {
 		return {
-			emailValue: '',
+			emailValue: this.$props.initialValue,
 			emailPattern: /^[^@]+@.+$/,
 			emailHasError: false,
 		};
+	},
+	props: {
+		initialValue: String,
 	},
 	methods: {
 		setEmail: function () {

--- a/skins/laika/src/pages/membership_application.ts
+++ b/skins/laika/src/pages/membership_application.ts
@@ -20,7 +20,7 @@ interface MembershipAmountModel {
 	tracking: Array<number>,
 	urls: any,
 	showMembershipTypeOption: Boolean,
-	initialFormValues: Object,
+	initialFormValues: Object | String,
 }
 
 const pageData = new PageDataInitializer<MembershipAmountModel>( '#app' );
@@ -52,7 +52,7 @@ new Vue( {
 				addressCountries: COUNTRIES,
 				trackingData: pageData.applicationVars.tracking,
 				showMembershipTypeOption: pageData.applicationVars.showMembershipTypeOption,
-				initialFormValues: pageData.applicationVars.initialFormValues,
+				initialFormValues: pageData.applicationVars.initialFormValues !== undefined ? pageData.applicationVars.initialFormValues : '',
 			},
 		} ),
 		h( Sidebar, {

--- a/skins/laika/src/pages/membership_application.ts
+++ b/skins/laika/src/pages/membership_application.ts
@@ -20,6 +20,7 @@ interface MembershipAmountModel {
 	tracking: Array<number>,
 	urls: any,
 	showMembershipTypeOption: Boolean,
+	initialFormValues: Object,
 }
 
 const pageData = new PageDataInitializer<MembershipAmountModel>( '#app' );
@@ -51,6 +52,7 @@ new Vue( {
 				addressCountries: COUNTRIES,
 				trackingData: pageData.applicationVars.tracking,
 				showMembershipTypeOption: pageData.applicationVars.showMembershipTypeOption,
+				initialFormValues: pageData.applicationVars.initialFormValues,
 			},
 		} ),
 		h( Sidebar, {

--- a/skins/laika/src/pages/membership_application.ts
+++ b/skins/laika/src/pages/membership_application.ts
@@ -18,7 +18,8 @@ interface MembershipAmountModel {
 	presetAmounts: Array<string>,
 	paymentTypes: Array<string>,
 	tracking: Array<number>,
-	urls: any
+	urls: any,
+	showMembershipTypeOption: Boolean,
 }
 
 const pageData = new PageDataInitializer<MembershipAmountModel>( '#app' );
@@ -49,6 +50,7 @@ new Vue( {
 				paymentTypes: pageData.applicationVars.paymentTypes,
 				addressCountries: COUNTRIES,
 				trackingData: pageData.applicationVars.tracking,
+				showMembershipTypeOption: pageData.applicationVars.showMembershipTypeOption,
 			},
 		} ),
 		h( Sidebar, {

--- a/skins/laika/src/view_models/AddressTypeModel.ts
+++ b/skins/laika/src/view_models/AddressTypeModel.ts
@@ -10,6 +10,12 @@ export const AddressTypeNames = new Map<number, string>( [
 	[ AddressTypeModel.COMPANY, 'firma' ],
 ] );
 
+export const AddressTypes = new Map<string, number>( [
+	[ 'anonym', AddressTypeModel.ANON ],
+	[ 'person', AddressTypeModel.PERSON ],
+	[ 'firma', AddressTypeModel.COMPANY ],
+] );
+
 export function addressTypeName( t: AddressTypeModel ): string {
 	const name = AddressTypeNames.get( t );
 	// poor man's type check to protect against future extensions of AddressTypeModel, e.g. https://phabricator.wikimedia.org/T220367
@@ -17,4 +23,13 @@ export function addressTypeName( t: AddressTypeModel ): string {
 		throw new Error( 'Unknown address type: ' + t );
 	}
 	return name;
+}
+
+export function addressTypeFromName( n: string ): AddressTypeModel {
+	const type = AddressTypes.get( n );
+	// poor man's type check to protect against future extensions of AddressTypeModel, e.g. https://phabricator.wikimedia.org/T220367
+	if ( typeof type === 'undefined' ) {
+		throw new Error( 'Unknown address type: ' + n );
+	}
+	return type;
 }


### PR DESCRIPTION
Feature: [T226928](https://phabricator.wikimedia.org/T226928)

- [x] Choosing "Firma" disables the membership type option "Aktive Mitgliedschaft".
- [x] Passing the membership type in the URL (type=sustaining) sets the given type and hides the membership type options.
- [x] Populate address fields if the address data is available on render
- [x] Populate email and pre-set address type if available on render