### PR TITLE
Remove column class from static text / rename CSS

### DIFF
--- a/skins/laika/src/components/pages/StaticPage.vue
+++ b/skins/laika/src/components/pages/StaticPage.vue
@@ -1,9 +1,9 @@
 <template>
 <div class="column is-full">
 	<h2 class="title is-size-2">{{ pageTitle }}</h2>
-	<div v-html="partialContentFirstHalf" class="has-margin-top-18 column is-full privacy"></div>
+	<div v-html="partialContentFirstHalf" class="has-margin-top-18 is-full static-content"></div>
 	<privacy-protection v-if="pageId === 'privacy_protection'"></privacy-protection>
-	<div v-html="partialContentSecondHalf" class="has-margin-top-18 column is-full privacy"></div>
+	<div v-html="partialContentSecondHalf" class="has-margin-top-18 is-full static-content"></div>
 </div>
 </template>
 
@@ -30,3 +30,19 @@ export default Vue.extend( {
 	},
 } );
 </script>
+
+<style lang="scss">
+	@import "../../scss/custom.scss";
+	.static-content {
+		ol {
+			margin-left: 1.5em;
+		}
+		& > ol {
+			padding-left: 10px;
+			list-style-type: upper-roman;
+		}
+		p {
+			margin: 0 0 11px;
+		}
+	}
+</style>

--- a/skins/laika/src/scss/custom.scss
+++ b/skins/laika/src/scss/custom.scss
@@ -93,17 +93,5 @@
 .external-notice {
 	color: $fun-color-dark-lighter;
 }
-.privacy {
-	ol {
-		margin-left: 1.5em;
-	}
-	& > ol {
-		padding-left: 10px;
-		list-style-type: upper-roman;
-	}
-	p {
-		margin: 0 0 11px;
-	}
-}
 
 @import "overrides";

--- a/skins/laika/templates/page_layouts/base.html.twig
+++ b/skins/laika/templates/page_layouts/base.html.twig
@@ -8,19 +8,14 @@
 		data-page-id="{$ page_id $}"
 		data-page-title="{$ title | e('html_attr') $}"
 		data-page-content="{$ content | e('html_attr') | raw $}"
-		data-application-vars="{$ _context|json_encode|e('html_attr') $}" 
-		data-application-messages="{$ translations()|e('html_attr') $}" 
+		data-application-vars="{$ _context|json_encode|e('html_attr') $}"
+		data-application-messages="{$ translations()|e('html_attr') $}"
 		data-assets-path="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/laika{% endif %}">
 	</div>
 	<noscript>
 		<h2>{$ title $}</h2>
 		{$ content $}
 	</noscript>
-<!--<div class="itz-logo col-xs-12 col-sm-5 col-sm-offset-7 col-md-offset-0 col-md-4 hidden-print">
-	<a href="{$ 'content_pages_itz_link' | trans | e ( 'html_attr' ) $}" target="_blank" title="{$ 'content_pages_itz_title' | trans | e ( 'html_attr' ) $}">
-		<img src="{$ 'content_pages_itz_logo' | trans | e ( 'html_attr' ) $}" alt="{$ 'content_pages_itz_title' | trans | e ( 'html_attr' ) $}">
-	</a>
-</div>-->
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
I have removed the column class from those two blocks because the content had too much "padding" because of it. Also renamed the "privacy" class so the name is a bit more accurate (as it applies to all content) and moved the CSS into that file.