### PR TITLE
Extend address type A/B test

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -77,10 +77,10 @@ anon_form_display:
   description: Test form variations of selecting anonymous donation - with selecting "address type" or 2 groups of radio buttons, first for selecting anonymous yes/no, then address type person/company
   reference: "https://phabricator.wikimedia.org/T234187"
   start: "2019-10-10 15:00:00"
-  end: "2019-10-25 15:00:00"
+  end: "2019-12-31 11:00:00"
   buckets:
      - "address_type"
      - "two_steps"
-  default_bucket: "address_type"
+  default_bucket: "two_steps"
   url_key: fd
   active: true


### PR DESCRIPTION
There is no final result which kind of choice is better, but we want to
use the successful one as default and be able to extend the test.

This is also important for Test #07, see https://phabricator.wikimedia.org/T235524#5602431