### PR TITLE
Activates preselection ab test in settings

### DIFF
--- a/app/config/campaigns.dev.yml
+++ b/app/config/campaigns.dev.yml
@@ -15,4 +15,4 @@ compact_design:
 
 address_type:
   active: true
-  start: "2020-03-26"
+  start: "2020-09-15"

--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -65,8 +65,8 @@ compact_design:
 address_type:
   description: Test if the address type not being preselected changes the user behaviour of entering nonsense address data.
   reference: "https://phabricator.wikimedia.org/T247228"
-  start: "2020-04-07"
-  end: "2020-07-15"
+  start: "2020-09-15"
+  end: "2020-11-02"
   buckets:
     - "preselection"
     - "no_preselection"


### PR DESCRIPTION
No further changes had to be done to reactivate
the a/b bucket test for addresstype preselection.
The initial value for the vue form component is received from
the ChoiceFactory (backend). No changes in the vue components
were required.

https://phabricator.wikimedia.org/T262532