### PR TITLE
Allow opt out in address change

### DIFF
--- a/skins/laika/src/components/pages/UpdateAddress.vue
+++ b/skins/laika/src/components/pages/UpdateAddress.vue
@@ -4,6 +4,8 @@
 			<h1 class="title is-size-1">{{ $t( 'address_change_form_title' ) }}</h1>
 			<legend class="title is-size-6">{{ $t( 'address_change_form_label' ) }}</legend>
 			<div>
+				<receipt-opt-out v-on:opted-out="setReceiptOptedOut( $event )"/>
+				<div> {{ $t( 'address_change_opt_out_hint') }}</div>
 				<name :show-error="fieldErrors"
 						:form-data="formData"
 						:address-type="addressType"
@@ -14,7 +16,6 @@
 						:countries="countries"
 						v-on:field-changed="onFieldChange">
 				</postal>
-				<receipt-opt-out v-on:opted-out="setReceiptOptedOut( $event )"/>
 				<submit-values :tracking-data="{}"></submit-values>
 			</div>
 			<div class="level has-margin-top-36">
@@ -155,6 +156,11 @@ export default Vue.extend( {
 			this.$store.dispatch( action( NS_ADDRESS, setAddressType ), addressType );
 		},
 		submit() {
+			if ( this.$store.state.address.receiptOptOut && this.$store.getters[ NS_ADDRESS + '/allRequiredFieldsEmpty' ] ) {
+				const form = this.$refs.form as HTMLFormElement;
+				trackFormSubmission( form );
+				form.submit();
+			}
 			this.validateForm().then( ( validationResult: ValidationResult ) => {
 				if ( validationResult.status === 'OK' ) {
 					const form = this.$refs.form as HTMLFormElement;

--- a/skins/laika/src/store/address/getters.ts
+++ b/skins/laika/src/store/address/getters.ts
@@ -24,4 +24,7 @@ export const getters: GetterTree<AddressState, any> = {
 	isValidating: ( state: AddressState ): boolean => {
 		return state.serverSideValidationCount > 0;
 	},
+	allRequiredFieldsEmpty: ( state: AddressState ): boolean => {
+		return state.requiredFields[ state.addressType ].map( field => state.values[ field ] === '' ).every( x => x );
+	},
 };


### PR DESCRIPTION
Users can opt out of receiving a donation receipt now and do not have
to fill in the form. If they fill in any field they have to do the rest
as well.

https://phabricator.wikimedia.org/T242436