### PR TITLE
Improve config file encryption check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,8 @@ migration-status:
 	docker-compose run --rm --no-deps app vendor/doctrine/migrations/bin/doctrine-migrations migrations:status --configuration=app/config/migrations/subscriptions.yml
 
 validate-encrypted-config:
-	grep -q ANSIBLE_VAULT deployment/inventory/group_vars/production.yml
-	grep -q ANSIBLE_VAULT deployment/inventory/group_vars/test.yml
-	grep -q ANSIBLE_VAULT deployment/inventory/group_vars/webserver.yml
-	grep -q ANSIBLE_VAULT deployment/files/configs/spenden.wikimedia.de/config.prod.json
-	grep -q ANSIBLE_VAULT deployment/files/configs/test-spenden-2.wikimedia.de/config.uat.json
+	build/validate-config-encryption deployment/inventory/group_vars/*.yml
+	build/validate-config-encryption deployment/files/configs/*/*.json
 
 ci: covers phpunit cs npm-ci validate-app-config validate-campaign-config validate-encrypted-config stan
 

--- a/build/validate-config-encryption
+++ b/build/validate-config-encryption
@@ -1,0 +1,12 @@
+#!/usr/bin/awk -f
+{ 
+	if ($0~"^\\\$ANSIBLE_VAULT")
+	{
+		nextfile; 
+	}
+	else 
+	{
+		print "Found unencrypted file", FILENAME
+		exit 1
+	}
+}


### PR DESCRIPTION
Use wildcards to check all encryption files

Use awk to do a line-wise check: If the 1st line begins with
"$ANSIBLE_VAULT", it will continue with the next file, otherwise it will
print the file name and exit with status 1.

Inspiration taken from
* https://unix.stackexchange.com/a/356374/6341
* https://unix.stackexchange.com/a/557110/6341