### PR TITLE
Fix radio button custom styling after type removal

### DIFF
--- a/skins/laika/src/scss/overrides.scss
+++ b/skins/laika/src/scss/overrides.scss
@@ -30,7 +30,7 @@
 			border-bottom: 2px solid $fun-color-primary;
 		}
 	}
-	.check.radio {
+	.check {
 		font-size: 12px;
 	}
 }


### PR DESCRIPTION
Follow up to: https://github.com/wmde/FundraisingFrontend/pull/1563

As noted by Tonina, the radio button design changed by removing the type. Turns out Buefy adds the type as a class to one of the elements which was used in one of our CSS selectors. Removing the type disabled the custom CSS rule and this PR fixes that.