### PR TITLE
Remove polling from laika dev server

### DIFF
--- a/skins/laika/vue.config.js
+++ b/skins/laika/vue.config.js
@@ -38,7 +38,7 @@ module.exports = {
 	},
 	devServer: {
 		watchOptions: {
-			poll: true,
+			poll: false,
 		},
 	},
 	outputDir: path.resolve( __dirname, '../../web/skins/laika' ),


### PR DESCRIPTION
See https://stackoverflow.com/questions/56768388/high-cpu-usage-from-node-js-when-running-vue-cli-service-serve

Let me know if this breaks the laika_skin docker container. I'm not using that while developing for laika because it's such a CPU hog.