### PR TITLE
Add "URL-triggered" bucket testing

### DIFF
--- a/app/config/archived_campaigns.yaml
+++ b/app/config/archived_campaigns.yaml
@@ -24,3 +24,15 @@ usability:
     - improved
   default_bucket: old
   url_key: us
+
+donation_address:
+  description: Test address form being required immediately against only being presented optionally on the confirmation page
+  reference: "https://phabricator.wikimedia.org/T211666"
+  start: "2018-12-12 12:00:00"
+  end: "2019-01-07 23:00:00"
+  active: true
+  buckets:
+    - required
+    - optional
+  default_bucket: required
+  url_key: da

--- a/app/config/campaigns.dev.yml
+++ b/app/config/campaigns.dev.yml
@@ -7,10 +7,6 @@ skins:
   start: "2018-10-10"
   end: "2099-12-31"
 
-donation_address:
-  active: true
-  start: "2018-12-11"
-
 membership_call_to_action:
   active: true
 

--- a/app/config/campaigns.test.yml
+++ b/app/config/campaigns.test.yml
@@ -13,6 +13,3 @@ skins:
   buckets:
      - "test"
   default_bucket: "test"
-
-donation_address:
-  active: false

--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -22,19 +22,6 @@
 # url_key: URL parameter key used for assigning buckets to people
 # param_only: (Optional) Set to true if the campaign should return the default bucket when the url key is not in a request. This is for A/B tests triggered by banners
 
-donation_address:
-  description: Test address form being required immediately against only being presented optionally on the confirmation page
-  reference: "https://phabricator.wikimedia.org/T211666"
-  start: "2018-12-12 12:00:00"
-  end: "2019-01-07 23:00:00"
-  active: true
-  buckets:
-    - required
-    - optional
-  default_bucket: required
-  url_key: da
-
-
 skins:
   description: Test different skins
   reference: "https://phabricator.wikimedia.org/T206994"

--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -20,6 +20,8 @@
 # buckets: List of bucket names
 # default_bucket: used bucket when campaign is not active. Must be listed in buckets.
 # url_key: URL parameter key used for assigning buckets to people
+# param_only: (Optional) Set to true if the campaign should return the default bucket when the url key is not in a request. This is for A/B tests triggered by banners
+
 donation_address:
   description: Test address form being required immediately against only being presented optionally on the confirmation page
   reference: "https://phabricator.wikimedia.org/T211666"
@@ -44,6 +46,7 @@ skins:
   default_bucket: "laika"
   url_key: skin
   active: true
+  param_only: true
 
 membership_call_to_action:
   description: Display different content for membership call to action on donation confirmation page
@@ -84,6 +87,7 @@ anon_form_display:
   default_bucket: "two_steps"
   url_key: fd
   active: true
+  param_only: true
 
 compact_design:
   description: Test form design variation where the design is more compact by moving elements onto the same row and generally closer together.

--- a/src/BucketTesting/BucketSelector.php
+++ b/src/BucketTesting/BucketSelector.php
@@ -34,6 +34,7 @@ class BucketSelector {
 		$selectionStrategies = [
 			new InactiveCampaignBucketSelection( new CampaignDate() ),
 			new ParameterBucketSelection( $possibleParameters ),
+			new SelectDefaultWhenParamsAreMissingSelection( $possibleParameters ),
 			$this->fallbackSelectionStrategy
 		];
 

--- a/src/BucketTesting/Campaign.php
+++ b/src/BucketTesting/Campaign.php
@@ -18,11 +18,16 @@ class Campaign {
 	private $buckets;
 	private $urlKey;
 	private $defaultBucketIndex;
+	private $onlyActiveWithUrlKey;
 
 	public const ACTIVE = true;
 	public const INACTIVE = false;
 
-	public function __construct( string $name, string $urlKey, CampaignDate $startTimestamp, CampaignDate $endTimestamp, bool $isActive ) {
+	public const NEEDS_URL_KEY = true;
+	public const NEEDS_NO_URL_KEY = false;
+
+	public function __construct( string $name, string $urlKey, CampaignDate $startTimestamp, CampaignDate $endTimestamp,
+								 bool $isActive, bool $onlyActiveWithUrlKey = false ) {
 		$this->name = $name;
 		$this->urlKey = $urlKey;
 		$this->active = $isActive;
@@ -30,6 +35,7 @@ class Campaign {
 		$this->endTimestamp = $endTimestamp;
 		$this->buckets = [];
 		$this->defaultBucketIndex = -1;
+		$this->onlyActiveWithUrlKey = $onlyActiveWithUrlKey;
 	}
 
 	public function isActive(): bool {
@@ -91,5 +97,8 @@ class Campaign {
 		return $bucket;
 	}
 
+	public function isOnlyActiveWithUrlKey(): bool {
+		return $this->onlyActiveWithUrlKey;
+	}
 
 }

--- a/src/BucketTesting/CampaignBuilder.php
+++ b/src/BucketTesting/CampaignBuilder.php
@@ -28,7 +28,8 @@ class CampaignBuilder {
 				$config['url_key'],
 				CampaignDate::createFromString( $config['start'], $this->timezone ),
 				CampaignDate::createFromString( $config['end'], $this->timezone ),
-				$config['active']
+				$config['active'],
+				$config['param_only'] ?? Campaign::NEEDS_NO_URL_KEY
 			);
 			foreach ( $config['buckets'] as $bucketName ) {
 				$campaign->addBucket( new Bucket( $bucketName, $campaign, $bucketName === $config['default_bucket'] ) );

--- a/src/BucketTesting/CampaignConfiguration.php
+++ b/src/BucketTesting/CampaignConfiguration.php
@@ -35,6 +35,7 @@ class CampaignConfiguration implements ConfigurationInterface {
 						->isRequired()
 					->end()
 					->booleanNode( 'active' )
+						->info( 'If campaign is active. Allows for campaigns to run as long as they want' )
 						->isRequired()
 					->end()
 					->arrayNode( 'buckets' )
@@ -49,6 +50,10 @@ class CampaignConfiguration implements ConfigurationInterface {
 					->scalarNode( 'url_key' )
 						->info( 'URL parameter key used for assigning buckets to people' )
 						->isRequired()
+					->end()
+					->booleanNode( 'param_only' )
+						->info( 'Returns the default bucket when the "url_key" parameter is missing in a request' )
+						->defaultFalse()
 					->end()
 				->end()
 			->end();

--- a/src/BucketTesting/SelectDefaultWhenParamsAreMissingSelection.php
+++ b/src/BucketTesting/SelectDefaultWhenParamsAreMissingSelection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\BucketTesting;
+
+/**
+ * @license GNU GPL v2+
+ */
+class SelectDefaultWhenParamsAreMissingSelection implements BucketSelectionStrategy {
+
+	private $params;
+
+	public function __construct( array $params ) {
+		$this->params = $params;
+	}
+
+	public function selectBucketForCampaign( Campaign $campaign ): ?Bucket {
+		if ( $campaign->isOnlyActiveWithUrlKey() && !isset( $this->params[$campaign->getUrlKey()] ) ) {
+			return $campaign->getDefaultBucket();
+		}
+		return null;
+	}
+}

--- a/src/Factories/ChoiceFactory.php
+++ b/src/Factories/ChoiceFactory.php
@@ -23,15 +23,6 @@ class ChoiceFactory {
 		$this->featureToggle = $featureToggle;
 	}
 
-	public function isDonationAddressOptional(): bool {
-		if ( $this->featureToggle->featureIsActive( 'campaigns.donation_address.required' ) ) {
-			return false;
-		} elseif ( $this->featureToggle->featureIsActive( 'campaigns.donation_address.optional' ) ) {
-			return true;
-		}
-		throw new UnknownChoiceDefinition( 'Confirmation Page Template configuration failure.' );
-	}
-
 	public function getSkinTemplateDirectory(): string {
 		if ( $this->featureToggle->featureIsActive( 'campaigns.skins.laika' ) ) {
 			return $this->getSkinDirectory( 'laika' );

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1221,7 +1221,6 @@ class FunFunFactory implements ServiceProviderInterface {
 					[
 						'paymentTypes' => $this->getPaymentTypesSettings()->getEnabledForMembershipApplication(),
 						'featureToggle' => [
-							'donorUpdateEnabled' => $this->getChoiceFactory()->isDonationAddressOptional(),
 							'callToActionTemplate' => $this->getChoiceFactory()->getMembershipCallToActionTemplate()
 						],
 					]

--- a/tests/Unit/BucketTesting/BucketSelectorTest.php
+++ b/tests/Unit/BucketTesting/BucketSelectorTest.php
@@ -153,6 +153,33 @@ class BucketSelectorTest extends TestCase {
 		$this->assertTrue( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket should be selected by fallback selection strategy' );
 	}
 
+	public function testGivenNoParamsAndUrlActivatedCampaign_defaultBucketIsSelected() {
+		$campaign = new Campaign(
+			'test1',
+			't1',
+			( new CampaignDate() )->sub( new \DateInterval( 'P1M' ) ),
+			( new CampaignDate() )->add( new \DateInterval( 'P1M' ) ),
+			Campaign::ACTIVE,
+			Campaign::NEEDS_URL_KEY
+		);
+		$defaultBucket = new Bucket( 'a', $campaign, Bucket::DEFAULT );
+		$alternativeBucket = new Bucket( 'b', $campaign, Bucket::NON_DEFAULT );
+		$campaign->addBucket( $defaultBucket )->addBucket( $alternativeBucket );
+		$bucketSelector = new BucketSelector( new CampaignCollection( $campaign ), $this->bucketSelectionStrategy );
+
+		$this->assertSame(
+			[ $defaultBucket ],
+			$bucketSelector->selectBuckets( [], [] ),
+		);
+		$this->assertFalse( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket not should be selected by fallback selection strategy' );
+
+		$this->assertSame(
+			[ $alternativeBucket ],
+			$bucketSelector->selectBuckets( ['t1' => 1], [] ),
+			);
+		$this->assertFalse( $this->bucketSelectionStrategy->bucketWasSelected(), 'Bucket not should be selected by fallback selection strategy' );
+	}
+
 	/**
 	 * @dataProvider invalidParametersProvider
 	 */

--- a/tests/Unit/BucketTesting/CampaignBuilderTest.php
+++ b/tests/Unit/BucketTesting/CampaignBuilderTest.php
@@ -21,7 +21,8 @@ class CampaignBuilderTest extends TestCase {
 			'f',
 			new CampaignDate( '2018-10-10', new \DateTimeZone( 'UTC' ) ),
 			new CampaignDate( '2018-12-12', new \DateTimeZone( 'UTC' ) ),
-			true
+			true,
+			false
 		);
 		$firstExpectedCampaign
 			->addBucket( new Bucket( 'bucket1', $firstExpectedCampaign, Bucket::DEFAULT ) )
@@ -31,7 +32,8 @@ class CampaignBuilderTest extends TestCase {
 			's',
 			new CampaignDate( '2019-01-01', new \DateTimeZone( 'UTC' ) ),
 			new CampaignDate( '2025-12-31', new \DateTimeZone( 'UTC' ) ),
-			false
+			false,
+			true
 		);
 		$secondExpectedCampaign
 			->addBucket( new Bucket( 'example1', $secondExpectedCampaign, Bucket::NON_DEFAULT ) )
@@ -47,7 +49,8 @@ class CampaignBuilderTest extends TestCase {
 					'active' => true,
 					'buckets' => [ 'bucket1', 'bucket2' ],
 					'default_bucket' => 'bucket1',
-					'url_key' => 'f'
+					'url_key' => 'f',
+					'param_only' => false
 				],
 				'second' => [
 					'start' => '2019-01-01',
@@ -55,7 +58,8 @@ class CampaignBuilderTest extends TestCase {
 					'active' => false,
 					'buckets' => [ 'example1', 'example2', 'default' ],
 					'default_bucket' => 'default',
-					'url_key' => 's'
+					'url_key' => 's',
+					'param_only' => true
 				],
 			]
 		);
@@ -96,7 +100,8 @@ class CampaignBuilderTest extends TestCase {
 					'active' => true,
 					'buckets' => [ 'bucket1', 'bucket2' ],
 					'default_bucket' => 'bucket1',
-					'url_key' => 'f'
+					'url_key' => 'f',
+					'param_only' => false
 				],
 				'second' => [
 					'start' => '2019-01-01',
@@ -104,7 +109,8 @@ class CampaignBuilderTest extends TestCase {
 					'active' => false,
 					'buckets' => [ 'example1', 'example2', 'default' ],
 					'default_bucket' => 'default',
-					'url_key' => 's'
+					'url_key' => 's',
+					'param_only' => false
 				],
 			]
 		);

--- a/tests/Unit/BucketTesting/CampaignConfigurationTest.php
+++ b/tests/Unit/BucketTesting/CampaignConfigurationTest.php
@@ -23,7 +23,8 @@ class CampaignConfigurationTest extends TestCase {
 						'active' => true,
 						'buckets' => [ 'bucket1', 'bucket2' ],
 						'default_bucket' => 'bucket2',
-						'url_key' => 'mc'
+						'url_key' => 'mc',
+						'param_only' => true
 					],
 					'full_campaign' => [
 						'description' => 'This is just a test of a campaign configuration with all possible values set',
@@ -144,7 +145,8 @@ class CampaignConfigurationTest extends TestCase {
 						'active' => false,
 						'buckets' => [ 'bucket3' ],
 						'default_bucket' => 'bucket3',
-						'url_key' => 'fc'
+						'url_key' => 'fc',
+						'param_only' => true
 					],
 					'third_campaign' => [
 						'start' => '2020-10-31',
@@ -169,7 +171,8 @@ class CampaignConfigurationTest extends TestCase {
 					'active' => false,
 					'buckets' => [ 'bucket1', 'bucket2', 'bucket3' ],
 					'default_bucket' => 'bucket3',
-					'url_key' => 'fc'
+					'url_key' => 'fc',
+					'param_only' => true
 				],
 				'second_campaign' => [
 					'start' => '2019-01-01',
@@ -177,7 +180,8 @@ class CampaignConfigurationTest extends TestCase {
 					'active' => false,
 					'buckets' => [ 'bucket1', 'bucket2' ],
 					'default_bucket' => 'bucket2',
-					'url_key' => 'sc'
+					'url_key' => 'sc',
+					'param_only' => false
 				],
 				'third_campaign' => [
 					'start' => '2020-10-31',
@@ -185,7 +189,8 @@ class CampaignConfigurationTest extends TestCase {
 					'active' => true,
 					'buckets' => [ 'default', 'fancy' ],
 					'default_bucket' => 'default',
-					'url_key' => 'tc'
+					'url_key' => 'tc',
+					'param_only' => false
 				]
 			]
 		);

--- a/tests/Unit/BucketTesting/CampaignTest.php
+++ b/tests/Unit/BucketTesting/CampaignTest.php
@@ -83,11 +83,27 @@ class CampaignTest extends TestCase {
 		$campaign->getDefaultBucket();
 	}
 
-	public function testGivenCampaignwithDateRange_itCanBeCheckedForExpiration() {
+	public function testGivenCampaignWithDateRange_itCanBeCheckedForExpiration() {
 		$campaign = new Campaign( 'test', 't', new CampaignDate( '2018-10-01' ), new CampaignDate( '2018-12-31' ), true );
 
 		$this->assertTrue( $campaign->isExpired( new CampaignDate( '2018-09-09' ) ), 'Campaign is expired before start date' );
 		$this->assertTrue( $campaign->isExpired( new CampaignDate( '2025-02-25' ) ), 'Campaign is expired after end date' );
 		$this->assertFalse( $campaign->isExpired( new CampaignDate( '2018-10-02' ) ), 'Campaign is not expired inside date range' );
+	}
+
+	public function testCampaignsCanBeActiveAndInactive() {
+		$activeCampaign = new Campaign( 'test', 't', new CampaignDate( '2018-10-01' ), new CampaignDate( '2018-12-31' ), Campaign::ACTIVE );
+		$inActiveCampaign = new Campaign( 'test', 't', new CampaignDate( '2018-10-01' ), new CampaignDate( '2018-12-31' ), Campaign::INACTIVE );
+
+		$this->assertTrue( $activeCampaign->isActive() );
+		$this->assertFalse( $inActiveCampaign->isActive() );
+	}
+
+	public function testCampaignsUrlParameterCanBeActiveAndInactive() {
+		$activeCampaign = new Campaign( 'test', 't', new CampaignDate( '2018-10-01' ), new CampaignDate( '2018-12-31' ), Campaign::ACTIVE, Campaign::NEEDS_URL_KEY );
+		$inActiveCampaign = new Campaign( 'test', 't', new CampaignDate( '2018-10-01' ), new CampaignDate( '2018-12-31' ), Campaign::ACTIVE, Campaign::NEEDS_NO_URL_KEY );
+
+		$this->assertTrue( $activeCampaign->isOnlyActiveWithUrlKey() );
+		$this->assertFalse( $inActiveCampaign->isOnlyActiveWithUrlKey() );
 	}
 }


### PR DESCRIPTION
With the new `param_only` campaign configuration you can define
campaigns that return the default value instead of a random value when
the campaign parameter is missing in the URL.

This is for https://phabricator.wikimedia.org/T238527