### PR TITLE
Fix receipt-opt-out on confirmation page

### DIFF
--- a/skins/laika/src/pages/address_update_success.ts
+++ b/skins/laika/src/pages/address_update_success.ts
@@ -32,7 +32,7 @@ new Vue( {
 	[
 		h( Component, {
 			props: {
-				donationReceipt: pageData.applicationVars.donationReceipt,
+				donationReceipt: pageData.applicationVars.receiptOptOut ? '0' : '1',
 			},
 		} ),
 		h( Sidebar, {


### PR DESCRIPTION
PR #1693 changed the field name for the opt-out.
Since we're reusing the HTTP request data, the field name
on the confirmation page needs to be adjusted as well