### PR TITLE
Remove all scoped CSS blocks for performance gain

### DIFF
--- a/skins/laika/src/components/pages/PrivacyProtection.vue
+++ b/skins/laika/src/components/pages/PrivacyProtection.vue
@@ -1,9 +1,10 @@
 <template>
 	<div class="column is-full privacy-selection has-padding-36">
 		<h2 class="title is-size-2">{{ $t( 'privacy_protection_title' ) }}</h2>
-		<p class="legend">
-			{{ $t('privacy_optout_description') }}
-		</p>
+		<fieldset>
+			<legend class="legend">
+				{{ $t('privacy_optout_description') }}
+			</legend>
 			<b-radio id="tracking-opt-in"
 					name="matomo_choice"
 					:native-value="0"
@@ -20,6 +21,7 @@
 			</b-radio>
 			<p v-if="showOptOutExplanation === 0" class="has-text-dark-lighter has-margin-top-18">{{ $t( 'privacy_optout_tracking_state' ) }}</p>
 			<p v-else class="has-text-dark-lighter has-margin-top-18" v-html="$t( 'privacy_optout_tracking_state_no' )"></p>
+		</fieldset>
 	</div>
 </template>
 
@@ -72,15 +74,16 @@ export default Vue.extend( {
 	},
 } );
 </script>
-<style lang="scss" scoped>
-@import "../../scss/custom.scss";
-	.b-radio.radio {
-		&+.radio {
-			margin-left: 0;
+
+<style lang="scss">
+	@import "../../scss/custom.scss";
+		.privacy-selection {
+			border: 1px solid $fun-color-gray-mid;
+			border-radius: 2px;
+			.b-radio.radio {
+				& + .radio {
+					margin-left: 0;
+				}
+			}
 		}
-	}
-	.privacy-selection {
-		border: 1px solid $fun-color-gray-mid;
-		border-radius: 2px;
-	}
 </style>

--- a/skins/laika/src/components/pages/donation_confirmation/PaymentNotice.vue
+++ b/skins/laika/src/components/pages/donation_confirmation/PaymentNotice.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="payment-notice" v-html="paymentNotice"></div>
+	<div class="has-margin-top-18 payment-notice" v-html="paymentNotice"></div>
 </template>
 
 <script>
@@ -45,9 +45,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-	.payment-notice {
-		margin-top: 18px;
-	}
-</style>

--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -152,19 +152,3 @@ export default Vue.extend( {
 	},
 } );
 </script>
-<style lang="scss" scoped>
-    @import "../../../scss/custom";
-
-    button.is-main {
-        height: 54px;
-        font-size: 1em;
-        font-weight: bold;
-        width: 250px;
-        border-radius: 0;
-    }
-    @include until($tablet) {
-        button.is-main {
-            width: 100%;
-        }
-    }
-</style>

--- a/skins/laika/src/components/pages/donation_form/DonationReview.vue
+++ b/skins/laika/src/components/pages/donation_form/DonationReview.vue
@@ -18,5 +18,3 @@ export default Vue.extend( {
 	name: 'DonationReview',
 } );
 </script>
-<style lang="scss" scoped>
-</style>

--- a/skins/laika/src/components/pages/donation_form/SubmitValues.vue
+++ b/skins/laika/src/components/pages/donation_form/SubmitValues.vue
@@ -69,7 +69,3 @@ export default Vue.extend( {
 	},
 } );
 </script>
-
-<style scoped>
-
-</style>

--- a/skins/laika/src/components/pages/donation_form/subpages/PaymentPage.vue
+++ b/skins/laika/src/components/pages/donation_form/subpages/PaymentPage.vue
@@ -45,7 +45,3 @@ export default Vue.extend( {
 	},
 } );
 </script>
-
-<style scoped>
-
-</style>

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -152,19 +152,3 @@ export default Vue.extend( {
 	},
 } );
 </script>
-<style lang="scss" scoped>
-    @import "../../../scss/custom";
-
-    button.is-main {
-        height: 54px;
-        font-size: 1em;
-        font-weight: bold;
-        width: 250px;
-        border-radius: 0;
-    }
-    @include until($tablet) {
-        button.is-main {
-            width: 100%;
-        }
-    }
-</style>

--- a/skins/laika/src/components/pages/membership_form/MembershipType.vue
+++ b/skins/laika/src/components/pages/membership_form/MembershipType.vue
@@ -1,7 +1,7 @@
 <template>
 	<fieldset class="has-margin-top-36 column is-full">
 		<legend class="title is-size-5">{{ $t('membership_form_membershiptype_legend') }}</legend>
-		<div>
+		<div class="membership-type">
 			<b-radio :class="{ 'is-active': selectedType === MembershipTypeModel.SUSTAINING }"
 					id="sustaining"
 					name="type"
@@ -73,12 +73,14 @@ export default Vue.extend( {
 	},
 } );
 </script>
-<style lang="scss" scoped>
+<style lang="scss">
 @import "../../../scss/custom.scss";
-	.b-radio.radio {
-		height: 6.5em;
-		&+.radio{
-			margin-left: 0;
+	.membership-type {
+		.b-radio.radio {
+			height: 6.5em;
+			& + .radio {
+				margin-left: 0;
+			}
 		}
 	}
 </style>


### PR DESCRIPTION
The uncompressed CSS file size was reduced from 2.6 Megabytes to 450 Kilobytes by removing all scoped slots. Some of the blocks were actually not needed at all and the others could be refactored by simply using CSS selectors with classes from the parent elements.