### PR TITLE
Exclude var directory from deployment tarball

### DIFF
--- a/deployment/tasks/build.yml
+++ b/deployment/tasks/build.yml
@@ -42,4 +42,4 @@
       DOCKER_FLAGS: ""
 
 - name: Create tarball
-  shell: tar -czf {{ build_dir }}.tar.gz --exclude=".git" --exclude=node_modules -C {{ build_dir }} . warn=no
+  shell: tar -czf {{ build_dir }}.tar.gz --exclude=".git" --exclude=node_modules --exclude=var -C {{ build_dir }} . warn=no


### PR DESCRIPTION
On the deploy server, `var` contains the npm cache directory. We don't
need to copy the cache to the target system at all because we only
deploy compiled JavaScript. This change will speed up the deployment -
the cache has about 8000 files and is 171 MB in size!