### PR TITLE
Add amount too low clientside validation message

### DIFF
--- a/skins/laika/src/components/pages/donation_form/Payment.vue
+++ b/skins/laika/src/components/pages/donation_form/Payment.vue
@@ -4,7 +4,7 @@
 				:payment-amounts="paymentAmounts"
 				:amount="amount"
 				:title="$t('donation_form_payment_amount_title')"
-				:error="amountIsValid ? '' : $t('donation_form_payment_amount_error')"
+				:error="showErrorMessage"
 				v-on:amount-selected="sendAmountToStore"
 		></amount-selection>
 		<payment-interval
@@ -37,6 +37,7 @@ import { NS_ADDRESS, NS_PAYMENT } from '@/store/namespaces';
 import { setAmount, setInterval, setType } from '@/store/payment/actionTypes';
 import { mapGetters, mapState } from 'vuex';
 import { AddressTypeModel } from '@/view_models/AddressTypeModel';
+import { AmountValidity } from '@/view_models/Payment';
 
 export default Vue.extend( {
 	name: 'Payment',
@@ -53,7 +54,15 @@ export default Vue.extend( {
 			type: ( state: any ) => state[ NS_PAYMENT ].values.type,
 			disabledPaymentTypes: ( state: any ) => state[ NS_ADDRESS ].addressType === AddressTypeModel.ANON ? [ 'BEZ' ] : [],
 		} ),
-		...mapGetters( NS_PAYMENT, [ 'amountIsValid', 'typeIsValid' ] ),
+		...mapGetters( NS_PAYMENT, [ 'amountValidity', 'typeIsValid' ] ),
+		showErrorMessage(): String {
+			const messages : { [ key:number ]:string; } = {
+				[ AmountValidity.AMOUNT_VALID ]: '',
+				[ AmountValidity.AMOUNT_TOO_LOW ]: this.$t( 'donation_form_payment_amount_error' ) as string,
+				[ AmountValidity.AMOUNT_TOO_HIGH ]: this.$t( 'donation_form_payment_amount_too_high' ) as string,
+			};
+			return messages[ this.$store.getters[ NS_PAYMENT + '/amountValidity' ] ];
+		},
 	},
 	methods: {
 		sendAmountToStore( amountValue: string ): Promise<null> {

--- a/skins/laika/src/store/payment/getters.ts
+++ b/skins/laika/src/store/payment/getters.ts
@@ -1,5 +1,5 @@
 import { GetterTree } from 'vuex';
-import { Payment } from '@/view_models/Payment';
+import { AmountValidity, Payment } from '@/view_models/Payment';
 import { Validity } from '@/view_models/Validity';
 
 export const getters: GetterTree<Payment, any> = {
@@ -8,6 +8,20 @@ export const getters: GetterTree<Payment, any> = {
 	},
 	typeIsValid: function ( state: Payment ): boolean {
 		return state.validity.type !== Validity.INVALID;
+	},
+	amountValidity: function ( state: Payment ): AmountValidity {
+		/* TODO reuse configuration amounts from config files:
+		    "donation-minimum-amount": 1,
+		    "donation-maximum-amount": 100000,
+		    see https://phabricator.wikimedia.org/T239349
+		    */
+		if ( state.validity.amount !== Validity.INVALID ) {
+			return AmountValidity.AMOUNT_VALID;
+		}
+		if ( Number( state.values.amount ) > 100000 ) {
+			return AmountValidity.AMOUNT_TOO_HIGH;
+		}
+		return AmountValidity.AMOUNT_TOO_LOW;
 	},
 	paymentDataIsValid: function ( state: Payment ): boolean {
 		for ( const prop in state.validity ) {

--- a/skins/laika/src/view_models/Payment.ts
+++ b/skins/laika/src/view_models/Payment.ts
@@ -29,3 +29,9 @@ export interface InitialPaymentValues {
     paymentIntervalInMonths: string,
     isCustomAmount: boolean,
 }
+
+export enum AmountValidity {
+    AMOUNT_VALID,
+    AMOUNT_TOO_LOW,
+    AMOUNT_TOO_HIGH,
+}

--- a/skins/laika/tests/unit/store/payment_store.spec.ts
+++ b/skins/laika/tests/unit/store/payment_store.spec.ts
@@ -2,6 +2,7 @@ import { getters } from '@/store/payment/getters';
 import { actions } from '@/store/payment/actions';
 import { mutations } from '@/store/payment/mutations';
 import { Validity } from '@/view_models/Validity';
+import { AmountValidity } from '@/view_models/Payment';
 import {
 	initializePayment,
 	markEmptyAmountAsInvalid,
@@ -70,6 +71,48 @@ describe( 'Payment', () => {
 				) ).toBe( isValid );
 			},
 		);
+	} );
+
+	describe( 'Getters/amountValidity', () => {
+		const invalidCentAmountsTooLow = [ 0, 99 ];
+		const invalidCentAmountsTooHigh = [ 10000000, 10000001 ];
+		const validCentAmounts = [ 100, 9999999 ];
+
+		it( 'does not return invalid amount on initalization', () => {
+			expect( getters.amountValidity(
+				newMinimalStore( {} ),
+				null,
+				null,
+				null
+			) ).toBe( AmountValidity.AMOUNT_VALID );
+		} );
+
+		each( validCentAmounts ).it( 'does not return invalid amount on valid donation amount (cents)', ( validAmount ) => {
+			expect( getters.amountValidity(
+				newMinimalStore( { values: { amount: validAmount } } ),
+				null,
+				null,
+				null
+			) ).toBe( AmountValidity.AMOUNT_VALID );
+		} );
+
+		each( invalidCentAmountsTooLow ).it( 'returns amount too low error on minimum donation amounts (cents)', ( tooLowAmount ) => {
+			expect( getters.amountValidity(
+				newMinimalStore( { values: { amount: tooLowAmount }, validity: { amount: Validity.INVALID } } ),
+				null,
+				null,
+				null
+			) ).toBe( AmountValidity.AMOUNT_TOO_LOW );
+		} );
+
+		each( invalidCentAmountsTooHigh ).it( 'returns amount too high error on maximum donation amounts (cents)', ( tooHighAmount ) => {
+			expect( getters.amountValidity(
+				newMinimalStore( { values: { amount: tooHighAmount }, validity: { amount: Validity.INVALID } } ),
+				null,
+				null,
+				null
+			) ).toBe( AmountValidity.AMOUNT_TOO_HIGH );
+		} );
 	} );
 
 	describe( 'Getters/typeIsValid', () => {


### PR DESCRIPTION
split up the amount's invalid state into two distinctive states (-> too high, -> too low)
so the Payment-component can check which error message it should display

https://phabricator.wikimedia.org/T239202