### PR TITLE
Add environment name to errbit logging

### DIFF
--- a/src/Factories/LoggerFactory.php
+++ b/src/Factories/LoggerFactory.php
@@ -51,7 +51,8 @@ class LoggerFactory {
 				$notifier = new Notifier([
 					'projectId' => $config['projectId'],
 					'projectKey' => $config['projectKey'],
-					'host' => $config['host']
+					'host' => $config['host'],
+					'environment' => getenv( 'APP_ENV' ) ?: 'dev'
 				]);
 
 				return new SupportHandler(


### PR DESCRIPTION
Currently, errbit always shows "development" for all environments, since we don't pass the environment.