### PR TITLE
Static pages content

### DIFF
--- a/skins/laika/src/components/pages/StaticPage.vue
+++ b/skins/laika/src/components/pages/StaticPage.vue
@@ -1,0 +1,21 @@
+<template>
+<!--set matomo_opt_out-->
+<div class="column is-full">
+	<h2 class="title is-size-2">{{ pageTitle }}</h2>
+	<div v-html="pageContent" class="has-margin-top-18 column is-full"></div>
+</div>
+<!--{$ web_content("pages/#{page_id}") | replace({: matomo_opt_out}) | raw $}-->
+
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend( {
+	name: 'PrivacyProtection',
+	props: {
+		pageTitle: String,
+		pageContent: String,
+	},
+} );
+</script>

--- a/skins/laika/src/pages/static_page.ts
+++ b/skins/laika/src/pages/static_page.ts
@@ -1,0 +1,44 @@
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+import PageDataInitializer from '@/page_data_initializer';
+import { DEFAULT_LOCALE } from '@/locales';
+import App from '@/components/App.vue';
+
+import Component from '@/components/pages/StaticPage.vue';
+import Sidebar from '@/components/layout/Sidebar.vue';
+
+const staticPage: any = document.getElementById( 'app' );
+const PAGE_IDENTIFIER = staticPage.getAttribute( 'data-page-id' );
+
+Vue.config.productionTip = false;
+Vue.use( VueI18n );
+
+const pageData = new PageDataInitializer<any>( '#app' );
+
+const i18n = new VueI18n( {
+	locale: DEFAULT_LOCALE,
+	messages: {
+		[ DEFAULT_LOCALE ]: pageData.messages,
+	},
+} );
+
+new Vue( {
+	i18n,
+	render: h => h( App, {
+		props: {
+			assetsPath: pageData.assetsPath,
+			pageIdentifier: PAGE_IDENTIFIER,
+		},
+	},
+	[
+		h( Component, {
+			props: {
+				pageTitle: staticPage.getAttribute( 'data-page-title' ),
+				pageContent: staticPage.getAttribute( 'data-page-content' ),
+			},
+		} ),
+		h( Sidebar, {
+			slot: 'sidebar',
+		} ),
+	] ),
+} ).$mount( '#app' );

--- a/skins/laika/templates/page_layouts/base.html.twig
+++ b/skins/laika/templates/page_layouts/base.html.twig
@@ -1,0 +1,30 @@
+{% extends 'Base_Layout.html.twig' %}
+{% set page_works_without_js = true %}
+{% set content = web_content("pages/#{page_id}") %}
+{% set title = page_id|trans({}, 'pageTitles') %}
+
+{% block main %}
+	<div id="app"
+		data-page-id="{$ page_id $}"
+		data-page-title="{$ title | e('html_attr') $}"
+		data-page-content="{$ content | e('html_attr') | raw $}"
+		data-application-vars="{$ _context|json_encode|e('html_attr') $}" 
+   		data-application-messages="{$ translations()|e('html_attr') $}" 
+    	data-assets-path="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/laika{% endif %}">
+	</div>
+        <noscript>
+                <h2>{$ title $}</h2>
+                {$ content $}
+        </noscript>
+    </div>
+	<!--<div class="itz-logo col-xs-12 col-sm-5 col-sm-offset-7 col-md-offset-0 col-md-4 hidden-print">
+		<a href="{$ 'content_pages_itz_link' | trans | e ( 'html_attr' ) $}" target="_blank" title="{$ 'content_pages_itz_title' | trans | e ( 'html_attr' ) $}">
+			<img src="{$ 'content_pages_itz_logo' | trans | e ( 'html_attr' ) $}" alt="{$ 'content_pages_itz_title' | trans | e ( 'html_attr' ) $}">
+		</a>
+	</div>-->
+{% endblock %}
+
+{% block scripts %}
+	{$ parent() $}
+	<script src="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/laika{% endif %}/js/static_page.js"></script>
+{% endblock %}

--- a/skins/laika/vue.config.js
+++ b/skins/laika/vue.config.js
@@ -32,6 +32,7 @@ module.exports = {
 		membership_application_confirmation: 'src/pages/membership_application_confirmation.ts',
 		page_not_found: 'src/pages/page_not_found.ts',
 		subscription_confirmation: 'src/pages/subscription_confirmation.ts',
+		static_page: 'src/pages/static_page.ts',
 		system_message: 'src/pages/system_message.ts',
 		update_address: 'src/pages/update_address.ts',
 		warning_page: 'src/pages/warning_page.ts',


### PR DESCRIPTION
**Feature:** [T224856](https://phabricator.wikimedia.org/T224856)

**Note 1:** The folder `page_layouts` had to be created, because the `PageDisplayHandler` expects `base.html.twig` to exist in there. 

**Note 2:** The static pages are still ugly style wise, that will be addressed in a separate PR, given that the design for the matomo opt out is not ready yet.