### PR TITLE
Make privacy protection page standalone

### DIFF
--- a/skins/laika/src/components/pages/PrivacyProtection.vue
+++ b/skins/laika/src/components/pages/PrivacyProtection.vue
@@ -1,42 +1,55 @@
 <template>
-	<div class="column is-full privacy-selection has-padding-36">
-		<h2 class="title is-size-2">{{ $t( 'privacy_protection_title' ) }}</h2>
-		<fieldset>
-			<legend class="legend">
-				{{ $t('privacy_optout_description') }}
-			</legend>
-			<b-radio id="tracking-opt-in"
-					name="matomo_choice"
-					:native-value="0"
-					v-model="optOut"
-					@input="changeTracking">
-				{{ $t('privacy_optout_tracking_permit') }}
-			</b-radio>
-			<b-radio id="tracking-opt-out"
-					name="matomo_choice"
-					:native-value="1"
-					v-model="optOut"
-					@input="changeTracking">
-				{{ $t('privacy_optout_tracking_deny') }}
-			</b-radio>
-			<p v-if="showOptOutExplanation === 0" class="has-text-dark-lighter has-margin-top-18">{{ $t( 'privacy_optout_tracking_state' ) }}</p>
-			<p v-else class="has-text-dark-lighter has-margin-top-18" v-html="$t( 'privacy_optout_tracking_state_no' )"></p>
-		</fieldset>
+	<div class="column is-full">
+		<h2 class="title is-size-2">{{ pageTitle }}</h2>
+		<div v-html="partialContentFirstHalf" class="has-margin-top-18 is-full static-content"></div>
+		<div class="column is-full privacy-selection has-padding-36">
+			<h2 class="title is-size-2">{{ $t( 'privacy_protection_title' ) }}</h2>
+			<fieldset>
+				<legend class="legend">
+					{{ $t('privacy_optout_description') }}
+				</legend>
+				<b-radio id="tracking-opt-in"
+						name="matomo_choice"
+						:native-value="0"
+						v-model="optOut"
+						@input="changeTracking">
+					{{ $t('privacy_optout_tracking_permit') }}
+				</b-radio>
+				<b-radio id="tracking-opt-out"
+						name="matomo_choice"
+						:native-value="1"
+						v-model="optOut"
+						@input="changeTracking">
+					{{ $t('privacy_optout_tracking_deny') }}
+				</b-radio>
+				<p v-if="showOptOutExplanation === 0" class="has-text-dark-lighter has-margin-top-18">{{ $t( 'privacy_optout_tracking_state' ) }}</p>
+				<p v-else class="has-text-dark-lighter has-margin-top-18" v-html="$t( 'privacy_optout_tracking_state_no' )"></p>
+			</fieldset>
+		</div>
+		<div v-html="partialContentSecondHalf" class="has-margin-top-18 is-full static-content"></div>
 	</div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import jsonp from 'jsonp';
-import { TRACKING_URL } from '@/trackingUrl';
 
 export default Vue.extend( {
 	name: 'PrivacyProtection',
 	data: function () {
+		const splitContent = this.$props.pageContent.split( '<!-- placeholder_matomo -->' );
 		return {
+			partialContentFirstHalf: splitContent[ 0 ],
+			partialContentSecondHalf: splitContent[ 1 ],
 			optOut: 0,
 			showOptOutExplanation: 0,
 		};
+	},
+	props: {
+		pageId: String,
+		pageTitle: String,
+		pageContent: String,
+		trackingUrl: String,
 	},
 	beforeMount: function () {
 		this.getInitialTrackingState();
@@ -44,7 +57,7 @@ export default Vue.extend( {
 	methods: {
 		changeTracking: function (): void {
 			if ( this.$data.optOut === 0 ) {
-				jsonp( TRACKING_URL + 'index.php?module=API&method=AjaxOptOut.doTrack&format=json',
+				jsonp( this.$props.trackingUrl + 'index.php?module=API&method=AjaxOptOut.doTrack&format=json',
 					undefined,
 					( error, data ) => {
 						if ( data.result === 'success' ) {
@@ -53,7 +66,7 @@ export default Vue.extend( {
 					}
 				);
 			} else {
-				jsonp( TRACKING_URL + 'index.php?module=API&method=AjaxOptOut.doIgnore&format=json',
+				jsonp( this.$props.trackingUrl + 'index.php?module=API&method=AjaxOptOut.doIgnore&format=json',
 					undefined,
 					( error, data ) => {
 						if ( data.result === 'success' ) {
@@ -64,7 +77,7 @@ export default Vue.extend( {
 			}
 		},
 		getInitialTrackingState: function (): void {
-			jsonp( TRACKING_URL + 'index.php?module=API&method=AjaxOptOut.isTracked&format=json',
+			jsonp( this.$props.trackingUrl + 'index.php?module=API&method=AjaxOptOut.isTracked&format=json',
 				undefined,
 				( error, data ) => {
 					this.$data.optOut = data.value ? 0 : 1;
@@ -77,13 +90,25 @@ export default Vue.extend( {
 
 <style lang="scss">
 	@import "../../scss/custom.scss";
-		.privacy-selection {
-			border: 1px solid $fun-color-gray-mid;
-			border-radius: 2px;
-			.b-radio.radio {
-				& + .radio {
-					margin-left: 0;
-				}
+	.privacy-selection {
+		border: 1px solid $fun-color-gray-mid;
+		border-radius: 2px;
+		.b-radio.radio {
+			& + .radio {
+				margin-left: 0;
 			}
 		}
+	}
+	.static-content {
+		ol {
+			margin-left: 1.5em;
+		}
+		& > ol {
+			padding-left: 10px;
+			list-style-type: upper-roman;
+		}
+		p {
+			margin: 0 0 11px;
+		}
+	}
 </style>

--- a/skins/laika/src/components/pages/StaticPage.vue
+++ b/skins/laika/src/components/pages/StaticPage.vue
@@ -1,28 +1,15 @@
 <template>
 <div class="column is-full">
 	<h2 class="title is-size-2">{{ pageTitle }}</h2>
-	<div v-html="partialContentFirstHalf" class="has-margin-top-18 is-full static-content"></div>
-	<privacy-protection v-if="pageId === 'privacy_protection'"></privacy-protection>
-	<div v-html="partialContentSecondHalf" class="has-margin-top-18 is-full static-content"></div>
+	<div v-html="pageContent" class="has-margin-top-18 is-full static-content"></div>
 </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import PrivacyProtection from '@/components/pages/PrivacyProtection.vue';
 
 export default Vue.extend( {
 	name: 'StaticPage',
-	components: {
-		PrivacyProtection,
-	},
-	data: function () {
-		const splitContent = this.$props.pageContent.split( '<!-- placeholder_matomo -->' );
-		return {
-			partialContentFirstHalf: splitContent[ 0 ],
-			partialContentSecondHalf: splitContent[ 1 ],
-		};
-	},
 	props: {
 		pageId: String,
 		pageTitle: String,

--- a/skins/laika/src/pages/privacy_protection.ts
+++ b/skins/laika/src/pages/privacy_protection.ts
@@ -1,0 +1,46 @@
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+import PageDataInitializer from '@/page_data_initializer';
+import { DEFAULT_LOCALE } from '@/locales';
+import App from '@/components/App.vue';
+
+import Component from '@/components/pages/PrivacyProtection.vue';
+import Sidebar from '@/components/layout/Sidebar.vue';
+
+const staticPage: any = document.getElementById( 'app' );
+const PAGE_IDENTIFIER = staticPage.getAttribute( 'data-page-id' );
+
+Vue.config.productionTip = false;
+Vue.use( VueI18n );
+
+const pageData = new PageDataInitializer<any>( '#app' );
+
+const i18n = new VueI18n( {
+	locale: DEFAULT_LOCALE,
+	messages: {
+		[ DEFAULT_LOCALE ]: pageData.messages,
+	},
+} );
+
+new Vue( {
+	i18n,
+	render: h => h( App, {
+		props: {
+			assetsPath: pageData.assetsPath,
+			pageIdentifier: PAGE_IDENTIFIER,
+		},
+	},
+	[
+		h( Component, {
+			props: {
+				pageId: staticPage.getAttribute( 'data-page-id' ),
+				pageTitle: staticPage.getAttribute( 'data-page-title' ),
+				pageContent: staticPage.getAttribute( 'data-page-content' ),
+				trackingUrl: staticPage.getAttribute( 'data-tracking-url' ),
+			},
+		} ),
+		h( Sidebar, {
+			slot: 'sidebar',
+		} ),
+	] ),
+} ).$mount( '#app' );

--- a/skins/laika/src/trackingUrl.ts
+++ b/skins/laika/src/trackingUrl.ts
@@ -1,1 +1,0 @@
-export const TRACKING_URL = '//tracking.wikimedia.de/';

--- a/skins/laika/templates/page_layouts/privacy_protection.html.twig
+++ b/skins/laika/templates/page_layouts/privacy_protection.html.twig
@@ -10,16 +10,17 @@
 		data-page-content="{$ content | e('html_attr') | raw $}"
 		data-application-vars="{$ _context|json_encode|e('html_attr') $}" 
 		data-application-messages="{$ translations()|e('html_attr') $}" 
-		data-assets-path="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/laika{% endif %}">
+		data-assets-path="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/laika{% endif %}"
+		data-tracking-url="{$ piwik.baseUrl | e('html_attr') $}">
 	</div>
 	<noscript>
 		<h2>{$ title $}</h2>
-		{$ content $}
+		{$ content | raw $}
 	</noscript>
 </div>
 {% endblock %}
 
 {% block scripts %}
 	{$ parent() $}
-	<script src="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/laika{% endif %}/js/static_page.js"></script>
+	<script src="{% if assets_path %}{$ assets_path $}{% else %}{$ basepath $}/skins/laika{% endif %}/js/privacy_protection.js"></script>
 {% endblock %}

--- a/skins/laika/vue.config.js
+++ b/skins/laika/vue.config.js
@@ -30,6 +30,7 @@ module.exports = {
 		membership_application_cancellation_confirmation: 'src/pages/membership_application_cancellation_confirmation.ts',
 		membership_application_confirmation: 'src/pages/membership_application_confirmation.ts',
 		page_not_found: 'src/pages/page_not_found.ts',
+		privacy_protection: 'src/pages/privacy_protection.ts',
 		static_page: 'src/pages/static_page.ts',
 		system_message: 'src/pages/system_message.ts',
 		update_address: 'src/pages/update_address.ts',


### PR DESCRIPTION
Split the privacy protection and static page component.
This makes the static page component more readable.

Remove trackingUrl constant, as the tracking URL is a global
configuration that needs to be passed into the app.