### PR TITLE
Hide stack trace container on production

### DIFF
--- a/skins/laika/src/components/pages/Error.vue
+++ b/skins/laika/src/components/pages/Error.vue
@@ -8,7 +8,7 @@
 		<pre v-if="errorMessage">
 			{{ errorMessage }}
 		</pre>
-		<div style="background-color: whitesmoke;font-family: monospace;white-space: pre; overflow: scroll; padding: 1.25rem 1.5rem;">
+		<div v-if="errorMessage" style="background-color: whitesmoke;font-family: monospace;white-space: pre; overflow: scroll; padding: 1.25rem 1.5rem;">
 			<div v-for="(trace, idx) in errorTrace" :key="idx">
 				<span>{{idx}} - </span>
 				<span v-if="trace.class">{{ trace.class }}{{ trace.type }}{{ trace.function }}</span>


### PR DESCRIPTION
https://phabricator.wikimedia.org/T249106

Small fix for hiding the stack trace container that is appearing on non-dev environments

Related PR: https://github.com/wmde/FundraisingFrontend/pull/1756/files