### PR TITLE
Fix race condition

### DIFF
--- a/skins/laika/src/components/pages/donation_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/donation_form/subpages/AddressPage.vue
@@ -18,7 +18,7 @@
 					</div>
 					<div class="column">
 						<b-button id="submit-btn" :class="[ $store.getters.isValidating ? 'is-loading' : '', 'level-item' ]"
-								@click="submit"
+								@mousedown.native="submit"
 								type="is-primary is-main">
 							{{ $t('donation_form_finalize') }}
 						</b-button>

--- a/skins/laika/src/components/pages/membership_form/subpages/PaymentPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/PaymentPage.vue
@@ -15,7 +15,7 @@
 				</div>
 				<div class="column">
 					<b-button id="submit-btn" :class="[ $store.getters.isValidating ? 'is-loading' : '', 'level-item']"
-						@click="submit"
+						@mousedown.native="submit"
 						type="is-primary is-main">
 						{{ $t('membership_form_finalize') }}
 					</b-button>


### PR DESCRIPTION
This is a desparate attempt at fixing [T228742](https://phabricator.wikimedia.org/T228742#5384305)
In the case of filling out the entire form with no errors and leaving the IBAN for last, filling it with correct data and clicking submit without leaving the IBAN field:
1. Blur event is fired.
2. Validation of bank data happens on the server side.
3. Bank data validity is set in the store.
4. Bank data info is filled in (iban, bic and bank name) on the client side.

but the click event is never fired thus the donation/membership is never submitted and the user is left on the same page with everything valid but nothing happening. 

**A** fix is to submit the donation/membership on mousedown, instead of on click, because mousedown is fired before blur (mousedown > blur > mouseup > click).