### PR TITLE
Remove Docker --name parameter in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ watch-js:
 
 clear:
 	rm -rf var/cache/
-	docker-compose run --rm --no-deps --name $@ app rm -rf var/cache/
+	docker-compose run --rm --no-deps app rm -rf var/cache/
 
 # n alias to avoid frequent typo
 clean: clear
@@ -68,38 +68,38 @@ setup-db:
 	docker-compose run --rm app ./vendor/bin/doctrine orm:generate-proxies var/doctrine_proxies
 
 covers:
-	docker-compose run --rm --no-deps --name $@ app ./vendor/bin/covers-validator
+	docker-compose run --rm --no-deps app ./vendor/bin/covers-validator
 
 phpunit:
-	docker-compose run --rm --name $@ app ./vendor/bin/phpunit $(TEST_DIR)
+	docker-compose run --rm app ./vendor/bin/phpunit $(TEST_DIR)
 
 phpunit-with-coverage:
 	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug ./vendor/bin/phpunit --dump-xdebug-filter var/xdebug-filter.php
 	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug ./vendor/bin/phpunit --prepend var/xdebug-filter.php --configuration=phpunit.xml.dist --coverage-clover coverage.clover --printer="PHPUnit\TextUI\ResultPrinter"
 
 phpunit-system:
-	docker-compose run --rm --name $@ app ./vendor/bin/phpunit tests/System/
+	docker-compose run --rm app ./vendor/bin/phpunit tests/System/
 
 cs:
-	docker-compose run --rm --no-deps --name $@ app ./vendor/bin/phpcs
+	docker-compose run --rm --no-deps app ./vendor/bin/phpcs
 
 fix-cs:
-	docker-compose run --rm --no-deps --name $@ app ./vendor/bin/phpcbf
+	docker-compose run --rm --no-deps app ./vendor/bin/phpcbf
 
 stan:
 	docker run --rm -it --volume $(BUILD_DIR):/app -w /app $(DOCKER_IMAGE):stan analyse --level=1 --no-progress cli/ src/ tests/
 
 validate-app-config:
-	docker-compose run --rm --no-deps --name $@ app ./console app:validate:config app/config/config.dist.json app/config/config.test.json
+	docker-compose run --rm --no-deps app ./console app:validate:config app/config/config.dist.json app/config/config.test.json
 
 validate-campaign-config:
-	docker-compose run --rm --no-deps --name $@ app ./console app:validate:campaigns $(APP_ENV)
+	docker-compose run --rm --no-deps app ./console app:validate:campaigns $(APP_ENV)
 
 validate-campaign-utilization:
-	docker-compose run --rm --no-deps --name $@ app ./console app:validate:campaigns:utilization
+	docker-compose run --rm --no-deps app ./console app:validate:campaigns:utilization
 
 phpmd:
-	docker-compose run --rm --no-deps --name $@ app ./vendor/bin/phpmd src/ text phpmd.xml
+	docker-compose run --rm --no-deps app ./vendor/bin/phpmd src/ text phpmd.xml
 
 npm-ci:
 	docker run --rm $(DOCKER_FLAGS) --user $(current_user):$(current_group) -v $(BUILD_DIR):/code -w /code -e NO_UPDATE_NOTIFIER=1 $(NODE_IMAGE) npm run ci


### PR DESCRIPTION
This is a followup to 7e5191a8d2c28375b42c65a7e7592439f9ddb5e2, which
removed unique IDs, but the not naming of containers. But containers
named after their Makwfile tasks don't make much sense, so I'm dropping
the `--name` parameter