### PR TITLE
Add fixtures on `make setup-db`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ setup-db:
 	docker-compose run --rm start_dependencies
 	docker-compose run --rm app ./vendor/bin/doctrine orm:schema-tool:create
 	docker-compose run --rm app ./vendor/bin/doctrine orm:generate-proxies var/doctrine_proxies
+	docker-compose run --rm app ./vendor/bin/doctrine dbal:import build/database/fixtures.sql
 
 covers:
 	docker-compose run --rm --no-deps app ./vendor/bin/covers-validator

--- a/build/database/fixtures.sql
+++ b/build/database/fixtures.sql
@@ -1,0 +1,2 @@
+-- Only needed until https://phabricator.wikimedia.org/T270721 is done
+INSERT INTO incentive (`id`, `name`) VALUES (1, 'tote_bag');


### PR DESCRIPTION
We now need the entries in the content repository, otherwise inserting
memberships into the database will fail.

Until we do https://phabricator.wikimedia.org/T270721 , we manually
create the incentive entry.