### PR TITLE
Fix Twig cache

### DIFF
--- a/tests/Unit/Factories/TwigFactoryTest.php
+++ b/tests/Unit/Factories/TwigFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Factories;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Cache\FilesystemCache;
+use Twig\Cache\NullCache;
+
+/**
+ * @covers \WMDE\Fundraising\Frontend\Factories\TwigFactory
+ */
+class TwigFactoryTest extends TestCase {
+
+	public function testEnabledCacheReturnsFilesystemCache(): void {
+		$factory = new TwigFactoryTestImplementation( [ 'enable-cache' => true ], '/tmp', 'NONE' );
+
+		$cache = $factory->getCache();
+
+		$this->assertInstanceOf( FilesystemCache::class, $cache );
+		$this->assertStringStartsWith( '/tmp/', $cache->generateKey( 'foo', '' ) );
+	}
+
+	public function testDisabledCacheReturnsNullCache(): void {
+		$factory = new TwigFactoryTestImplementation( [ 'enable-cache' => false ], '/tmp', 'NONE' );
+
+		$cache = $factory->getCache();
+
+		$this->assertInstanceOf( NullCache::class, $cache );
+	}
+
+}

--- a/tests/Unit/Factories/TwigFactoryTestImplementation.php
+++ b/tests/Unit/Factories/TwigFactoryTestImplementation.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Factories;
+
+use WMDE\Fundraising\Frontend\Factories\TwigFactory;
+
+/**
+ * Implementation for testing common functionality
+ *
+ * @codeCoverageIgnore
+ */
+class TwigFactoryTestImplementation extends TwigFactory {
+
+}


### PR DESCRIPTION
Fix error where we passed a boolean `true` instead of
string|CacheInterface.

Add test for cache creation.