### PR TITLE
Remove debug logging in Donation Confirmation

### DIFF
--- a/skins/laika/src/components/DonationSummary.vue
+++ b/skins/laika/src/components/DonationSummary.vue
@@ -19,7 +19,6 @@ class PrivateDonorRenderer {
 				+ address.streetAddress + ', ' + address.postalCode + ' ' + address.city + ', ' + country;
 	}
 	static canRender( address ) {
-		console.log( 'can render?', address.salutation, address.firstName, address.lastName, address.streetAddress, address.postalCode, address.city );
 		return address.salutation && address.firstName && address.lastName && address.streetAddress && address.postalCode && address.city;
 	}
 }


### PR DESCRIPTION
PR #1665 accidentally kept the debug logging of donor confirmation
data to the browser console.