### PR TITLE
Log client IP address when credit card notification fails

### DIFF
--- a/app/Controllers/CreditCardPaymentNotificationController.php
+++ b/app/Controllers/CreditCardPaymentNotificationController.php
@@ -35,6 +35,7 @@ class CreditCardPaymentNotificationController {
 		$loggingContext = $response->getLowLevelError() === null ? [] : [ 'exception' => $response->getLowLevelError() ];
 		if ( !$response->isSuccessful() ) {
 			$loggingContext['queryParams'] = $request->query->all();
+			$loggingContext['clientIP'] = $request->getClientIp();
 			$ffFactory->getLogger()->error( 'Credit Card Notification Error: ' . $response->getErrorMessage(), $loggingContext );
 		} elseif ( $loggingContext !== [] ) {
 			$ffFactory->getLogger()->warning( 'Failed to send conformation email for credit card notification', $loggingContext );


### PR DESCRIPTION
This is useful to check if the request originated from the payment provider or some malicious entity.

This is for https://phabricator.wikimedia.org/T236293 and a followup for #1653 