### PR TITLE
Remove GELF logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
 		"remotelyliving/doorkeeper": "^1.4",
 		"doctrine/migrations": "~1.8",
 		"nikic/php-parser": "~4.0",
-		"graylog2/gelf-php": "~1.5",
 		"vlucas/phpdotenv": "~3.3.3"
 	},
 	"repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e727fc7d7fb655599a84f091f74a21ec",
+    "content-hash": "910b92899f925034e5a5dd40d8ac3aa8",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -763,16 +763,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.6.3",
+            "version": "v2.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "434820973cadf2da2d66e7184be370084cc32ca8"
+                "reference": "b52ef5a1002f99ab506a5a2d6dba5a2c236c5f43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/434820973cadf2da2d66e7184be370084cc32ca8",
-                "reference": "434820973cadf2da2d66e7184be370084cc32ca8",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/b52ef5a1002f99ab506a5a2d6dba5a2c236c5f43",
+                "reference": "b52ef5a1002f99ab506a5a2d6dba5a2c236c5f43",
                 "shasum": ""
             },
             "require": {
@@ -787,9 +787,8 @@
                 "symfony/console": "~3.0|~4.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^1.0",
-                "phpunit/phpunit": "^6.5",
-                "squizlabs/php_codesniffer": "^3.2",
+                "doctrine/coding-standard": "^5.0",
+                "phpunit/phpunit": "^7.5",
                 "symfony/yaml": "~3.4|~4.0"
             },
             "suggest": {
@@ -815,16 +814,16 @@
             ],
             "authors": [
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
                     "name": "Benjamin Eberlei",
                     "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
                 },
                 {
                     "name": "Jonathan Wage",
@@ -841,7 +840,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2018-11-20T23:46:46+00:00"
+            "time": "2019-09-20T14:30:26+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -1127,60 +1126,6 @@
                 "uploadable"
             ],
             "time": "2019-03-17T18:16:12+00:00"
-        },
-        {
-            "name": "graylog2/gelf-php",
-            "version": "1.6.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bzikarsky/gelf-php.git",
-                "reference": "252a8be183f36dc8ad60d952f17bc36138d743cc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bzikarsky/gelf-php/zipball/252a8be183f36dc8ad60d952f17bc36138d743cc",
-                "reference": "252a8be183f36dc8ad60d952f17bc36138d743cc",
-                "shasum": ""
-            },
-            "require": {
-                "paragonie/constant_time_encoding": "^1|^2",
-                "php": ">=5.3.9",
-                "psr/log": "~1.0"
-            },
-            "provide": {
-                "psr/log-implementation": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8.36",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Gelf\\": "src/Gelf"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Benjamin Zikarsky",
-                    "email": "benjamin@zikarsky.de"
-                },
-                {
-                    "name": "gelf-php contributors",
-                    "homepage": "https://github.com/bzikarsky/gelf-php/contributors"
-                }
-            ],
-            "description": "A php implementation to send log-messages to a GELF compatible backend like Graylog2.",
-            "time": "2019-07-29T18:15:25+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1815,68 +1760,6 @@
                 "service proxies"
             ],
             "time": "2019-08-10T08:37:15+00:00"
-        },
-        {
-            "name": "paragonie/constant_time_encoding",
-            "version": "v2.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/constant_time_encoding.git",
-                "reference": "55af0dc01992b4d0da7f6372e2eac097bbbaffdb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/55af0dc01992b4d0da7f6372e2eac097bbbaffdb",
-                "reference": "55af0dc01992b4d0da7f6372e2eac097bbbaffdb",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6|^7",
-                "vimeo/psalm": "^1|^2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ParagonIE\\ConstantTime\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Steve 'Sc00bz' Thomas",
-                    "email": "steve@tobtu.com",
-                    "homepage": "https://www.tobtu.com",
-                    "role": "Original Developer"
-                }
-            ],
-            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
-            "keywords": [
-                "base16",
-                "base32",
-                "base32_decode",
-                "base32_encode",
-                "base64",
-                "base64_decode",
-                "base64_encode",
-                "bin2hex",
-                "encoding",
-                "hex",
-                "hex2bin",
-                "rfc4648"
-            ],
-            "time": "2019-01-03T20:26:31+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -5339,7 +5222,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "? Nette NEON: encodes and decodes NEON file format.",
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",

--- a/src/Factories/LoggerFactory.php
+++ b/src/Factories/LoggerFactory.php
@@ -4,10 +4,7 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Factories;
 
-use Gelf\Publisher;
-use Gelf\Transport\UdpTransport;
 use Monolog\Handler\ErrorLogHandler;
-use Monolog\Handler\GelfHandler;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
@@ -19,7 +16,6 @@ class LoggerFactory {
 
 	private const TYPE_ERROR_LOG = 'error_log';
 	private const TYPE_FILE = 'file';
-	private const TYPE_GELF = 'gelf';
 
 	private $config;
 
@@ -38,14 +34,6 @@ class LoggerFactory {
 				return new ErrorLogHandler( ErrorLogHandler::OPERATING_SYSTEM, $this->config['level'] );
 			case self::TYPE_FILE:
 				return new StreamHandler( $this->config['url'], $this->config['level'] );
-			case self::TYPE_GELF:
-				$url = parse_url( $this->config['url'] );
-				return new GelfHandler(
-					new Publisher(
-						new UdpTransport( $url['host'], $url['port'] ?? UdpTransport::DEFAULT_PORT )
-					),
-					$this->config['level']
-				);
 			default:
 				throw new \InvalidArgumentException( 'Unknown logging method - ' . $this->config['method'] );
 		}

--- a/tests/Unit/Factories/LoggerFactoryTest.php
+++ b/tests/Unit/Factories/LoggerFactoryTest.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Tests\Unit\Factories;
 
 use Monolog\Handler\ErrorLogHandler;
-use Monolog\Handler\GelfHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use org\bovigo\vfs\vfsStream;
@@ -38,19 +37,6 @@ class LoggerFactoryTest extends TestCase {
 		$this->assertInstanceOf( StreamHandler::class, $firstHandler );
 		$this->assertSame( Logger::ERROR, $firstHandler->getLevel() );
 		$this->assertSame( vfsStream::url( 'logs/error.log' ), $firstHandler->getUrl() );
-	}
-
-	public function testGivenGraylogConfiguration_itReturnsStreamHandler() {
-		$factory = new LoggerFactory( [
-			'method' => 'gelf',
-			'url' => 'example.com:12201',
-			'level' => 'NOTICE'
-		]);
-		$logger = $factory->getLogger();
-		$this->assertCount( 1, $logger->getHandlers() );
-		$firstHandler = $logger->getHandlers()[0]; /** @var GelfHandler $firstHandler */
-		$this->assertInstanceOf( GelfHandler::class, $firstHandler );
-		$this->assertSame( Logger::NOTICE, $firstHandler->getLevel() );
 	}
 
 	public function testGivenUnknownLogType_exeptionIsThrown() {


### PR DESCRIPTION
We no longer use Graylog and have switched all configuration files to
file-based logging.

This is for https://phabricator.wikimedia.org/T213293 and https://phabricator.wikimedia.org/T221643