### PR TITLE
Log Referrer address of outdated parameters

### DIFF
--- a/src/Infrastructure/Validation/FallbackRequestValueReader.php
+++ b/src/Infrastructure/Validation/FallbackRequestValueReader.php
@@ -52,7 +52,10 @@ class FallbackRequestValueReader {
 	}
 
 	private function logDeprecationWarning( string $deprecatedParameterName ): void {
-		$this->logger->warning( "Some application is still submitting the deprecated form parameter '{$deprecatedParameterName}'" );
+		$this->logger->warning(
+			"Some application is still submitting the deprecated form parameter '{$deprecatedParameterName}'",
+			[ 'referrer' => $this->request->headers->get( 'referer' ) ]
+		);
 	}
 
 }


### PR DESCRIPTION
To track down the potential sources of outdated parameters, log the
originating address of the request with invalid parameters.

This is a followup for #1700 for Ticket https://phabricator.wikimedia.org/T203248