### PR TITLE
Fix use-of-funds page

### DIFF
--- a/src/Factories/ChoiceFactory.php
+++ b/src/Factories/ChoiceFactory.php
@@ -23,25 +23,6 @@ class ChoiceFactory {
 		$this->featureToggle = $featureToggle;
 	}
 
-	public function getUseOfFundsResponse( FunFunFactory $factory ): \Closure {
-		if ( $this->featureToggle->featureIsActive( 'campaigns.skins.laika' ) ) {
-			$factory->getTranslationCollector()->addTranslationFile( $factory->getI18nDirectory() . '/messages/useOfFundsMessages.json' );
-			$template = $factory->getLayoutTemplate( 'Funds_Usage.html.twig', [
-				'use_of_funds_content' => $factory->getApplicationOfFundsContent(),
-				'use_of_funds_messages' => $factory->getApplicationOfFundsMessages()
-			] );
-			return function() use ( $template )  {
-				return $template->render( [] );
-			};
-		} elseif ( $this->featureToggle->featureIsActive( 'campaigns.skins.test' ) ) {
-			// we don't care what happens in test
-			return function() {
-				return 'Test rendering: Use of funds';
-			};
-		}
-		throw new UnknownChoiceDefinition( 'Use of funds configuration failure.' );
-	}
-
 	public function getMembershipCallToActionTemplate(): string {
 		if ( $this->featureToggle->featureIsActive( 'campaigns.membership_call_to_action.regular' ) ) {
 			return 'partials/donation_confirmation/feature_toggle/call_to_action_regular.html.twig';

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -1841,7 +1841,23 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function getUseOfFundsRenderer(): \Closure {
-		return $this->getChoiceFactory()->getUseOfFundsResponse( $this );
+		if ( $this->config['skin'] === 'laika' ) {
+			$this->getTranslationCollector()->addTranslationFile( $this->getI18nDirectory() . '/messages/useOfFundsMessages.json' );
+			$template = $this->getLayoutTemplate( 'Funds_Usage.html.twig', [
+				'use_of_funds_content' => $this->getApplicationOfFundsContent(),
+				'use_of_funds_messages' => $this->getApplicationOfFundsMessages()
+			] );
+			return function() use ( $template )  {
+				return $template->render( [] );
+			};
+		} elseif ( $this->config['skin'] === 'test' ) {
+			// we don't care what happens in test
+			return function() {
+				return 'Test rendering: Use of funds';
+			};
+		}
+
+		throw new \InvalidArgumentException( 'Unsupported skin for use of funds:' . $this->config['skin'] );
 	}
 
 	/**


### PR DESCRIPTION
Move the code for creation of the use-of-funds renderer back into
FunFunFactory because the skin a/b test no longer exists and the
ChoiceFactory was throwing errors.

This is a followup for #1705