### PR TITLE
Change SubmissionRateLimit storage to Session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,11 @@ covers:
 	docker-compose run --rm --no-deps app ./vendor/bin/covers-validator
 
 phpunit:
-	docker-compose run --rm app ./vendor/bin/phpunit $(TEST_DIR)
+	docker-compose run --rm app php -d memory_limit=1G vendor/bin/phpunit $(TEST_DIR)
 
 phpunit-with-coverage:
-	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug ./vendor/bin/phpunit --dump-xdebug-filter var/xdebug-filter.php
-	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug ./vendor/bin/phpunit --prepend var/xdebug-filter.php --configuration=phpunit.xml.dist --stop-on-error --coverage-clover coverage.clover
+	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug php -d memory_limit=1G vendor/bin/phpunit --dump-xdebug-filter var/xdebug-filter.php
+	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug php -d memory_limit=1G vendor/bin/phpunit --prepend var/xdebug-filter.php --configuration=phpunit.xml.dist --stop-on-error --coverage-clover coverage.clover
 
 phpunit-system:
 	docker-compose run --rm app ./vendor/bin/phpunit tests/System/

--- a/app/Controllers/Donation/AddDonationController.php
+++ b/app/Controllers/Donation/AddDonationController.php
@@ -111,7 +111,6 @@ class AddDonationController {
 				return new RedirectResponse(
 					$this->ffFactory->newCreditCardPaymentUrlGenerator()->buildUrl( $responseModel )
 				);
-				break;
 			default:
 				throw new \LogicException( 'Unknown Payment method - can\'t determine response' );
 		}

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -214,8 +214,8 @@ use WMDE\FunValidators\Validators\TextPolicyValidator;
  */
 class FunFunFactory {
 
-	public const DONATION_RATE_LIMIT_COOKIE_NAME = 'donation_timestamp';
-	public const MEMBERSHIP_RATE_LIMIT_COOKIE_NAME = 'memapp_timestamp';
+	public const DONATION_RATE_LIMIT_SESSION_KEY = 'donation_timestamp';
+	public const MEMBERSHIP_RATE_LIMIT_SESSION_KEY = 'memapp_timestamp';
 
 	/**
 	 * @var array<string, mixed>
@@ -1581,19 +1581,15 @@ class FunFunFactory {
 
 	public function getDonationSubmissionRateLimiter(): SubmissionRateLimit {
 		return new SubmissionRateLimit(
-			self::DONATION_RATE_LIMIT_COOKIE_NAME,
-			new \DateInterval( $this->config['donation-timeframe-limit'] ),
-			$this->getCookieBuilder(),
-			$this->getLogger()
+			self::DONATION_RATE_LIMIT_SESSION_KEY,
+			new \DateInterval( $this->config['donation-timeframe-limit'] )
 		);
 	}
 
 	public function getMembershipSubmissionRateLimiter(): SubmissionRateLimit {
 		return new SubmissionRateLimit(
-			self::MEMBERSHIP_RATE_LIMIT_COOKIE_NAME,
-			new \DateInterval( $this->config['membership-application-timeframe-limit'] ),
-			$this->getCookieBuilder(),
-			$this->getLogger()
+			self::MEMBERSHIP_RATE_LIMIT_SESSION_KEY,
+			new \DateInterval( $this->config['membership-application-timeframe-limit'] )
 		);
 	}
 


### PR DESCRIPTION
Store the submission rate limit in Session instead of cookie, to avoid
having to parse time formats from cookie and to avoid sending extraneous
data to user.

Added session manipulation methods to WebRouteTestCase.
Adding session access to WebRouteTestCase means the Silex Application
object will be persisted, leading to increased memory usage during unit
tests. To alleviate that, we increase the PHP memory limit in the
Makefile.

Previously, AddDonationRouteTest and ApplyForMembershipRouteTest checked
the rate limit cookie for the correct cookie parameters. I've removed
that check for ApplyForMembershipRouteTest and added a generalized check
to AddDonationRouteTest. This test is skipped for now, because it will
fail until we use CookieBuilder everywhere. This change is already on
the horizon with https://github.com/wmde/FundraisingFrontend/pull/1936
When that that PR is merged, we should remove the `markTestAsSkipped`
instruction and try again.

In general AddDonationRouteTest is a bad place to ensure all cookies
have the right parameters, we only (mis)use that test because we're
fairly sure that it is the route that sets the most cookies.

This is for https://phabricator.wikimedia.org/T268766
