### PR TITLE
Add membership migration configuration

### DIFF
--- a/app/config/migrations/memberships.yml
+++ b/app/config/migrations/memberships.yml
@@ -1,0 +1,4 @@
+name: Doctrine Migration Scripts for Membership Bounded Context
+migrations_namespace: DoctrineMigrations
+table_name: membership_migration_versions
+migrations_directory: vendor/wmde/fundraising-memberships/migrations


### PR DESCRIPTION
Add a migration configuration file for memberships. The migration can't
be run until we merge https://github.com/wmde/fundraising-memberships/pull/57 and upgrade the `wmde/fundraising-memberships` dependency, but
we will only do that when the whole incentive feature is ready. This
PR can be merged none the less.