### PR TITLE
Set wpde banner cookie on confirmation

### DIFF
--- a/skins/laika/src/components/pages/DonationConfirmation.vue
+++ b/skins/laika/src/components/pages/DonationConfirmation.vue
@@ -47,6 +47,11 @@
 			width="0"
 			height="0"
 		/>
+		<img src="https://bruce.wikipedia.de/finish-donation?c=fundraising"
+			alt=""
+			width="0"
+			height="0"
+		/>
 	</div>
 </template>
 


### PR DESCRIPTION
Link a 'pseudo-image' on the donation confirmation page that prevents
the banner server for wikipedia.de to show more banners for users that have donated.

This is for https://phabricator.wikimedia.org/T243616