### PR TITLE
Remove Google webmaster confirmation

### DIFF
--- a/web/googlee2eb29b7ca19c071.html
+++ b/web/googlee2eb29b7ca19c071.html
@@ -1,1 +1,0 @@
-google-site-verification: googlee2eb29b7ca19c071.html


### PR DESCRIPTION
This PR removes a confirmation file for a developer who's no longer a
member of the FUN team. The file was checked by Google to prove that he
has write access to the web page.
