### PR TITLE
Track form validation errors (client side) in web analytics

### DIFF
--- a/skins/laika/src/pages/donation_form.ts
+++ b/skins/laika/src/pages/donation_form.ts
@@ -18,6 +18,7 @@ import { createInitialDonationAddressValues, createInitialDonationPaymentValues 
 import LocalStorageRepository from '@/store/LocalStorageRepository';
 import { initializeAddress } from '@/store/address/actionTypes';
 import { Country } from '@/view_models/Country';
+import { createTrackFormErrorsPlugin } from '@/store/track_form_errors_plugin';
 
 const PAGE_IDENTIFIER = 'donation-form';
 const FORM_NAMESPACE = 'donation_form';
@@ -44,6 +45,7 @@ const dataPersister = createDataPersister(
 );
 const store = createStore( [
 	dataPersister.getPlugin( persistenceItems ),
+	createTrackFormErrorsPlugin( FORM_NAMESPACE ),
 ] );
 
 const i18n = new VueI18n( {

--- a/skins/laika/src/pages/membership_application.ts
+++ b/skins/laika/src/pages/membership_application.ts
@@ -57,14 +57,10 @@ const i18n = new VueI18n( {
 } );
 
 const store = createStore( [
-<<<<<<< HEAD
 	dataPersister.getPlugin( persistenceItems ),
-] );
-=======
 	createTrackFormErrorsPlugin( FORM_NAMESPACE ),
 ]
 );
->>>>>>> Create and integrate tracking store plugin
 
 dataPersister.decryptInitialValues( persistenceItems ).then( () => {
 

--- a/skins/laika/src/pages/membership_application.ts
+++ b/skins/laika/src/pages/membership_application.ts
@@ -22,6 +22,7 @@ import { InitialMembershipData } from '@/view_models/Address';
 import { initializeBankData } from '@/store/bankdata/actionTypes';
 import { Country } from '@/view_models/Country';
 import { initializeMembershipFee } from '@/store/membership_fee/actionTypes';
+import { createTrackFormErrorsPlugin } from '@/store/track_form_errors_plugin';
 
 const PAGE_IDENTIFIER = 'membership-application';
 const FORM_NAMESPACE = 'membership_application';
@@ -56,8 +57,14 @@ const i18n = new VueI18n( {
 } );
 
 const store = createStore( [
+<<<<<<< HEAD
 	dataPersister.getPlugin( persistenceItems ),
 ] );
+=======
+	createTrackFormErrorsPlugin( FORM_NAMESPACE ),
+]
+);
+>>>>>>> Create and integrate tracking store plugin
 
 dataPersister.decryptInitialValues( persistenceItems ).then( () => {
 

--- a/skins/laika/src/pages/update_address.ts
+++ b/skins/laika/src/pages/update_address.ts
@@ -7,14 +7,18 @@ import { createStore } from '@/store/update_address_store';
 import App from '@/components/App.vue';
 import Component from '@/components/pages/UpdateAddress.vue';
 import Sidebar from '@/components/layout/Sidebar.vue';
+import { createTrackFormErrorsPlugin } from '@/store/track_form_errors_plugin';
 
 const PAGE_IDENTIFIER = 'update-address';
+const FORM_NAMESPACE = 'update_address';
 
 Vue.config.productionTip = false;
 Vue.use( VueI18n );
 
 const pageData = new PageDataInitializer<any>( '#app' );
-const store = createStore();
+const store = createStore( [
+	createTrackFormErrorsPlugin( FORM_NAMESPACE ),
+] );
 
 const i18n = new VueI18n( {
 	locale: DEFAULT_LOCALE,

--- a/skins/laika/src/store/track_form_errors_plugin.ts
+++ b/skins/laika/src/store/track_form_errors_plugin.ts
@@ -1,0 +1,40 @@
+import { MutationPayload, Store } from 'vuex';
+import { mutation as mutationName } from '@/store/util';
+import { NS_ADDRESS, NS_MEMBERSHIP_ADDRESS } from '@/store/namespaces';
+import { trackFormValidationErrors } from '@/tracking';
+import { VALIDATE_INPUT } from '@/store/address/mutationTypes';
+import { Validity } from '@/view_models/Validity';
+
+export const trackFormErrorPlugin = ( store: Store<any>, formName: string ) => {
+
+	const formNameToStoreNameLookUp: { [key: string]: string} = {
+		'donation_form': 'address',
+		'update_address': 'address',
+		'membership_application': 'membership_address',
+	};
+	const storeName = formNameToStoreNameLookUp[ formName ];
+
+	let prevState = { ... store.state[ storeName ].validity };
+
+	store.subscribe( ( mutation: MutationPayload, mutatedState: any ) => {
+
+		if ( mutation.type === ( storeName + '/VALIDATE_INPUT' ) ) {
+			const currentFormFieldName = mutation.payload.name;
+
+			if ( prevState[ currentFormFieldName ] === Validity.INCOMPLETE
+				|| prevState[ currentFormFieldName ] === Validity.VALID ) {
+
+				if ( mutatedState[ storeName ].validity[ currentFormFieldName ] === Validity.INVALID ) {
+					trackFormValidationErrors( formName, currentFormFieldName );
+				}
+			}
+			prevState = { ...mutatedState[ storeName ].validity };
+		}
+	} );
+};
+
+export function createTrackFormErrorsPlugin( formName: string ) {
+	return ( store: Store<any> ) => {
+		return trackFormErrorPlugin( store, formName );
+	};
+}

--- a/skins/laika/src/store/update_address_store.ts
+++ b/skins/laika/src/store/update_address_store.ts
@@ -1,12 +1,12 @@
 import Vue from 'vue';
-import Vuex, { StoreOptions } from 'vuex';
+import Vuex, { Store, StoreOptions } from 'vuex';
 import createAddress from '@/store/address';
 import { NS_ADDRESS } from './namespaces';
 import { REQUIRED_FIELDS_ADDRESS_UPDATE } from '@/store/address/constants';
 
 Vue.use( Vuex );
 
-export function createStore() {
+export function createStore( plugins: Array< ( s: Store<any> ) => void > = [] ) {
 	const storeBundle: StoreOptions<any> = {
 		modules: {
 			[ NS_ADDRESS ]: createAddress( REQUIRED_FIELDS_ADDRESS_UPDATE ),
@@ -17,6 +17,7 @@ export function createStore() {
 				return state[ NS_ADDRESS ].isValidating;
 			},
 		},
+		plugins,
 	};
 
 	return new Vuex.Store<any>( storeBundle );

--- a/skins/laika/src/tracking.ts
+++ b/skins/laika/src/tracking.ts
@@ -17,3 +17,7 @@ export function trackFormSubmission( formElement: HTMLFormElement ) {
 export function trackFormFieldRestored( field: string, value: string ) {
 	_paq.push( [ 'trackEvent', 'Form Field Restored', field, value ] );
 }
+
+export function trackFormValidationErrors( formName: string, formFieldName: string ) {
+	_paq.push( [ 'trackEvent', formName, formFieldName ] );
+}


### PR DESCRIPTION
A new vuex store plugin was added.
It it used in the donation form (address section), membership form and the update address form.
The plugin calls a tracking function whenever the user triggers "invalid" validation state
on a form field.

https://phabricator.wikimedia.org/T252374