### PR TITLE
Fix validation issue with optional form fields

### DIFF
--- a/skins/laika/src/components/pages/membership_form/DateOfBirth.vue
+++ b/skins/laika/src/components/pages/membership_form/DateOfBirth.vue
@@ -43,6 +43,9 @@ export default Vue.extend( {
 			}
 		},
 		dateIsValid: function () {
+			if ( this.$data.date === '' ) {
+				return true;
+			}
 			return this.datePattern.test( this.$data.date );
 		},
 	},

--- a/skins/laika/src/store/address/mutations.ts
+++ b/skins/laika/src/store/address/mutations.ts
@@ -19,7 +19,7 @@ import { REQUIRED_FIELDS } from '@/store/address/constants';
 export const mutations: MutationTree<AddressState> = {
 	[ VALIDATE_INPUT ]( state: AddressState, field: InputField ) {
 		if ( field.value === '' && field.optionalField ) {
-			state.validity[ field.name ] = Validity.INCOMPLETE;
+			state.validity[ field.name ] = Validity.VALID;
 		} else {
 			state.validity[ field.name ] = Helper.inputIsValid( field.value, field.pattern );
 		}


### PR DESCRIPTION
Currently, if a user proceeds with the address page without having filled in all data, the optional `title` form field is marked as invalid instead of being ignored. Since the error will not go away, it might cause some confusion for users or cause them to be stuck.

I think the change I propose here should fix this issue but I just wanted to separate it out because I was not 100% sure.