### PR TITLE
Fix import of wrong Request class

### DIFF
--- a/app/Controllers/StaticContent/ShowUseOfFundsController.php
+++ b/app/Controllers/StaticContent/ShowUseOfFundsController.php
@@ -4,8 +4,8 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\App\Controllers\StaticContent;
 
+use Symfony\Component\HttpFoundation\Request;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
-use WMDE\Fundraising\PaymentContext\DataAccess\Sofort\Transfer\Request;
 
 class ShowUseOfFundsController {
 


### PR DESCRIPTION
Controllers should always get an instance of Symfony\Component\HttpFoundation\Request
