### PR TITLE
Avoid HTTP request in BankData test

### DIFF
--- a/skins/laika/tests/unit/components/shared/BankData.spec.ts
+++ b/skins/laika/tests/unit/components/shared/BankData.spec.ts
@@ -79,6 +79,8 @@ describe( 'BankData', () => {
 				$t: () => {},
 			},
 		} );
+		const store = wrapper.vm.$store;
+		store.dispatch = jest.fn();
 
 		const iban = wrapper.find( '#iban' );
 		const bic = wrapper.find( '#bic' );


### PR DESCRIPTION
Stub the dispatch methods of the store to avoid calls to the
(nonexistent) server.