### PR TITLE
Prevent banner display after certain actions

### DIFF
--- a/skins/laika/src/components/pages/DonationConfirmation.vue
+++ b/skins/laika/src/components/pages/DonationConfirmation.vue
@@ -42,6 +42,11 @@
 			</div>
 		</div>
 		<membership-info :confirmation-data="confirmationData"></membership-info>
+		<img :src="'https://de.wikipedia.org/wiki/Special:HideBanners?duration=' + confirmationData.donation.cookieDuration + '&reason=donate'"
+			alt=""
+			width="0"
+			height="0"
+		/>
 	</div>
 </template>
 

--- a/skins/laika/src/components/pages/MembershipConfirmation.vue
+++ b/skins/laika/src/components/pages/MembershipConfirmation.vue
@@ -12,6 +12,11 @@
 			<div class="column is-half">
 				<summary-links :confirmation-data="confirmationData"/>
 			</div>
+			<img src="https://de.wikipedia.org/wiki/Special:HideBanners?category=fr-thankyou&duration=15552000&reason=membership"
+				alt=""
+				width="0"
+				height="0"
+			/>
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
Include an invisible image to set a cookie on the confirmation page.
This prevents the banners that lead to the confirmation page from
re-appearing on WP.org.

This fixes https://phabricator.wikimedia.org/T240963