### PR TITLE
Remove type radio from all buefy b-radio components

### DIFF
--- a/skins/laika/src/components/pages/donation_form/AddressType.vue
+++ b/skins/laika/src/components/pages/donation_form/AddressType.vue
@@ -2,8 +2,7 @@
 	<fieldset>
 		<legend class="subtitle">{{ $t( 'donation_form_section_address_header_type' ) }}</legend>
 		<div>
-			<b-radio type="radio"
-					id="personal"
+			<b-radio id="personal"
 					name="addressTypeInternal"
 					v-model="type"
 					:native-value="AddressTypeModel.PERSON"
@@ -11,8 +10,7 @@
 			</b-radio>
 		</div>
 		<div>
-			<b-radio type="radio"
-					id="company"
+			<b-radio id="company"
 					name="addressTypeInternal"
 					v-model="type"
 					:native-value="AddressTypeModel.COMPANY"
@@ -21,8 +19,7 @@
 			</b-radio>
 		</div>
 		<div>
-			<b-radio type="radio"
-					id="anonymous"
+			<b-radio id="anonymous"
 					name="addressTypeInternal"
 					v-model="type"
 					:native-value="AddressTypeModel.ANON"

--- a/skins/laika/src/components/pages/donation_form/PaymentType.vue
+++ b/skins/laika/src/components/pages/donation_form/PaymentType.vue
@@ -4,7 +4,6 @@
 		<div>
 			<div v-for="paymentType in paymentTypes" :key="paymentType">
 				<b-radio :class="{ 'is-active': selectedType === paymentType }"
-						type="radio"
 						:id="'payment-' + paymentType.toLowerCase()"
 						name="payment"
 						v-model="selectedType"

--- a/skins/laika/src/components/pages/membership_form/AddressType.vue
+++ b/skins/laika/src/components/pages/membership_form/AddressType.vue
@@ -2,8 +2,7 @@
 	<fieldset>
 		<legend class="title is-size-5">{{ $t( 'membership_form_section_address_header_type' ) }}</legend>
 		<div>
-			<b-radio type="radio"
-					id="personal"
+			<b-radio id="personal"
 					name="addressTypeInternal"
 					v-model="type"
 					:native-value="AddressTypeModel.PERSON"
@@ -11,8 +10,7 @@
 			</b-radio>
 		</div>
 		<div>
-			<b-radio type="radio"
-					id="company"
+			<b-radio id="company"
 					name="addressTypeInternal"
 					v-model="type"
 					:native-value="AddressTypeModel.COMPANY"

--- a/skins/laika/src/components/pages/membership_form/MembershipType.vue
+++ b/skins/laika/src/components/pages/membership_form/MembershipType.vue
@@ -3,13 +3,12 @@
         <legend class="title is-size-5">{{ $t('membership_form_membershiptype_legend') }}</legend>
         <div>
             <b-radio :class="{ 'is-active': selectedType === MembershipTypeModel.SUSTAINING }"
-                    type="radio"
                     id="sustaining"
                     name="type"
                     v-model="selectedType"
                     :native-value="MembershipTypeModel.SUSTAINING"
                     @change.native="setType">
-                <span>{{ $t( 'membership_form_membershiptype_option_sustaining' ) }}</span>
+                {{ $t( 'membership_form_membershiptype_option_sustaining' ) }}
                 <p class="has-text-dark-lighter">{{ $t( 'membership_form_membershiptype_option_sustaining_legend' ) }}</p>
             </b-radio>
             <b-radio :class="{ 'is-active': selectedType === MembershipTypeModel.ACTIVE && !isActiveTypeDisabled }"

--- a/skins/laika/src/components/shared/Name.vue
+++ b/skins/laika/src/components/shared/Name.vue
@@ -4,8 +4,7 @@
 		<fieldset class="has-margin-top-36">
 			<legend class="subtitle">{{ $t( 'donation_form_salutation_label' ) }}</legend>
 			<div>
-				<b-radio type="radio"
-						id="salutation-mr"
+				<b-radio id="salutation-mr"
 						name="salutationInternal"
 						:native-value="$t( 'donation_form_salutation_option_mr' ) "
 						v-model="formData.salutation.value"
@@ -14,8 +13,7 @@
 				</b-radio>
 			</div>
 			<div>
-				<b-radio type="radio"
-						id="salutation-mrs"
+				<b-radio id="salutation-mrs"
 						name="salutationInternal"
 						:native-value="$t( 'donation_form_salutation_option_mrs' ) "
 						v-model="formData.salutation.value"

--- a/skins/laika/src/components/shared/PaymentInterval.vue
+++ b/skins/laika/src/components/shared/PaymentInterval.vue
@@ -4,7 +4,6 @@
 		<div>
 			<div class="wrap-radio" v-for="interval in paymentIntervals" :key="'interval-' + interval">
 				<b-radio :class="{ 'is-active': selectedInterval === interval }"
-						type="radio"
 						:id="'interval-' + interval"
 						name="interval"
 						v-model="selectedInterval"


### PR DESCRIPTION
According to [Buefy's docs](https://buefy.org/documentation/radio) `b-radio` elements don't need the type attribute to be set. As a matter of fact having `type="radio"` makes the circle part of the radio button smaller. 🤷‍♀ 
This PR removes `type=radio` from all the `b-radio` components used in our Vue components.