### PR TITLE
Prepare for PHPUnit 10

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,35 @@
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="tests/bootstrap.php"
-         cacheTokens="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="false"
-         convertWarningsToExceptions="true"
-         stopOnError="false"
-         stopOnFailure="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         verbose="false">
-    <testsuites>
-        <testsuite name="unit">
-            <directory>tests/Unit</directory>
-        </testsuite>
-        <testsuite name="integration">
-            <directory>tests/Integration</directory>
-        </testsuite>
-        <testsuite name="edgetoedge">
-            <directory>tests/EdgeToEdge</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-            <directory suffix=".php">app</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	backupGlobals="false"
+	backupStaticAttributes="false"
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="false"
+	convertWarningsToExceptions="true"
+	stopOnError="false"
+	stopOnFailure="false"
+	stopOnIncomplete="false"
+	stopOnSkipped="false"
+	verbose="false"
+	>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+      <directory suffix=".php">app</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests/Unit</directory>
+    </testsuite>
+    <testsuite name="integration">
+      <directory>tests/Integration</directory>
+    </testsuite>
+    <testsuite name="edgetoedge">
+      <directory>tests/EdgeToEdge</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Unit/Infrastructure/SupportHandlerTest.php
+++ b/tests/Unit/Infrastructure/SupportHandlerTest.php
@@ -44,24 +44,26 @@ class SupportHandlerTest extends TestCase {
 		$this->assertFalse( $wasHandled, 'Support handler should always return false when error-prone handler has thrown an exception.' );
 	}
 
-	public function testSupportHandlerReturnsHandlingResultFromWrappedMainHandler(): void {
+	/**
+	 * @dataProvider handlerResultsProvider
+	 *
+	 * @param bool $returnValue
+	 */
+	public function testSupportHandlerReturnsHandlingResultFromWrappedMainHandler( bool $returnValue ): void {
 		/** @var AbstractHandler&MockObject $returningHandler */
 		$returningHandler = $this->createMock( AbstractHandler::class );
-
-		$returningHandler->expects( $this->at( 0 ) )
-			->method( 'handle' )
-			->willReturn( false );
-
-		$returningHandler->expects( $this->at( 1 ) )
-			->method( 'handle' )
-			->willReturn( true );
-
+		$returningHandler->method( 'handle' )
+			->willReturn( $returnValue );
 		$supportHandler = new SupportHandler( $returningHandler, new NullLogger() );
-		$firstCallResult = $supportHandler->handle( [] );
-		$secondCallResult = $supportHandler->handle( [] );
 
-		$this->assertFalse( $firstCallResult );
-		$this->assertTrue( $secondCallResult );
+		$callResult = $supportHandler->handle( [] );
+
+		$this->assertSame( $returnValue, $callResult );
+	}
+
+	public function handlerResultsProvider(): iterable {
+		yield [ true ];
+		yield [ false ];
 	}
 
 }


### PR DESCRIPTION
PHPUnit 9.3 threw some deprecation warnings, this PR fixes that.

- Update PHPUnit configuration
- Remove deprecated PHPUnit methods
