### PR TITLE
Move HTTP rate limiting to its own class

### DIFF
--- a/app/Controllers/Donation/ShowDonationConfirmationController.php
+++ b/app/Controllers/Donation/ShowDonationConfirmationController.php
@@ -18,9 +18,6 @@ use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
  */
 class ShowDonationConfirmationController {
 
-	public const SUBMISSION_COOKIE_NAME = 'donation_timestamp';
-	public const TIMESTAMP_FORMAT = 'Y-m-d H:i:s';
-
 	public function index( Request $request, FunFunFactory $ffFactory ): Response {
 		$useCase = $ffFactory->newGetDonationUseCase( $request->get( 'accessToken', '' ) );
 
@@ -33,7 +30,7 @@ class ShowDonationConfirmationController {
 		}
 
 		$ffFactory->getTranslationCollector()->addTranslationFile( $ffFactory->getI18nDirectory() . '/messages/paymentTypes.json' );
-		$httpResponse = new Response(
+		return new Response(
 			$ffFactory->newDonationConfirmationPresenter()->present(
 				$responseModel->getDonation(),
 				$responseModel->getUpdateToken(),
@@ -51,14 +48,6 @@ class ShowDonationConfirmationController {
 				)
 			)
 		);
-
-		if ( !$request->cookies->get( self::SUBMISSION_COOKIE_NAME ) ) {
-			$cookie = $ffFactory->getCookieBuilder();
-			$httpResponse->headers->setCookie(
-				$cookie->newCookie( self::SUBMISSION_COOKIE_NAME, date( self::TIMESTAMP_FORMAT ) )
-			);
-		}
-		return $httpResponse;
 	}
 
 }

--- a/src/Infrastructure/SubmissionRateLimit.php
+++ b/src/Infrastructure/SubmissionRateLimit.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\Fundraising\Frontend\Infrastructure;
+
+use DateInterval;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SubmissionRateLimit {
+
+	public const TIMESTAMP_FORMAT = 'Y-m-d H:i:s';
+
+	private string $cookieName;
+	private LoggerInterface $logger;
+	private DateInterval $intervalBetweenSubmissions;
+	private CookieBuilder $cookieBuilder;
+
+	public function __construct( string $cookieName, DateInterval $intervalBetweenSubmissions, CookieBuilder $cookieBuilder, LoggerInterface $logger ) {
+		$this->cookieName = $cookieName;
+		$this->logger = $logger;
+		$this->intervalBetweenSubmissions = $intervalBetweenSubmissions;
+		$this->cookieBuilder = $cookieBuilder;
+	}
+
+	public function isSubmissionAllowed( Request $request ): bool {
+		$lastSubmission = $request->cookies->get( $this->cookieName, '' );
+		if ( $lastSubmission === '' ) {
+			return true;
+		}
+
+		$timeFromCookie = \DateTime::createFromFormat( self::TIMESTAMP_FORMAT, $lastSubmission );
+		if ( $timeFromCookie === false ) {
+			$this->logger->info( sprintf(
+				'Invalid time string in cookie "%s": "%s" does not match "%s"',
+				$this->cookieName,
+				$lastSubmission,
+				self::TIMESTAMP_FORMAT
+			) );
+			return true;
+		}
+
+		$minNextTimestamp = $timeFromCookie->add( $this->intervalBetweenSubmissions );
+		if ( $minNextTimestamp > new \DateTime() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public function setRateLimitCookie( Request $request, Response $response ) {
+		if ( !$request->cookies->get( $this->cookieName ) ) {
+			$response->headers->setCookie(
+				$this->cookieBuilder->newCookie( $this->cookieName, date( self::TIMESTAMP_FORMAT ) )
+			);
+		}
+	}
+
+}

--- a/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ApplyForMembershipRouteTest.php
@@ -279,7 +279,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 			$this->newValidHttpParameters()
 		);
 
-		$cookie = $client->getCookieJar()->get( 'memapp_timestamp' );
+		$cookie = $client->getCookieJar()->get( FunFunFactory::MEMBERSHIP_RATE_LIMIT_COOKIE_NAME );
 		$this->assertNotNull( $cookie );
 		$donationTimestamp = new \DateTime( $cookie->getValue() );
 		$this->assertEqualsWithDelta( time(), $donationTimestamp->getTimestamp(), 5.0, 'Timestamp should be not more than 5 seconds old' );
@@ -514,7 +514,7 @@ class ApplyForMembershipRouteTest extends WebRouteTestCase {
 
 		$cookieJar = $client->getCookieJar();
 		$cookieJar->updateFromResponse( $client->getInternalResponse() );
-		$cookie = $cookieJar->get( ApplyForMembershipController::SUBMISSION_COOKIE_NAME );
+		$cookie = $cookieJar->get( FunFunFactory::MEMBERSHIP_RATE_LIMIT_COOKIE_NAME );
 
 		$this->assertTrue( $cookie->isHttpOnly() );
 		$this->assertTrue( $cookie->isSecure() );

--- a/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowDonationConfirmationRouteTest.php
@@ -160,26 +160,4 @@ class ShowDonationConfirmationRouteTest extends WebRouteTestCase {
 		$this->assertStringContainsString( self::ACCESS_DENIED_TEXT, $responseContent );
 	}
 
-	public function testWhenDonationTimestampCookiePreexists_itIsNotOverwritten(): void {
-		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ): void {
-			$donation = $this->newStoredDonation( $factory );
-
-			$client->getCookieJar()->set(
-				new Cookie( ShowDonationConfirmationController::SUBMISSION_COOKIE_NAME, 'some value' )
-			);
-			$client->request(
-				'GET',
-				'show-donation-confirmation',
-				[
-					'id' => $donation->getId(),
-					'accessToken' => self::CORRECT_ACCESS_TOKEN
-				]
-			);
-
-			$this->assertSame(
-				'some value',
-				$client->getCookieJar()->get( ShowDonationConfirmationController::SUBMISSION_COOKIE_NAME )->getValue()
-			);
-		} );
-	}
 }

--- a/tests/EdgeToEdge/Routes/ShowMembershipConfirmationRouteTest.php
+++ b/tests/EdgeToEdge/Routes/ShowMembershipConfirmationRouteTest.php
@@ -38,29 +38,6 @@ class ShowMembershipConfirmationRouteTest extends WebRouteTestCase {
 		return $membershipApplication;
 	}
 
-	public function testWhenMembershipApplicationTimestampCookiePreexists_itIsNotOverwritten(): void {
-		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ): void {
-			$membershipApplication = $this->newStoredMembershipApplication( $factory );
-
-			$client->getCookieJar()->set(
-				new Cookie( ApplyForMembershipController::SUBMISSION_COOKIE_NAME, 'some value' )
-			);
-			$client->request(
-				Request::METHOD_GET,
-				self::PATH,
-				[
-					'id' => $membershipApplication->getId(),
-					'accessToken' => self::CORRECT_ACCESS_TOKEN
-				]
-			);
-
-			$this->assertSame(
-				'some value',
-				$client->getCookieJar()->get( ApplyForMembershipController::SUBMISSION_COOKIE_NAME )->getValue()
-			);
-		} );
-	}
-
 	public function testCallWithWrongAccessToken_deniedPageIsShown(): void {
 		$this->createEnvironment( [], function ( Client $client, FunFunFactory $factory ): void {
 			$membershipApplication = $this->newStoredMembershipApplication( $factory );

--- a/tests/Unit/Infrastructure/SubmissionRateLimitTest.php
+++ b/tests/Unit/Infrastructure/SubmissionRateLimitTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace WMDE\Fundraising\Frontend\Tests\Unit\Infrastructure;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Psr\Log\NullLogger;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use WMDE\Fundraising\Frontend\Infrastructure\CookieBuilder;
+use WMDE\Fundraising\Frontend\Infrastructure\SubmissionRateLimit;
+use WMDE\PsrLogTestDoubles\LoggerSpy;
+
+/**
+ * @covers \WMDE\Fundraising\Frontend\Infrastructure\SubmissionRateLimit
+ */
+class SubmissionRateLimitTest extends TestCase {
+
+	public function testSubmissionAllowedWhenCookieIsEmpty(): void {
+		$cookieBuilder = $this->createMock( CookieBuilder::class );
+		$limit = new SubmissionRateLimit( 'donation_timestamp', new \DateInterval( 'PT1H' ), $cookieBuilder, new NullLogger() );
+		$request = new Request();
+
+		$this->assertTrue( $limit->isSubmissionAllowed( $request ) );
+	}
+
+	public function testSubmissionAllowedWhenCookieHasInvalidTimestamp(): void {
+		$cookieBuilder = $this->createMock( CookieBuilder::class );
+		$limit = new SubmissionRateLimit( 'donation_timestamp', new \DateInterval( 'PT1H' ), $cookieBuilder, new NullLogger() );
+		$request = new Request( [], [], [], [ 'donation_timestamp' => 'Now is not the time!' ] );
+
+		$this->assertTrue( $limit->isSubmissionAllowed( $request ) );
+	}
+
+	public function testSubmissionAllowedWhenCookieHasExpiredTimestamp(): void {
+		$cookieBuilder = $this->createMock( CookieBuilder::class );
+		$limit = new SubmissionRateLimit( 'donation_timestamp', new \DateInterval( 'PT1H' ), $cookieBuilder, new NullLogger() );
+		$request = new Request( [], [], [], [ 'donation_timestamp' => date( SubmissionRateLimit::TIMESTAMP_FORMAT, time() - 7200 ) ] );
+
+		$this->assertTrue( $limit->isSubmissionAllowed( $request ) );
+	}
+
+	public function testSubmissionForbiddenWhenCookieTimestampIsInRange(): void {
+		$cookieBuilder = $this->createMock( CookieBuilder::class );
+		$limit = new SubmissionRateLimit( 'donation_timestamp', new \DateInterval( 'PT1H' ), $cookieBuilder, new NullLogger() );
+		$request = new Request( [], [], [], [ 'donation_timestamp' => date( SubmissionRateLimit::TIMESTAMP_FORMAT, time() - 120 ) ] );
+
+		$this->assertFalse( $limit->isSubmissionAllowed( $request ) );
+	}
+
+	public function testWhenTimestampOfPreviousDonationIsFaulty_timestampGetsLogged(): void {
+		$cookieBuilder = $this->createMock( CookieBuilder::class );
+		$logger = new LoggerSpy();
+		$limit = new SubmissionRateLimit( 'donation_timestamp', new \DateInterval( 'PT1H' ), $cookieBuilder, $logger );
+		$request = new Request( [], [], [], [ 'donation_timestamp' => 'Now is not the time!' ] );
+
+		$limit->isSubmissionAllowed( $request );
+
+		$call = $logger->getFirstLogCall();
+		$this->assertSame( LogLevel::INFO, $call->getLevel() );
+		$this->assertStringContainsString( 'Now is not the time', $call->getMessage() );
+	}
+
+	public function testWhenRequestHasNoCookieItSetsRateLimitCookieWithCurrentDateValue(): void {
+		$cookieBuilder = new CookieBuilder( time() + 10000, '/', 'example.com', true, false, false, null );
+		$limit = new SubmissionRateLimit( 'donation_timestamp', new \DateInterval( 'PT1H' ), $cookieBuilder, new NullLogger() );
+		$response = new Response();
+		$request = new Request();
+
+		$limit->setRateLimitCookie( $request, $response );
+
+		$limitCookie = $response->headers->getCookies()[0];
+		$this->assertSame( 'donation_timestamp', $limitCookie->getName() );
+		$this->assertStringStartsWith( date( SubmissionRateLimit::TIMESTAMP_FORMAT, time() ), $limitCookie->getValue() );
+	}
+
+	public function testWhenDonationTimestampCookieExists_itIsNotOverwritten(): void {
+		$cookieBuilder = $this->createMock( CookieBuilder::class );
+		$cookieBuilder->expects( $this->never() )->method( 'newCookie' );
+
+		$limit = new SubmissionRateLimit( 'donation_timestamp', new \DateInterval( 'PT1H' ), $cookieBuilder, new NullLogger() );
+		$response = new Response();
+		$request = new Request( [], [], [], [ 'donation_timestamp' => '2020-11-11 11:11:00' ] );
+
+		$limit->setRateLimitCookie( $request, $response );
+	}
+
+}


### PR DESCRIPTION
Donation and membership controllers limit the amount of
donations/memberships to a certain configured amount, to prevent spam.
They use cookies to track the last time someone has donated/applied for
membership.

The code was identical, but had a flaw: The execution halted with a
fatal error when the time stamp did not have a valid format. The fix
would have meant more duplication, so I extracted the functionality into
a separate class.

This change also sets the cookie for donations earlier - when controller
generates the success response (redirect to payment provider or success
page) instead of misusing the confirmation controller for that
functionality. This ensures that people can't do multiple bogus
donations with external payment providers.
