### PR TITLE
Log request parameters when CC notification fails

### DIFF
--- a/app/Controllers/CreditCardPaymentNotificationController.php
+++ b/app/Controllers/CreditCardPaymentNotificationController.php
@@ -34,6 +34,7 @@ class CreditCardPaymentNotificationController {
 
 		$loggingContext = $response->getLowLevelError() === null ? [] : [ 'exception' => $response->getLowLevelError() ];
 		if ( !$response->isSuccessful() ) {
+			$loggingContext['queryParams'] = $request->query->all();
 			$ffFactory->getLogger()->error( 'Credit Card Notification Error: ' . $response->getErrorMessage(), $loggingContext );
 		} elseif ( $loggingContext !== [] ) {
 			$ffFactory->getLogger()->warning( 'Failed to send conformation email for credit card notification', $loggingContext );


### PR DESCRIPTION
We're passing the incoming parameters of the credit card notification route
unvalidated to the credit card request library (micropayment). It
validates the parameters and will throw an exception if important
parameters are missing. To avoid losing the context (values in other,
valid parameters), we log the query string when an error occurs.

This is for https://phabricator.wikimedia.org/T236231