### PR TITLE
Drop local tables on make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ test: covers phpunit
 
 setup-db:
 	docker-compose run --rm start_dependencies
+	docker-compose run --rm app ./vendor/bin/doctrine orm:schema-tool:drop --force
 	docker-compose run --rm app ./vendor/bin/doctrine orm:schema-tool:create
 	docker-compose run --rm app ./vendor/bin/doctrine orm:generate-proxies var/doctrine_proxies
 


### PR DESCRIPTION
This fixes errors thrown when the local tables already exist