### PR TITLE
Redirect to laika for use of funds

### DIFF
--- a/app/Routes.php
+++ b/app/Routes.php
@@ -329,14 +329,9 @@ class Routes {
 
 		$app->get(
 			'use-of-funds',
-			function () use ( $ffFactory ) {
-				$ffFactory->getTranslationCollector()->addTranslationFile($ffFactory->getI18nDirectory() . '/messages/useOfFundsMessages.json' );
-				return $ffFactory->getLayoutTemplate( 'Funds_Usage.html.twig' )->render(
-					[
-						'use_of_funds_content' => $ffFactory->getApplicationOfFundsContent(),
-						'use_of_funds_messages' => $ffFactory->getApplicationOfFundsMessages()
-					]
-				);
+			function ( Request $request ) use ( $ffFactory ) {
+				$renderer = $ffFactory->getUseOfFundsRenderer();
+				return $renderer( $request );
 			}
 		)->bind( self::SHOW_USE_OF_FUNDS );
 

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1854,6 +1854,10 @@ class FunFunFactory implements ServiceProviderInterface {
 		return new CampaignCollection( ...$this->getCampaigns() );
 	}
 
+	public function getUseOfFundsRenderer(): \Closure {
+		return $this->getChoiceFactory()->getUseOfFundsResponse( $this );
+	}
+
 	/**
 	 * TranslationCollector is currently only used by the Laika Vue-based frontend
 	 * In the future, the desired solution would be to use laika_messages.json exclusively


### PR DESCRIPTION
Create a redirect response when the use-of-funds page is requested on
10h16.

This solves https://phabricator.wikimedia.org/T237619

If we got too many errors for the faq page, we could apply a similar
pattern.