### PR TITLE
Remove coverage allow list generation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,7 @@ phpunit:
 	docker-compose run --rm app php -d memory_limit=1G vendor/bin/phpunit $(TEST_DIR)
 
 phpunit-with-coverage:
-	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug php -d memory_limit=1G vendor/bin/phpunit --dump-xdebug-filter var/xdebug-filter.php
-	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug php -d memory_limit=1G vendor/bin/phpunit --prepend var/xdebug-filter.php --configuration=phpunit.xml.dist --stop-on-error --coverage-clover coverage.clover
+	docker-compose -f docker-compose.yml -f docker-compose.debug.yml run --rm app_debug php -d memory_limit=1G vendor/bin/phpunit --configuration=phpunit.xml.dist --stop-on-error --coverage-clover coverage.clover
 
 phpunit-system:
 	docker-compose run --rm app ./vendor/bin/phpunit tests/System/


### PR DESCRIPTION
PHPUnit deprecated the coverage list parameter (see https://github.com/sebastianbergmann/phpunit/issues/4226) and our build script was throwing errors.
