### PR TITLE
Fix styling of organizations on use of funds page

### DIFF
--- a/skins/laika/src/components/pages/MembershipConfirmation.vue
+++ b/skins/laika/src/components/pages/MembershipConfirmation.vue
@@ -32,5 +32,3 @@ export default Vue.extend( {
 	],
 } );
 </script>
-
-<style lang="scss"></style>

--- a/skins/laika/src/components/pages/UseOfFunds.vue
+++ b/skins/laika/src/components/pages/UseOfFunds.vue
@@ -15,10 +15,16 @@
 		<div class="column is-one-third">
 			<ul class="list-menu list-unstyled">
 				<li>
-					<a :href="content.organizations.wmde.url">{{ $t('year_plan_wmde') }} {{ content.organizations.wmde.title }}</a>
+					<a class="organization-link" :href="content.organizations.wmde.url">
+						<span>{{ $t('year_plan_wmde') }}</span>
+						<span>{{ content.organizations.wmde.title }}</span>
+					</a>
 				</li>
 				<li>
-					<a :href="content.organizations.wmf.url">{{ $t('year_plan_wmf')  }} {{ content.organizations.wmf.title }}</a>
+					<a class="organization-link" :href="content.organizations.wmf.url">
+						<span>{{ $t('year_plan_wmf')  }}</span>
+						<span>{{ content.organizations.wmf.title }}</span>
+					</a>
 				</li>
 			</ul>
 		</div>
@@ -49,3 +55,9 @@ export default Vue.extend( {
 	},
 } );
 </script>
+
+<style lang="scss">
+	.organization-link > span {
+		display: inline-block;
+	}
+</style>


### PR DESCRIPTION
If I have to look at that "V." being on its own line one more second I'll quit so here is a quick fix to ensure that the organization name is preferably not broken up.

![triggering](https://user-images.githubusercontent.com/4571512/70914665-b9661380-2018-11ea-8107-5bc4aff2890b.png)
