### PR TITLE
Remove Pimple from FunFunFactory

### DIFF
--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -16,8 +16,6 @@ use FileFetcher\ErrorLoggingFileFetcher;
 use FileFetcher\SimpleFileFetcher;
 use GuzzleHttp\Client;
 use NumberFormatter;
-use Pimple\Container;
-use Pimple\ServiceProviderInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RemotelyLiving\Doorkeeper\Doorkeeper;
@@ -216,14 +214,12 @@ use WMDE\FunValidators\Validators\TextPolicyValidator;
 /**
  * @license GPL-2.0-or-later
  */
-class FunFunFactory implements ServiceProviderInterface {
+class FunFunFactory {
 
 	/**
 	 * @var array<string, mixed>
 	 */
 	private array $config;
-
-	private Container $pimple;
 
 	private bool $addDoctrineSubscribers = true;
 
@@ -236,17 +232,7 @@ class FunFunFactory implements ServiceProviderInterface {
 
 	public function __construct( array $config ) {
 		$this->config = $config;
-		$this->pimple = $this->newPimple();
 		$this->sharedObjects = [];
-	}
-
-	private function newPimple(): Container {
-		$container = new Container();
-		$this->register( $container );
-		return $container;
-	}
-
-	public function register( Container $container ): void {
 	}
 
 	private function createSharedObject( string $id, callable $constructionFunction ) { // @codingStandardsIgnoreLine

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -247,162 +247,6 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function register( Container $container ): void {
-		$container['logger'] = function () {
-			return new NullLogger();
-		};
-
-		$container['paypal_logger'] = function () {
-			return new NullLogger();
-		};
-
-		$container['sofort_logger'] = function () {
-			return new NullLogger();
-		};
-
-		$container['dbal_connection'] = function () {
-			return DriverManager::getConnection( $this->config['db'] );
-		};
-
-		$container['subscription_repository'] = function () {
-			return new LoggingSubscriptionRepository(
-				new DoctrineSubscriptionRepository( $this->getEntityManager() ),
-				$this->getLogger()
-			);
-		};
-
-		$container['donation_repository'] = function () {
-			return new LoggingDonationRepository(
-				new DoctrineDonationRepository( $this->getEntityManager() ),
-				$this->getLogger()
-			);
-		};
-
-		$container['membership_application_repository'] = function () {
-			return new LoggingApplicationRepository(
-				new DoctrineApplicationRepository( $this->getEntityManager() ),
-				$this->getLogger()
-			);
-		};
-
-		$container['comment_repository'] = function () {
-			return new LoggingCommentFinder(
-				new DoctrineCommentFinder( $this->getEntityManager() ),
-				$this->getLogger()
-			);
-		};
-
-		$container['mail_validator'] = function () {
-			return new EmailValidator( new InternetDomainNameValidator() );
-		};
-
-		$container['contact_validator'] = function () {
-			return new GetInTouchValidator( $this->getEmailValidator() );
-		};
-
-		// In the future, this could be locale-specific or filled from a DB table
-		$container['honorifics'] = function () {
-			return new Honorifics( [
-				'' => 'Kein Titel',
-				'Dr.' => 'Dr.',
-				'Prof.' => 'Prof.',
-				'Prof. Dr.' => 'Prof. Dr.'
-			] );
-		};
-
-		$container['paypal-payment-notification-verifier'] = function () {
-			return new LoggingPaymentNotificationVerifier(
-				new PayPalPaymentNotificationVerifier(
-					new Client(),
-					$this->config['paypal-donation']['base-url'],
-					$this->config['paypal-donation']['account-address']
-				),
-				$this->getLogger()
-			);
-		};
-
-		$container['paypal-membership-fee-notification-verifier'] = function () {
-			return new LoggingPaymentNotificationVerifier(
-				new PayPalPaymentNotificationVerifier(
-					new Client(),
-					$this->config['paypal-membership']['base-url'],
-					$this->config['paypal-membership']['account-address']
-				),
-				$this->getLogger()
-			);
-		};
-
-		$container['credit-card-api-service'] = function () {
-			return new McpCreditCardService(
-				new TNvpServiceDispatcher(
-					'IMcpCreditcardService_v1_5',
-					'https://sipg.micropayment.de/public/creditcard/v1.5/nvp/'
-				),
-				$this->config['creditcard']['access-key'],
-				$this->config['creditcard']['testmode']
-			);
-		};
-
-		$container['page_cache'] = function () {
-			return new VoidCache();
-		};
-
-		$container['rendered_page_cache'] = function () {
-			return new VoidCache();
-		};
-
-		$container['campaign_cache'] = function () {
-			return new VoidCache();
-		};
-
-		$container['page_view_tracker'] = function () {
-			return new PageViewTracker( $this->newServerSideTracker(), $this->config['piwik']['siteUrlBase'] );
-		};
-
-		$container['cachebusting_fileprefixer'] = function () {
-			return new FilePrefixer( $this->getFilePrefix() );
-		};
-
-		$container['content_page_selector'] = function () {
-			$json = ( new SimpleFileFetcher() )->fetchFile( $this->getI18nDirectory() . '/data/pages.json' );
-			$config = json_decode( $json, true ) ?? [];
-
-			return new PageSelector( $config );
-		};
-
-		$container['content_provider'] = function () {
-			return new ContentProvider( [
-				'content_path' => $this->getI18nDirectory(),
-				'cache' => $this->config['twig']['enable-cache'] ? $this->getCachePath() . '/content' : false,
-				'globals' => [
-					'basepath' => $this->config['web-basepath']
-				]
-			] );
-		};
-
-		$container['payment-delay-calculator'] = function () {
-			return new DefaultPaymentDelayCalculator( $this->getPaymentDelayInDays() );
-		};
-
-		$container['sofort-client'] = function () {
-			$config = $this->config['sofort'];
-			return new SofortClient( $config['config-key'] );
-		};
-
-		$container['cookie-builder'] = function (): CookieBuilder {
-			return new CookieBuilder(
-				$this->config['cookie']['expiration'],
-				$this->config['cookie']['path'],
-				$this->config['cookie']['domain'],
-				$this->config['cookie']['secure'],
-				$this->config['cookie']['httpOnly'],
-				$this->config['cookie']['raw'],
-				$this->config['cookie']['sameSite']
-			);
-		};
-
-		$container['payment-types-settings'] = function (): PaymentTypesSettings {
-			return new PaymentTypesSettings( $this->config['payment-types'] );
-		};
 	}
 
 	private function createSharedObject( string $id, callable $constructionFunction ) { // @codingStandardsIgnoreLine
@@ -413,7 +257,9 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function getConnection(): Connection {
-		return $this->pimple['dbal_connection'];
+		return $this->createSharedObject( DriverManager::class, function () {
+			return DriverManager::getConnection( $this->config['db'] );
+		} );
 	}
 
 	public function getEntityManager(): EntityManager {
@@ -487,15 +333,25 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	private function getCommentFinder(): CommentFinder {
-		return $this->pimple['comment_repository'];
+		return $this->createSharedObject( CommentFinder::class, function () {
+			return new LoggingCommentFinder(
+				new DoctrineCommentFinder( $this->getEntityManager() ),
+				$this->getLogger()
+			);
+		} );
 	}
 
 	public function getSubscriptionRepository(): SubscriptionRepository {
-		return $this->pimple['subscription_repository'];
+		return $this->createSharedObject( SubscriptionRepository::class, function () {
+			return new LoggingSubscriptionRepository(
+				new DoctrineSubscriptionRepository( $this->getEntityManager() ),
+				$this->getLogger()
+			);
+		} );
 	}
 
 	public function setSubscriptionRepository( SubscriptionRepository $subscriptionRepository ): void {
-		$this->pimple['subscription_repository'] = $subscriptionRepository;
+		$this->sharedObjects[SubscriptionRepository::class] = $subscriptionRepository;
 	}
 
 	private function getSubscriptionValidator(): SubscriptionValidator {
@@ -508,7 +364,9 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function getEmailValidator(): EmailValidator {
-		return $this->pimple['mail_validator'];
+		return $this->createSharedObject( EmailValidator::class, function () {
+			return new EmailValidator( new InternetDomainNameValidator() );
+		} );
 	}
 
 	public function newAddSubscriptionHtmlPresenter(): AddSubscriptionHtmlPresenter {
@@ -569,7 +427,7 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setSkinTwigEnvironment( Twig_Environment $twig ): void {
-		$this->pimple['skin_twig_environment'] = $twig;
+		$this->sharedObjects[Twig_Environment::class . '::Skin'] = $twig;
 	}
 
 	public function getSkinTwig(): Twig_Environment {
@@ -608,7 +466,7 @@ class FunFunFactory implements ServiceProviderInterface {
 				),
 			];
 
-			return $configurator->getEnvironment( $this->pimple['skin_twig_environment'], $loaders, $extensions, $filters, $functions );
+			return $configurator->getEnvironment( new Twig_Environment(), $loaders, $extensions, $filters, $functions );
 		} );
 	}
 
@@ -711,15 +569,21 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function getLogger(): LoggerInterface {
-		return $this->pimple['logger'];
+		return $this->createSharedObject( LoggerInterface::class . '::Application', function () {
+			return new NullLogger();
+		} );
 	}
 
 	public function getPaypalLogger(): LoggerInterface {
-		return $this->pimple['paypal_logger'];
+		return $this->createSharedObject( LoggerInterface::class . '::Paypal', function () {
+			return new NullLogger();
+		} );
 	}
 
 	public function getSofortLogger(): LoggerInterface {
-		return $this->pimple['sofort_logger'];
+		return $this->createSharedObject( LoggerInterface::class . '::Sofort', function () {
+			return new NullLogger();
+		} );
 	}
 
 	public function getWritableApplicationDataPath(): string {
@@ -732,10 +596,6 @@ class FunFunFactory implements ServiceProviderInterface {
 
 	public function getLoggingPath(): string {
 		return $this->getWritableApplicationDataPath() . '/log';
-	}
-
-	private function getSharedResourcesPath(): string {
-		return $this->getWritableApplicationDataPath() . '/shared';
 	}
 
 	public function newAddSubscriptionUseCase(): AddSubscriptionUseCase {
@@ -841,7 +701,9 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	private function getContactValidator(): GetInTouchValidator {
-		return $this->pimple['contact_validator'];
+		return $this->createSharedObject( GetInTouchValidator::class, function () {
+			return new GetInTouchValidator( $this->getEmailValidator() );
+		} );
 	}
 
 	private function newSubscriptionDuplicateValidator(): SubscriptionDuplicateValidator {
@@ -862,7 +724,16 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	private function getHonorifics(): Honorifics {
-		return $this->pimple['honorifics'];
+		return $this->createSharedObject( Honorifics::class,
+			function () {
+				return new Honorifics( [
+					// In the future, this could be locale-specific or filled from a DB table
+					'' => 'Kein Titel',
+					'Dr.' => 'Dr.',
+					'Prof.' => 'Prof.',
+					'Prof. Dr.' => 'Prof. Dr.'
+				] );
+			} );
 	}
 
 	public function newAuthorizedCachePurger(): AuthorizedCachePurger {
@@ -1135,11 +1006,14 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setSofortClient( SofortClient $client ): void {
-		$this->pimple['sofort-client'] = $client;
+		$this->sharedObjects[SofortClient::class] = $client;
 	}
 
 	private function getSofortClient(): SofortClient {
-		return $this->pimple['sofort-client'];
+		return $this->createSharedObject( SofortClient::class, function () {
+			$config = $this->config['sofort'];
+			return new SofortClient( $config['config-key'] );
+		} );
 	}
 
 	private function newCreditCardUrlGenerator(): CreditCardUrlGenerator {
@@ -1151,7 +1025,12 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function getDonationRepository(): DonationRepository {
-		return $this->pimple['donation_repository'];
+		return $this->createSharedObject( DonationRepository::class, function () {
+			return new LoggingDonationRepository(
+				new DoctrineDonationRepository( $this->getEntityManager() ),
+				$this->getLogger()
+			);
+		} );
 	}
 
 	public function newAddressChangeRepository(): AddressChangeRepository {
@@ -1291,7 +1170,9 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	private function getPaymentDelayCalculator(): PaymentDelayCalculator {
-		return $this->pimple['payment-delay-calculator'];
+		return $this->createSharedObject( PaymentDelayCalculator::class, function () {
+			return new DefaultPaymentDelayCalculator( $this->getPaymentDelayInDays() );
+		} );
 	}
 
 	public function getPaymentDelayInDays(): int {
@@ -1299,7 +1180,7 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setPaymentDelayCalculator( PaymentDelayCalculator $paymentDelayCalculator ): void {
-		$this->pimple['payment-delay-calculator'] = $paymentDelayCalculator;
+		$this->sharedObjects[PaymentDelayCalculator::class] = $paymentDelayCalculator;
 	}
 
 	private function newApplyForMembershipPolicyValidator(): ApplyForMembershipPolicyValidator {
@@ -1328,11 +1209,16 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setMembershipApplicationRepository( ApplicationRepository $applicationRepository ): void {
-		$this->pimple['membership_application_repository'] = $applicationRepository;
+		$this->sharedObjects[ApplicationRepository::class] = $applicationRepository;
 	}
 
 	public function getMembershipApplicationRepository(): ApplicationRepository {
-		return $this->pimple['membership_application_repository'];
+		return $this->createSharedObject( ApplicationRepository::class, function () {
+			return new LoggingApplicationRepository(
+				new DoctrineApplicationRepository( $this->getEntityManager() ),
+				$this->getLogger()
+			);
+		} );
 	}
 
 	public function setMembershipApplicationAuthorizer( ApplicationAuthorizer $authorizer ): void {
@@ -1463,19 +1349,37 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function getPayPalPaymentNotificationVerifier(): PaymentNotificationVerifier {
-		return $this->pimple['paypal-payment-notification-verifier'];
+		return $this->createSharedObject( PaymentNotificationVerifier::class . '::Donation', function () {
+			return new LoggingPaymentNotificationVerifier(
+				new PayPalPaymentNotificationVerifier(
+					new Client(),
+					$this->config['paypal-donation']['base-url'],
+					$this->config['paypal-donation']['account-address']
+				),
+				$this->getLogger()
+			);
+		} );
 	}
 
 	public function setPayPalPaymentNotificationVerifier( PaymentNotificationVerifier $verifier ): void {
-		$this->pimple['paypal-payment-notification-verifier'] = $verifier;
+		$this->sharedObjects[PaymentNotificationVerifier::class . '::Donation'] = $verifier;
 	}
 
 	public function getPayPalMembershipFeeNotificationVerifier(): PaymentNotificationVerifier {
-		return $this->pimple['paypal-membership-fee-notification-verifier'];
+		return $this->createSharedObject( PaymentNotificationVerifier::class . '::Membership', function () {
+			return new LoggingPaymentNotificationVerifier(
+				new PayPalPaymentNotificationVerifier(
+					new Client(),
+					$this->config['paypal-membership']['base-url'],
+					$this->config['paypal-membership']['account-address']
+				),
+				$this->getLogger()
+			);
+		} );
 	}
 
 	public function setPayPalMembershipFeeNotificationVerifier( PaymentNotificationVerifier $verifier ): void {
-		$this->pimple['paypal-membership-fee-notification-verifier'] = $verifier;
+		$this->sharedObjects[ PaymentNotificationVerifier::class . '::Membership' ] = $verifier;
 	}
 
 	public function newCreditCardNotificationUseCase( string $updateToken ): CreditCardNotificationUseCase {
@@ -1509,11 +1413,20 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setCreditCardService( CreditCardService $ccService ): void {
-		$this->pimple['credit-card-api-service'] = $ccService;
+		$this->sharedObjects[CreditCardService::class] = $ccService;
 	}
 
 	public function getCreditCardService(): CreditCardService {
-		return $this->pimple['credit-card-api-service'];
+		return $this->createSharedObject( CreditCardService::class, function () {
+			return new McpCreditCardService(
+				new TNvpServiceDispatcher(
+					'IMcpCreditcardService_v1_5',
+					'https://sipg.micropayment.de/public/creditcard/v1.5/nvp/'
+				),
+				$this->config['creditcard']['access-key'],
+				$this->config['creditcard']['testmode']
+			);
+		} );
 	}
 
 	public function newCreditCardNotificationPresenter(): CreditCardNotificationPresenter {
@@ -1579,29 +1492,40 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	private function getPageCache(): Cache {
-		return $this->pimple['page_cache'];
+		// TODO check config for cache options
+		return $this->createSharedObject( Cache::class . '::Page', function () {
+			return new VoidCache();
+		} );
 	}
 
 	private function getRenderedPageCache(): Cache {
-		return $this->pimple['rendered_page_cache'];
+		// TODO check config for cache options
+		return $this->createSharedObject( Cache::class . '::RenderedPage', function () {
+			return new VoidCache();
+		} );
 	}
 
 	private function getCampaignCache(): CacheProvider {
-		return $this->pimple['campaign_cache'];
+		// TODO check config for cache options
+		return $this->createSharedObject( Cache::class . '::RenderedPage', function () {
+			return new VoidCache();
+		} );
 	}
 
+	/**
+	 * Caching should be a configuration value.
+	 *
+	 * This method violates the on-demand initialization of caches when they are requested.
+	 * Instead the getXXXCache methods should check the config and return the appropriate cache
+	 *
+	 * Or even better, use Symfony DI and service definitions
+	 *
+	 * @deprecated
+	 */
 	public function enableCaching(): void {
-		$this->pimple['page_cache'] = function () {
-			return new FilesystemCache( $this->getCachePath() . '/pages/raw', FilesystemCache::EXTENSION, 0002 );
-		};
-
-		$this->pimple['rendered_page_cache'] = function () {
-			return new FilesystemCache( $this->getCachePath() . '/pages/rendered' );
-		};
-
-		$this->pimple['campaign_cache'] = function () {
-			return new FilesystemCache( $this->getCachePath() . '/campaigns' );
-		};
+		$this->sharedObjects[Cache::class . '::Page'] = new FilesystemCache( $this->getCachePath() . '/pages/raw' );
+		$this->sharedObjects[Cache::class . '::RenderedPage'] = new FilesystemCache( $this->getCachePath() . '/pages/rendered' );
+		$this->sharedObjects[Cache::class . '::Campaign'] = new FilesystemCache( $this->getCachePath() . '/campaigns' );
 	}
 
 	public function setProfiler( Stopwatch $profiler ): void {
@@ -1609,19 +1533,19 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setEmailValidator( EmailValidator $validator ): void {
-		$this->pimple['mail_validator'] = $validator;
+		$this->sharedObjects[EmailValidator::class] = $validator;
 	}
 
 	public function setLogger( LoggerInterface $logger ): void {
-		$this->pimple['logger'] = $logger;
+		$this->sharedObjects[LoggerInterface::class . '::Application'] = $logger;
 	}
 
 	public function setPaypalLogger( LoggerInterface $logger ): void {
-		$this->pimple['paypal_logger'] = $logger;
+		$this->sharedObjects[LoggerInterface::class . '::Paypal'] = $logger;
 	}
 
 	public function setSofortLogger( LoggerInterface $logger ): void {
-		$this->pimple['sofort_logger'] = $logger;
+		$this->sharedObjects[LoggerInterface::class . '::Sofort'] = $logger;
 	}
 
 	private function newIbanValidator(): KontoCheckIbanValidator {
@@ -1633,11 +1557,13 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setFilePrefixer( FilePrefixer $prefixer ): void {
-		$this->pimple['cachebusting_fileprefixer'] = $prefixer;
+		$this->sharedObjects[FilePrefixer::class] = $prefixer;
 	}
 
 	private function getFilePrefixer(): FilePrefixer {
-		return $this->pimple['cachebusting_fileprefixer'];
+		return $this->createSharedObject( FilePrefixer::class, function () {
+			return new FilePrefixer( $this->getFilePrefix() );
+		} );
 	}
 
 	private function getFilePrefix(): string {
@@ -1661,13 +1587,13 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setPageViewTracker( PageViewTracker $tracker ): void {
-		$this->pimple['page_view_tracker'] = function () use ( $tracker )  {
-			return $tracker;
-		};
+		$this->sharedObjects[PageViewTracker::class] = $tracker;
 	}
 
 	public function getPageViewTracker(): PageViewTracker {
-		return $this->pimple['page_view_tracker'];
+		return $this->createSharedObject( PageViewTracker::class, function () {
+			return new PageViewTracker( $this->newServerSideTracker(), $this->config['piwik']['siteUrlBase'] );
+		} );
 	}
 
 	public function newServerSideTracker(): ServerSideTracker {
@@ -1696,19 +1622,32 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function setContentPagePageSelector( PageSelector $pageSelector ): void {
-		$this->pimple['content_page_selector'] = $pageSelector;
+		$this->sharedObjects[PageSelector::class] = $pageSelector;
 	}
 
 	public function getContentPagePageSelector(): PageSelector {
-		return $this->pimple['content_page_selector'];
+		return $this->createSharedObject( PageSelector::class, function () {
+			$json = ( new SimpleFileFetcher() )->fetchFile( $this->getI18nDirectory() . '/data/pages.json' );
+			$config = json_decode( $json, true ) ?? [];
+
+			return new PageSelector( $config );
+		} );
 	}
 
 	public function setContentProvider( ContentProvider $contentProvider ): void {
-		$this->pimple['content_provider'] = $contentProvider;
+		$this->sharedObjects[ContentProvider::class] = $contentProvider;
 	}
 
 	private function getContentProvider(): ContentProvider {
-		return $this->pimple['content_provider'];
+		return $this->createSharedObject( ContentProvider::class, function () {
+			return new ContentProvider( [
+				'content_path' => $this->getI18nDirectory(),
+				'cache' => $this->config['twig']['enable-cache'] ? $this->getCachePath() . '/content' : false,
+				'globals' => [
+					'basepath' => $this->config['web-basepath']
+				]
+			] );
+		} );
 	}
 
 	public function newMailTemplateFilenameTraversable(): MailTemplateFilenameTraversable {
@@ -1718,19 +1657,35 @@ class FunFunFactory implements ServiceProviderInterface {
 	}
 
 	public function getUrlGenerator(): UrlGenerator {
-		return $this->pimple['url_generator'];
+		// TODO Remove startup dependency
+		if ( !isset( $this->sharedObjects[UrlGenerator::class] ) ) {
+			throw new \RuntimeException( 'UrlGenerated is a routing dependency that must be set at startup!' );
+		}
+		return $this->sharedObjects[UrlGenerator::class];
 	}
 
 	public function setUrlGenerator( UrlGenerator $urlGenerator ): void {
-		$this->pimple['url_generator'] = $urlGenerator;
+		$this->sharedObjects[UrlGenerator::class] = $urlGenerator;
 	}
 
 	public function getCookieBuilder(): CookieBuilder {
-		return $this->pimple['cookie-builder'];
+		return $this->createSharedObject( CookieBuilder::class, function (): CookieBuilder {
+			return new CookieBuilder(
+				$this->config['cookie']['expiration'],
+				$this->config['cookie']['path'],
+				$this->config['cookie']['domain'],
+				$this->config['cookie']['secure'],
+				$this->config['cookie']['httpOnly'],
+				$this->config['cookie']['raw'],
+				$this->config['cookie']['sameSite']
+			);
+		} );
 	}
 
 	public function getPaymentTypesSettings(): PaymentTypesSettings {
-		return $this->pimple['payment-types-settings'];
+		return $this->createSharedObject( PaymentTypesSettings::class, function (): PaymentTypesSettings {
+			return new PaymentTypesSettings( $this->config['payment-types'] );
+		} );
 	}
 
 	/**

--- a/tests/EdgeToEdge/WebRouteTestCase.php
+++ b/tests/EdgeToEdge/WebRouteTestCase.php
@@ -100,8 +100,6 @@ abstract class WebRouteTestCase extends TestCase {
 
 		$app['session.test'] = true;
 
-		$ffFactory->setSkinTwigEnvironment( $app['twig'] );
-
 		return $app;
 	}
 

--- a/tests/TestEnvironmentSetup.php
+++ b/tests/TestEnvironmentSetup.php
@@ -17,7 +17,6 @@ use WMDE\Fundraising\Frontend\Tests\Fixtures\FakeUrlGenerator;
 class TestEnvironmentSetup implements EnvironmentSetup {
 	public function setEnvironmentDependentInstances( FunFunFactory $factory, array $configuration ) {
 		$factory->setNullMessenger();
-		$factory->setSkinTwigEnvironment( new \Twig_Environment() );
 		$factory->setUrlGenerator( new FakeUrlGenerator() );
 
 		$factory->setDoctrineConfiguration( Setup::createConfiguration( true ) );

--- a/web/index.php
+++ b/web/index.php
@@ -37,8 +37,6 @@ $ffFactory = call_user_func( function() {
 
 $app = \WMDE\Fundraising\Frontend\App\Bootstrap::initializeApplication( $ffFactory );
 
-$ffFactory->setSkinTwigEnvironment( $app['twig'] );
-
 $ffFactory->setUrlGenerator( new UrlGeneratorAdapter( $app['url_generator'] ) );
 
 $app->run();


### PR DESCRIPTION
This PR is for becoming more independent from the Silex framework, which uses
the Pimple Dependency Injection Container internally.

- Move shared object creation from Pimple to FunFunFactory internals
- Remove Pimple from FunFunFactory

This is for https://phabricator.wikimedia.org/T263462
