### PR TITLE
Fix unit tests for address component

### DIFF
--- a/skins/laika/tests/unit/components/pages/donation_form/Address.spec.ts
+++ b/skins/laika/tests/unit/components/pages/donation_form/Address.spec.ts
@@ -1,6 +1,7 @@
 import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import Buefy from 'buefy';
+import CompositionAPI from '@vue/composition-api';
 import Address from '@/components/pages/donation_form/Address.vue';
 import Name from '@/components/shared/Name.vue';
 import Postal from '@/components/shared/Postal.vue';
@@ -22,6 +23,7 @@ import { addressValidationPatterns } from '../../../../data/validation';
 const localVue = createLocalVue();
 localVue.use( Vuex );
 localVue.use( Buefy );
+localVue.use( CompositionAPI );
 
 localVue.use( FeatureTogglePlugin, { activeFeatures: [ 'campaigns.address_type.preselection' ] } );
 
@@ -35,6 +37,7 @@ describe( 'Address.vue', () => {
 				countries: countries,
 				initialFormValues: '',
 				addressValidationPatterns: addressValidationPatterns,
+				isDirectDebit: false,
 			},
 			store: createStore(),
 			mocks: {
@@ -51,14 +54,26 @@ describe( 'Address.vue', () => {
 		expect( wrapper.findComponent( NewsletterOptIn ).exists() ).toBe( true );
 	} );
 
-	it( 'renders Bank Data component only if payment is direct debit', () => {
+	it( 'hides Bank Data component if payment is not direct debit', () => {
 		expect( wrapper.findComponent( PaymentBankData ).exists() ).toBe( false );
-		// Stub payment option direct debit (BEZ) being selected
-		const comp = wrapper.vm.$options!.computed;
-		if ( typeof comp.isDirectDebit === 'function' ) {
-			comp.isDirectDebit = jest.fn( () => true );
-			expect( wrapper.findComponent( PaymentBankData ).exists() ).toBe( true );
-		}
+	} );
+
+	it( 'renders Bank Data component if payment is direct debit', () => {
+		wrapper = mount( Address, {
+			localVue,
+			propsData: {
+				validateAddressUrl: 'validate-address',
+				countries: countries,
+				initialFormValues: '',
+				addressValidationPatterns: addressValidationPatterns,
+				isDirectDebit: true,
+			},
+			store: createStore(),
+			mocks: {
+				$t: () => { },
+			},
+		} );
+		expect( wrapper.findComponent( PaymentBankData ).exists() ).toBe( true );
 	} );
 
 	it( 'does not render postal and receipt opt out if adress type is anonymous', async () => {

--- a/skins/laika/tests/unit/components/pages/donation_form/AddressPage.spec.ts
+++ b/skins/laika/tests/unit/components/pages/donation_form/AddressPage.spec.ts
@@ -1,17 +1,25 @@
-import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 
 import AddressPage from '@/components/pages/donation_form/subpages/AddressPage.vue';
 import Vuex from 'vuex';
 import Buefy from 'buefy';
+import CompositionAPI from '@vue/composition-api';
 import { createStore } from '@/store/donation_store';
 import Address from '@/components/pages/donation_form/Address.vue';
 import { action } from '@/store/util';
 import { NS_PAYMENT } from '@/store/namespaces';
 import { initializePayment } from '@/store/payment/actionTypes';
+import { FeatureTogglePlugin } from '@/FeatureToggle';
 
 const localVue = createLocalVue();
 localVue.use( Vuex );
 localVue.use( Buefy );
+localVue.use( CompositionAPI );
+
+localVue.use( FeatureTogglePlugin, { activeFeatures: [
+	'campaigns.address_type.preselection',
+	'campaigns.address_provision_options.old_address_type_options',
+] } );
 
 describe( 'AddressPage', () => {
 


### PR DESCRIPTION
Add composition API to local Vue instance
Use feature toggle plugin for address page test.
Don't mess with internals in bank data display test, use properties instead.