### PR TITLE
Ensure interval is a string

### DIFF
--- a/skins/laika/src/components/shared/PaymentInterval.vue
+++ b/skins/laika/src/components/shared/PaymentInterval.vue
@@ -8,7 +8,7 @@
 						:id="'interval-' + interval"
 						name="interval"
 						v-model="selectedInterval"
-						:native-value="interval"
+						:native-value="interval.toString()"
 						@change.native="setInterval">
 					{{ $t( 'donation_form_payment_interval_' + interval.toString() ) }}
 				</b-radio>
@@ -39,7 +39,7 @@ export default Vue.extend( {
 		},
 	},
 	watch: {
-		currentInterval: function ( newInterval ) {
+		currentInterval: function ( newInterval: string ): void {
 			this.selectedInterval = newInterval;
 		},
 	},

--- a/skins/laika/src/pages/donation_form.ts
+++ b/skins/laika/src/pages/donation_form.ts
@@ -40,7 +40,7 @@ store.dispatch( action( NS_PAYMENT, initializePayment ), {
 	// convert German-Formatted amount, see DonationFormPresenter
 	amount: pageData.applicationVars.initialFormValues.amount.replace( ',', '' ).replace( /^000$/, '0' ),
 	type: pageData.applicationVars.initialFormValues.paymentType,
-	paymentIntervalInMonths: pageData.applicationVars.initialFormValues.paymentIntervalInMonths,
+	paymentIntervalInMonths: String( pageData.applicationVars.initialFormValues.paymentIntervalInMonths ),
 	isCustomAmount: pageData.applicationVars.initialFormValues.isCustomAmount,
 } ).then( paymentDataComplete => {
 

--- a/skins/laika/tests/unit/components/shared/PaymentInterval.spec.ts
+++ b/skins/laika/tests/unit/components/shared/PaymentInterval.spec.ts
@@ -29,7 +29,7 @@ describe( 'PaymentInterval', () => {
 		wrapper.find( `#interval-${YEARLY}` ).trigger( 'click' );
 
 		expect( wrapper.emitted( 'interval-selected' ) ).toBeTruthy();
-		expect( wrapper.emitted( 'interval-selected' )[ 0 ] ).toEqual( [ YEARLY ] );
+		expect( wrapper.emitted( 'interval-selected' )[ 0 ] ).toEqual( [ String( YEARLY ) ] );
 	} );
 
 	it( 'updates the selected interval when the incoming property changes', () => {


### PR DESCRIPTION
Make sure PaymentInterval stores its data as a string. This avoids type
errors in the console.