### PR TITLE
Fix undeclared props shown as attributes in DOM

### DIFF
--- a/skins/laika/src/components/pages/donation_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/donation_form/subpages/AddressPage.vue
@@ -11,10 +11,16 @@
 							:amount="paymentSummary.amount"
 							:payment-type="paymentSummary.paymentType"
 							:interval="paymentSummary.interval"
-							v-on:previous-page="previousPage"
-			></payment-summary>
+							v-on:previous-page="previousPage">
+			</payment-summary>
 		</div>
-		<address-fields v-bind="$props" ref="address"></address-fields>
+		<address-fields
+				:validate-address-url="validateAddressUrl"
+				:validate-bank-data-url="validateBankDataUrl"
+				:validate-legacy-bank-data-url="validateLegacyBankDataUrl"
+				:countries="countries"
+				ref="address">
+		</address-fields>
 			<div class="summary-wrapper has-margin-top-18 has-outside-border">
 				<donation-summary :payment="paymentSummary" :address-type="addressType" :address="addressSummary">
 					<div class="title is-size-5">{{ $t( 'donation_confirmation_review_headline' ) }}</div>

--- a/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
+++ b/skins/laika/src/components/pages/membership_form/subpages/AddressPage.vue
@@ -2,7 +2,11 @@
 	<div class="address-page">
 		<h1 class="title is-size-1">{{ $t('membership_form_headline' ) }}</h1>
 		<membership-type v-if="showMembershipTypeOption"></membership-type>
-		<address-fields v-bind="$props" ref="address"></address-fields>
+		<address-fields
+				:validate-address-url="validateAddressUrl"
+				:countries="countries"
+				ref="address">
+		</address-fields>
 		<div class="level has-margin-top-18">
 			<div class="level-left">
 				<b-button id="next" :class="[ 'is-form-input-width', $store.getters.isValidating ? 'is-loading' : '', 'level-item']"


### PR DESCRIPTION
This PR fixes issues caused by `v-bind="$props"`. Specifically, trackingData was handed to the Address components but not used which then made Vue turn them into attributes which were not being handled properly and ended up looking like this:

![Bild eingefügt am 2019-9-18 09-24](https://user-images.githubusercontent.com/4571512/65140535-0da82a00-da0f-11e9-9a6f-754df45a0639.png)

Thanks @tzhelyazkova for explaining the gist of the problem.