### PR TITLE
Make IBAN on confirmation page more readable.

### DIFF
--- a/skins/10h16/templates/Donation_Confirmation.html.twig
+++ b/skins/10h16/templates/Donation_Confirmation.html.twig
@@ -88,8 +88,8 @@
 					<div class="container payment">
 						<span class="label">Kontoinhaber</span>Wikimedia Foerdergesellschaft<br/>
 						<span class="label">Betrag</span>{$ formattedAmount $}<br/>
-						<span class="label">IBAN</span>DE33100205000001194700<br/>
-						<span class="label">BIC</span>BFSWDE33BER<br/>
+						<span class="label">IBAN</span><span class="digit-group">DE33</span><span class="digit-group">1002</span><span class="digit-group">0500</span><span class="digit-group">0001</span><span class="digit-group">1947</span><span class="digit-group">00</span><br/>
+						<span class="label">BIC</span><span class="digit-group">BFSW</span><span class="digit-group">DE33</span><span class="digit-group">BER</span><br/>
 						<span class="label">Kontonummer</span>1194700<br/>
 						<span class="label">Bankleitzahl</span>10020500<br/>
 						<span class="label">Bank</span>Bank für Sozialwirtschaft<br/>

--- a/skins/10h16/web/_styles/styles.css
+++ b/skins/10h16/web/_styles/styles.css
@@ -442,6 +442,11 @@ section.container { overflow: hidden; }
 .step-list li.first { background: #65b6ed url(../_assets/img/steps_overview_step_list_item_1.png) right center no-repeat; }
 .step-list li.last { width: 155px; background: #64aadb; margin-right: 0 !important; padding-right: 0; }
 
+/* separating long numbers into digit groups */
+.digit-group {
+	margin-right: 0.25em;
+}
+
 ul.horizontal.share { height: 0px; margin-top: -4px; }
 ul.horizontal.share li { margin: 0 0 0 8px; font-size: 1.4em; }
 ul.horizontal.share li a { color: #e1f3de; }


### PR DESCRIPTION
Add spaces in the markup that will not be copied when selecting and
pasting as plain text.

This is for https://phabricator.wikimedia.org/T238913