### PR TITLE
Upgrade Docker image to Node 12 LTS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   # webpack dev server for laika skin development
   skin_laika:
-    image: node:10
+    image: node:12
     expose:
       - "8080"
     ports:


### PR DESCRIPTION
This upgrades the Docker containers from 10 to 12 in hopes of resolving some Node-related crashes we sometimes have.

Once this is merged, you need to run `docker-compose rm skin_laika` to force it to re-download the Sass version which is compatible with Node 12.
