### PR TITLE
Fix Autofill errors

### DIFF
--- a/skins/laika/src/camlize_name.ts
+++ b/skins/laika/src/camlize_name.ts
@@ -1,4 +1,4 @@
 // from kebab-case to camelCase
 export function camelizeName( fieldName: string ): string {
-	return fieldName.replace(/-(\w)/g, (_: string, firstChar: string) => firstChar.toUpperCase() );
+	return fieldName.replace( /-(\w)/g, ( _: string, firstChar: string ) => firstChar.toUpperCase() );
 }

--- a/skins/laika/src/camlize_name.ts
+++ b/skins/laika/src/camlize_name.ts
@@ -1,0 +1,4 @@
+// from kebab-case to camelCase
+export function camelizeName( fieldName: string ): string {
+	return fieldName.replace(/-(\w)/g, (_: string, firstChar: string) => firstChar.toUpperCase() );
+}

--- a/skins/laika/src/components/pages/donation_confirmation/AddressModal.vue
+++ b/skins/laika/src/components/pages/donation_confirmation/AddressModal.vue
@@ -7,10 +7,12 @@
 			{{ $t( 'donation_confirmation_address_update_success' ) }}
 		</div>
 		<div v-if="!hasErrored && !hasSucceeded">
-			<address-type v-on:address-type="setAddressType( $event )" :disabled-anonymous-type="true"></address-type>
-			<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
-			<postal :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"></postal>
-			<email :show-error="fieldErrors.email" :form-data="formData" v-on:field-changed="onFieldChange"></email>
+			<AutofillHandler v-on:autofill="onAutofill">
+				<address-type v-on:address-type="setAddressType( $event )" :disabled-anonymous-type="true"></address-type>
+				<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
+				<postal :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"></postal>
+				<email :show-error="fieldErrors.email" :form-data="formData" v-on:field-changed="onFieldChange"></email>
+			</AutofillHandler>
 			<newsletter-opt-in></newsletter-opt-in>
 			<div class="columns has-margin-top-18 has-padding-bottom-18">
 				<div class="column">
@@ -45,6 +47,7 @@ import Postal from '@/components/shared/Postal.vue';
 import ReceiptOptOut from '@/components/shared/ReceiptOptOut.vue';
 import Email from '@/components/shared/Email.vue';
 import NewsletterOptIn from '@/components/pages/donation_form/NewsletterOptIn.vue';
+import AutofillHandler from "@/components/shared/AutofillHandler.vue";
 import { mapGetters } from 'vuex';
 import { AddressValidity, AddressFormData, ValidationResult } from '@/view_models/Address';
 import { AddressTypeModel, addressTypeName } from '@/view_models/AddressTypeModel';
@@ -58,6 +61,7 @@ import SubmitValues from '@/components/pages/update_address/SubmitValues.vue';
 import axios, { AxiosResponse } from 'axios';
 import { trackDynamicForm, trackFormSubmission } from '@/tracking';
 import { mergeValidationResults } from '@/merge_validation_results';
+import { camelizeName } from "@/camlize_name";
 
 export interface SubmittedAddress {
 	addressData: AddressFormData,
@@ -76,6 +80,7 @@ export default Vue.extend( {
 		NewsletterOptIn,
 		PaymentBankData,
 		SubmitValues,
+		AutofillHandler
 	},
 	data: function (): { formData: AddressFormData, isValidating: boolean } {
 		return {
@@ -181,6 +186,14 @@ export default Vue.extend( {
 		},
 		onFieldChange( fieldName: string ): void {
 			this.$store.dispatch( action( NS_ADDRESS, setAddressField ), this.$data.formData[ fieldName ] );
+		},
+		onAutofill( autofilledFields: { [key: string]: string; } ) {
+			Object.keys( autofilledFields ).forEach( key => {
+				const fieldName = camelizeName( key );
+				if ( this.$data.formData[ fieldName ] ) {
+					this.$store.dispatch( action( NS_ADDRESS, setAddressField ), this.$data.formData[ fieldName ] );
+				}
+			} );
 		},
 		setAddressType( addressType: AddressTypeModel ): void {
 			this.$store.dispatch( action( NS_ADDRESS, setAddressType ), addressType );

--- a/skins/laika/src/components/pages/donation_confirmation/AddressModal.vue
+++ b/skins/laika/src/components/pages/donation_confirmation/AddressModal.vue
@@ -47,7 +47,7 @@ import Postal from '@/components/shared/Postal.vue';
 import ReceiptOptOut from '@/components/shared/ReceiptOptOut.vue';
 import Email from '@/components/shared/Email.vue';
 import NewsletterOptIn from '@/components/pages/donation_form/NewsletterOptIn.vue';
-import AutofillHandler from "@/components/shared/AutofillHandler.vue";
+import AutofillHandler from '@/components/shared/AutofillHandler.vue';
 import { mapGetters } from 'vuex';
 import { AddressValidity, AddressFormData, ValidationResult } from '@/view_models/Address';
 import { AddressTypeModel, addressTypeName } from '@/view_models/AddressTypeModel';
@@ -61,7 +61,7 @@ import SubmitValues from '@/components/pages/update_address/SubmitValues.vue';
 import axios, { AxiosResponse } from 'axios';
 import { trackDynamicForm, trackFormSubmission } from '@/tracking';
 import { mergeValidationResults } from '@/merge_validation_results';
-import { camelizeName } from "@/camlize_name";
+import { camelizeName } from '@/camlize_name';
 
 export interface SubmittedAddress {
 	addressData: AddressFormData,
@@ -80,7 +80,7 @@ export default Vue.extend( {
 		NewsletterOptIn,
 		PaymentBankData,
 		SubmitValues,
-		AutofillHandler
+		AutofillHandler,
 	},
 	data: function (): { formData: AddressFormData, isValidating: boolean } {
 		return {

--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -1,6 +1,8 @@
 <template>
 	<div class="address-section">
-		<payment-bank-data v-if="isDirectDebit" :validateBankDataUrl="validateBankDataUrl" :validateLegacyBankDataUrl="validateLegacyBankDataUrl"></payment-bank-data>
+		<AutofillHandler @autofill="onAutofill" >
+			<payment-bank-data v-if="isDirectDebit" :validateBankDataUrl="validateBankDataUrl" :validateLegacyBankDataUrl="validateLegacyBankDataUrl"></payment-bank-data>
+		</AutofillHandler>
 		<feature-toggle>
 			<two-step-address-type
 					slot="campaigns.anon_form_display.two_steps"
@@ -24,16 +26,19 @@
 					class="has-margin-top-18"
 					v-show="!addressTypeIsNotAnon">{{ $t( 'donation_addresstype_option_anonymous_disclaimer' ) }}</div>
 		</feature-toggle>
-		<name v-if="addressTypeIsNotAnon" :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
-		<postal v-if="addressTypeIsNotAnon" :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"></postal>
-		<receipt-opt-out v-if="addressTypeIsNotAnon" v-on:opted-out="setReceiptOptedOut( $event )"/>
-		<email v-if="addressTypeIsNotAnon" :show-error="fieldErrors.email" :form-data="formData" v-on:field-changed="onFieldChange"></email>
-		<newsletter-opt-in v-if="addressTypeIsNotAnon"></newsletter-opt-in>
+		<AutofillHandler @autofill="onAutofill" >
+			<name v-if="addressTypeIsNotAnon" :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
+			<postal v-if="addressTypeIsNotAnon" :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"></postal>
+			<receipt-opt-out v-if="addressTypeIsNotAnon" v-on:opted-out="setReceiptOptedOut( $event )"/>
+			<email v-if="addressTypeIsNotAnon" :show-error="fieldErrors.email" :form-data="formData" v-on:field-changed="onFieldChange"></email>
+			<newsletter-opt-in v-if="addressTypeIsNotAnon"></newsletter-opt-in>
+		</AutofillHandler>
 	</div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import AutofillHandler from '@/components/shared/AutofillHandler.vue';
 import AddressType from '@/components/pages/donation_form/AddressType.vue';
 import Name from '@/components/shared/Name.vue';
 import Postal from '@/components/shared/Postal.vue';
@@ -52,6 +57,11 @@ import TwoStepAddressType from '@/components/pages/donation_form/TwoStepAddressT
 import TwoStepFixedDisclaimerAddressType from '@/components/pages/donation_form/TwoStepFixedDisclaimerAddressType.vue';
 import { mergeValidationResults } from '@/merge_validation_results';
 
+// from kebab-case to camelCase
+function camelizeName( fieldName: string ): string {
+	return fieldName.replace(/-(\w)/g, (_: string, firstChar: string) => firstChar.toUpperCase() );
+}
+
 export default Vue.extend( {
 	name: 'Address',
 	components: {
@@ -64,6 +74,7 @@ export default Vue.extend( {
 		Email,
 		NewsletterOptIn,
 		PaymentBankData,
+		AutofillHandler
 	},
 	data: function (): { formData: AddressFormData } {
 		return {
@@ -173,6 +184,14 @@ export default Vue.extend( {
 		},
 		onFieldChange( fieldName: string ): void {
 			this.$store.dispatch( action( NS_ADDRESS, setAddressField ), this.$data.formData[ fieldName ] );
+		},
+		onAutofill( autofilledFields: { [key: string]: string; } ) {
+			Object.keys( autofilledFields ).forEach( key => {
+				const fieldName = camelizeName( key );
+				if ( this.$data.formData[ fieldName ] ) {
+					this.$store.dispatch( action( NS_ADDRESS, setAddressField ), this.$data.formData[ fieldName ] );
+				}
+			} );
 		},
 		setReceiptOptedOut( optedOut: boolean ): void {
 			this.$store.dispatch( action( NS_ADDRESS, setReceiptOptOut ), optedOut );

--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -70,7 +70,7 @@ export default Vue.extend( {
 		Email,
 		NewsletterOptIn,
 		PaymentBankData,
-		AutofillHandler
+		AutofillHandler,
 	},
 	data: function (): { formData: AddressFormData } {
 		return {

--- a/skins/laika/src/components/pages/donation_form/Address.vue
+++ b/skins/laika/src/components/pages/donation_form/Address.vue
@@ -56,11 +56,7 @@ import PaymentBankData from '@/components/shared/PaymentBankData.vue';
 import TwoStepAddressType from '@/components/pages/donation_form/TwoStepAddressType.vue';
 import TwoStepFixedDisclaimerAddressType from '@/components/pages/donation_form/TwoStepFixedDisclaimerAddressType.vue';
 import { mergeValidationResults } from '@/merge_validation_results';
-
-// from kebab-case to camelCase
-function camelizeName( fieldName: string ): string {
-	return fieldName.replace(/-(\w)/g, (_: string, firstChar: string) => firstChar.toUpperCase() );
-}
+import { camelizeName } from '@/camlize_name';
 
 export default Vue.extend( {
 	name: 'Address',

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -5,11 +5,13 @@
 			<address-type :initial-value="addressType" v-on:address-type="setAddressType( $event )"/>
 		</div>
 		<h1 class="has-margin-top-36 title is-size-5">{{ $t( 'donation_form_section_address_title' ) }}</h1>
-		<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"></name>
-		<postal :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"></postal>
-		<receipt-opt-out v-on:opted-out="setReceiptOptedOut( $event )"/>
-		<date-of-birth v-if="isPerson"/>
-		<email :show-error="fieldErrors.email" :form-data="formData" v-on:field-changed="onFieldChange"/>
+		<AutofillHandler @autofill="onAutofill">
+			<name :show-error="fieldErrors" :form-data="formData" :address-type="addressType" v-on:field-changed="onFieldChange"/>
+			<postal :show-error="fieldErrors" :form-data="formData" :countries="countries" v-on:field-changed="onFieldChange"/>
+			<receipt-opt-out v-on:opted-out="setReceiptOptedOut( $event )"/>
+			<date-of-birth v-if="isPerson"/>
+			<email :show-error="fieldErrors.email" :form-data="formData" v-on:field-changed="onFieldChange"/>
+		</AutofillHandler>
 	</div>
 </template>
 
@@ -22,6 +24,7 @@ import Postal from '@/components/shared/Postal.vue';
 import DateOfBirth from '@/components/pages/membership_form/DateOfBirth.vue';
 import ReceiptOptOut from '@/components/shared/ReceiptOptOut.vue';
 import Email from '@/components/shared/Email.vue';
+import AutofillHandler from "@/components/shared/AutofillHandler.vue";
 import { AddressValidity, AddressFormData, ValidationResult } from '@/view_models/Address';
 import { AddressTypeModel } from '@/view_models/AddressTypeModel';
 import { Validity } from '@/view_models/Validity';
@@ -29,6 +32,7 @@ import { NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
 import { setAddressField, validateAddress, validateEmail, setReceiptOptOut, setAddressType } from '@/store/membership_address/actionTypes';
 import { action } from '@/store/util';
 import { mergeValidationResults } from '@/merge_validation_results';
+import { camelizeName } from '@/camlize_name';
 
 export default Vue.extend( {
 	name: 'Address',
@@ -39,6 +43,7 @@ export default Vue.extend( {
 		ReceiptOptOut,
 		AddressType,
 		Email,
+		AutofillHandler,
 	},
 	data: function (): { formData: AddressFormData } {
 		return {
@@ -149,6 +154,15 @@ export default Vue.extend( {
 		},
 		onFieldChange( fieldName: string ): void {
 			this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setAddressField ), this.$data.formData[ fieldName ] );
+		},
+		onAutofill( autofilledFields: { [key: string]: string; } ) {
+			console.log("Autofill called", autofilledFields);
+			Object.keys( autofilledFields ).forEach( key => {
+				const fieldName = camelizeName( key );
+				if ( this.$data.formData[ fieldName ] ) {
+					this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setAddressField ), this.$data.formData[ fieldName ] );
+				}
+			} );
 		},
 		setReceiptOptedOut( optedOut: boolean ): void {
 			this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setReceiptOptOut ), optedOut );

--- a/skins/laika/src/components/pages/membership_form/Address.vue
+++ b/skins/laika/src/components/pages/membership_form/Address.vue
@@ -24,7 +24,7 @@ import Postal from '@/components/shared/Postal.vue';
 import DateOfBirth from '@/components/pages/membership_form/DateOfBirth.vue';
 import ReceiptOptOut from '@/components/shared/ReceiptOptOut.vue';
 import Email from '@/components/shared/Email.vue';
-import AutofillHandler from "@/components/shared/AutofillHandler.vue";
+import AutofillHandler from '@/components/shared/AutofillHandler.vue';
 import { AddressValidity, AddressFormData, ValidationResult } from '@/view_models/Address';
 import { AddressTypeModel } from '@/view_models/AddressTypeModel';
 import { Validity } from '@/view_models/Validity';
@@ -156,7 +156,7 @@ export default Vue.extend( {
 			this.$store.dispatch( action( NS_MEMBERSHIP_ADDRESS, setAddressField ), this.$data.formData[ fieldName ] );
 		},
 		onAutofill( autofilledFields: { [key: string]: string; } ) {
-			console.log("Autofill called", autofilledFields);
+			console.log( 'Autofill called', autofilledFields );
 			Object.keys( autofilledFields ).forEach( key => {
 				const fieldName = camelizeName( key );
 				if ( this.$data.formData[ fieldName ] ) {

--- a/skins/laika/src/components/shared/AutofillHandler.vue
+++ b/skins/laika/src/components/shared/AutofillHandler.vue
@@ -1,0 +1,55 @@
+<template>
+	<div class="autofill-handler" v-on:animationstart="onAutofillAnimationStart"><slot/></div>
+</template>
+
+<script lang="ts">
+	import Vue from 'vue';
+
+	/**
+	 * This class is a hack around the Safari/Edge bug where no events are triggered on autofill.
+	 * We get around this by defining keyframe animations for the `:-webkit-autofill` pseudo selector and
+	 * listening to the animationstart event for that specific keyframe.
+	 *
+	 * The autofilled input elements must have an id attributes to show up in the `autofill` event
+	 * emitted by this component.
+	 *
+	 * Based on the comments at https://stackoverflow.com/q/11708092/130121
+	 */
+	export default Vue.extend( {
+		name: "AutofillHandler",
+		props: {
+			inputSelector: {
+				type: String,
+				default: 'input[id]'
+			}
+		},
+		data: function() {
+			return {
+				autofillQueue: new Set<HTMLInputElement>(),
+				debounceTimeout: null,
+			}
+		},
+		methods: {
+			onAutofillAnimationStart( evt: AnimationEvent ) {
+				if ( evt.animationName !== 'onAutoFillStart' ) {
+					return;
+				}
+				this.$data.autofillQueue.add( evt.target );
+				if ( this.$data.debounceTimeout !== null ) {
+					clearTimeout( this.$data.debounceTimeout );
+				}
+				this.$data.debounceTimeout = setTimeout( this.emitAutofillValues.bind( this ), 200 );
+			},
+			emitAutofillValues() {
+				let eventData: { [key: string]: string; }  = {};
+				this.$data.autofillQueue.forEach( ( elem: HTMLInputElement ) => {
+					if ( elem.id ) {
+						eventData[ elem.id ] = elem.value;
+					}
+				} );
+				this.$data.debounceTimeout = null;
+				this.$emit( 'autofill', eventData );
+			}
+		}
+	} );
+</script>

--- a/skins/laika/src/components/shared/AutofillHandler.vue
+++ b/skins/laika/src/components/shared/AutofillHandler.vue
@@ -3,16 +3,16 @@
 </template>
 
 <script lang="ts">
-	import Vue from 'vue';
+import Vue from 'vue';
 
-	/**
+/**
 	 * Number of milliseconds in which all autofill "events" are collected until they are emitted
 	 * as event data. This value needs to strike a balance between the browser's autofill slowly filling
 	 * out the fields and the period in which the error messages appear.
 	 */
-	const AUTOFILL_DEBOUNCE_PERIOD = 50;
+const AUTOFILL_DEBOUNCE_PERIOD = 50;
 
-	/**
+/**
 	 * This class is a hack around the Safari/Edge bug where no events are triggered on autofill.
 	 * We get around this by defining keyframe animations for the `:-webkit-autofill` pseudo selector and
 	 * listening to the animationstart event for that specific keyframe.
@@ -22,41 +22,41 @@
 	 *
 	 * Based on the comments at https://stackoverflow.com/q/11708092/130121
 	 */
-	export default Vue.extend( {
-		name: "AutofillHandler",
-		props: {
-			inputSelector: {
-				type: String,
-				default: 'input[id]'
-			}
+export default Vue.extend( {
+	name: 'AutofillHandler',
+	props: {
+		inputSelector: {
+			type: String,
+			default: 'input[id]',
 		},
-		data: function() {
-			return {
-				autofillQueue: new Set<HTMLInputElement>(),
-				debounceTimeout: null,
+	},
+	data: function () {
+		return {
+			autofillQueue: new Set<HTMLInputElement>(),
+			debounceTimeout: null,
+		};
+	},
+	methods: {
+		onAutofillAnimationStart( evt: AnimationEvent ) {
+			if ( evt.animationName !== 'onAutoFillStart' ) {
+				return;
 			}
+			this.$data.autofillQueue.add( evt.target );
+			if ( this.$data.debounceTimeout !== null ) {
+				clearTimeout( this.$data.debounceTimeout );
+			}
+			this.$data.debounceTimeout = setTimeout( this.emitAutofillValues.bind( this ), AUTOFILL_DEBOUNCE_PERIOD );
 		},
-		methods: {
-			onAutofillAnimationStart( evt: AnimationEvent ) {
-				if ( evt.animationName !== 'onAutoFillStart' ) {
-					return;
+		emitAutofillValues() {
+			let eventData: { [key: string]: string; } = {};
+			this.$data.autofillQueue.forEach( ( elem: HTMLInputElement ) => {
+				if ( elem.id ) {
+					eventData[ elem.id ] = elem.value;
 				}
-				this.$data.autofillQueue.add( evt.target );
-				if ( this.$data.debounceTimeout !== null ) {
-					clearTimeout( this.$data.debounceTimeout );
-				}
-				this.$data.debounceTimeout = setTimeout( this.emitAutofillValues.bind( this ), AUTOFILL_DEBOUNCE_PERIOD );
-			},
-			emitAutofillValues() {
-				let eventData: { [key: string]: string; }  = {};
-				this.$data.autofillQueue.forEach( ( elem: HTMLInputElement ) => {
-					if ( elem.id ) {
-						eventData[ elem.id ] = elem.value;
-					}
-				} );
-				this.$data.debounceTimeout = null;
-				this.$emit( 'autofill', eventData );
-			}
-		}
-	} );
+			} );
+			this.$data.debounceTimeout = null;
+			this.$emit( 'autofill', eventData );
+		},
+	},
+} );
 </script>

--- a/skins/laika/src/components/shared/AutofillHandler.vue
+++ b/skins/laika/src/components/shared/AutofillHandler.vue
@@ -6,6 +6,13 @@
 	import Vue from 'vue';
 
 	/**
+	 * Number of milliseconds in which all autofill "events" are collected until they are emitted
+	 * as event data. This value needs to strike a balance between the browser's autofill slowly filling
+	 * out the fields and the period in which the error messages appear.
+	 */
+	const AUTOFILL_DEBOUNCE_PERIOD = 50;
+
+	/**
 	 * This class is a hack around the Safari/Edge bug where no events are triggered on autofill.
 	 * We get around this by defining keyframe animations for the `:-webkit-autofill` pseudo selector and
 	 * listening to the animationstart event for that specific keyframe.
@@ -38,7 +45,7 @@
 				if ( this.$data.debounceTimeout !== null ) {
 					clearTimeout( this.$data.debounceTimeout );
 				}
-				this.$data.debounceTimeout = setTimeout( this.emitAutofillValues.bind( this ), 200 );
+				this.$data.debounceTimeout = setTimeout( this.emitAutofillValues.bind( this ), AUTOFILL_DEBOUNCE_PERIOD );
 			},
 			emitAutofillValues() {
 				let eventData: { [key: string]: string; }  = {};

--- a/skins/laika/src/components/shared/Email.vue
+++ b/skins/laika/src/components/shared/Email.vue
@@ -5,6 +5,7 @@
 			<b-input type="text"
 				id="email"
 				:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_email_placeholder' ) } )"
+				autocomplete="email"
 				v-model="formData.email.value"
 				@blur="$emit('field-changed', 'email')">
 			</b-input>

--- a/skins/laika/src/components/shared/Name.vue
+++ b/skins/laika/src/components/shared/Name.vue
@@ -45,6 +45,7 @@
 						id="first-name"
 						v-model="formData.firstName.value"
 						:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_firstname_placeholder' ) } )"
+						autocomplete="given-name"
 						@blur="$emit('field-changed', 'firstName')">
 				</b-input>
 			</b-field>
@@ -57,6 +58,7 @@
 						id="last-name"
 						v-model="formData.lastName.value"
 						:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_lastname_placeholder' ) } )"
+						autocomplete="family-name"
 						@blur="$emit('field-changed', 'lastName')">
 				</b-input>
 			</b-field>
@@ -70,6 +72,7 @@
 			<b-input type="text"
 					id="company-name"
 					:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_companyname_placeholder' ) } )"
+					autocomplete="organization"
 					v-model="formData.companyName.value"
 					@blur="$emit('field-changed', 'companyName')">
 			</b-input>

--- a/skins/laika/src/components/shared/Postal.vue
+++ b/skins/laika/src/components/shared/Postal.vue
@@ -6,6 +6,7 @@
 			<b-input type="text"
 					id="street"
 					:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_street_placeholder' ) } )"
+					autocomplete="street-address"
 					v-model="formData.street.value"
 					@blur="$emit('field-changed', 'street'); displayStreetWarning()">
 			</b-input>
@@ -21,6 +22,7 @@
 					id="post-code"
 					v-model="formData.postcode.value"
 					:placeholder="$t( 'form_for_example', { example: $t( 'donation_form_zip_placeholder' ) } )"
+					autocomplete="postal-code"
 					@blur="$emit('field-changed', 'postcode')">
 			</b-input>
 		</b-field>

--- a/skins/laika/src/scss/custom.scss
+++ b/skins/laika/src/scss/custom.scss
@@ -180,5 +180,17 @@
 	margin-bottom: -18px !important;
 }
 
+// trigger animation events on autofill
+@keyframes onAutoFillStart {  from {
+	background-color: initial;
+}  to {
+	background-color: #faffbd; /* iOS autofill indication color */
+}}
+.autofill-handler {
+	input[id]:-webkit-autofill {
+		animation: onAutoFillStart 0.5s;
+	}
+}
+
 @import "overrides";
 @import "compact_form"; // AB Test Import


### PR DESCRIPTION
Add a component that hacks around the fact that Safari/Edge do not fire
events when they autofill form fields.

This is based on ideas from #1641, but does not implement the autofill events on a per-field level because that would override all other fields (with empty data from the store) whenever a field is autofilled.