### PR TITLE
Make 3-step address chooser default

### DIFF
--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -74,7 +74,7 @@ anon_form_display:
      - "address_type"
      - "two_steps"
      - "two_steps_fixed_disclaimer"
-  default_bucket: "two_steps"
+  default_bucket: "address_type"
   url_key: fd
   active: true
   param_only: true


### PR DESCRIPTION
We were missing too many addresses with `two_step`.