### PR TITLE
Remove deprecated source tracking

### DIFF
--- a/app/Controllers/Donation/AddDonationController.php
+++ b/app/Controllers/Donation/AddDonationController.php
@@ -9,12 +9,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\DonationContext\Domain\Model\DonorType;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationRequest;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationResponse;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Infrastructure\AddressType;
+use WMDE\Fundraising\Frontend\Presentation\Presenters\DonationFormPresenter\ImpressionCounts;
 use WMDE\Fundraising\PaymentContext\Domain\Model\BankData;
 use WMDE\Fundraising\PaymentContext\Domain\Model\Iban;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethod;
@@ -122,9 +122,6 @@ class AddDonationController {
 
 		$donationRequest->setTracking( $request->attributes->get( 'trackingCode', '' ) );
 		$donationRequest->setOptIn( $request->get( 'info', '' ) );
-		// Setting source for completeness sake,
-		// TODO Remove when  https://phabricator.wikimedia.org/T134327 is done
-		$donationRequest->setSource( '' );
 		$donationRequest->setTotalImpressionCount( intval( $request->get( 'impCount', 0 ) ) );
 		$donationRequest->setSingleBannerImpressionCount( intval( $request->get( 'bImpCount', 0 ) ) );
 		$donationRequest->setOptsIntoDonationReceipt( $request->request->getBoolean( 'donationReceipt', true ) );
@@ -175,12 +172,11 @@ class AddDonationController {
 		return 0;
 	}
 
-	private function newTrackingInfoFromRequest( Request $request ): DonationTrackingInfo {
-		$tracking = new DonationTrackingInfo();
-		$tracking->setSingleBannerImpressionCount( intval( $request->get( 'bImpCount', 0 ) ) );
-		$tracking->setTotalImpressionCount( intval( $request->get( 'impCount', 0 ) ) );
-
-		return $tracking;
+	private function newTrackingInfoFromRequest( Request $request ): ImpressionCounts {
+		return new ImpressionCounts(
+			intval( $request->get( 'impCount', 0 ) ),
+			intval( $request->get( 'bImpCount', 0 ) )
+		);
 	}
 
 	/**

--- a/app/Controllers/Donation/NewDonationController.php
+++ b/app/Controllers/Donation/NewDonationController.php
@@ -7,9 +7,9 @@ namespace WMDE\Fundraising\Frontend\App\Controllers\Donation;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\Frontend\App\Routes;
 use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
+use WMDE\Fundraising\Frontend\Presentation\Presenters\DonationFormPresenter\ImpressionCounts;
 
 class NewDonationController {
 
@@ -32,9 +32,10 @@ class NewDonationController {
 
 		$validationResult = $ffFactory->newPaymentDataValidator()->validate( $amount, $paymentType );
 
-		$trackingInfo = new DonationTrackingInfo();
-		$trackingInfo->setTotalImpressionCount( intval( $request->get( 'impCount' ) ) );
-		$trackingInfo->setSingleBannerImpressionCount( intval( $request->get( 'bImpCount' ) ) );
+		$trackingInfo = new ImpressionCounts(
+			intval( $request->get( 'impCount' ) ),
+			intval( $request->get( 'bImpCount' ) )
+		);
 
 		return new Response(
 			$ffFactory->newDonationFormPresenter()->present(

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"wmde/email-address": "~1.0",
 		"wmde/euro": "~1.0",
 		"wmde/clock": "~1.0",
-		"wmde/fundraising-donations": "~4.0.5",
+		"wmde/fundraising-donations": "~5.0.0",
 		"wmde/fundraising-memberships": "~4.1.0",
 		"wmde/fundraising-payments": "~1.0.1",
 		"wmde/fundraising-subscriptions": "~2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3adc55937f0af25b4e6ac425c539731",
+    "content-hash": "b7fe92d48a9daa6cd12fe378b24cba97",
     "packages": [
         {
             "name": "airbrake/phpbrake",
@@ -3914,7 +3914,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -3973,7 +3973,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -3993,16 +3993,16 @@
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "b34bfb8c4c22650ac080d2662ae3502e5f2f4ae6"
+                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/b34bfb8c4c22650ac080d2662ae3502e5f2f4ae6",
-                "reference": "b34bfb8c4c22650ac080d2662ae3502e5f2f4ae6",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/06fb361659649bcfd6a208a0f1fcaf4e827ad342",
+                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342",
                 "shasum": ""
             },
             "require": {
@@ -4053,7 +4053,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4069,20 +4069,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af"
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/267a9adeb8ecb8071040a740930e077cdfb987af",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
                 "shasum": ""
             },
             "require": {
@@ -4134,7 +4134,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4150,20 +4150,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "0eb8293dbbcd6ef6bf81404c9ce7d95bcdf34f44"
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/0eb8293dbbcd6ef6bf81404c9ce7d95bcdf34f44",
-                "reference": "0eb8293dbbcd6ef6bf81404c9ce7d95bcdf34f44",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/2d63434d922daf7da8dd863e7907e67ee3031483",
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483",
                 "shasum": ""
             },
             "require": {
@@ -4221,7 +4221,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4237,20 +4237,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba"
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/6e971c891537eb617a00bb07a43d182a6915faba",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
                 "shasum": ""
             },
             "require": {
@@ -4305,7 +4305,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4321,20 +4321,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T17:09:11+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13"
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
                 "shasum": ""
             },
             "require": {
@@ -4385,7 +4385,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4401,7 +4401,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -4541,7 +4541,7 @@
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
@@ -4597,7 +4597,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4617,7 +4617,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -4680,7 +4680,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -5854,16 +5854,16 @@
         },
         {
             "name": "wmde/fundraising-donations",
-            "version": "v4.0.5",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-donations",
-                "reference": "68d03c42407821b0efa5f81a793838a5741c57ce"
+                "reference": "50687f5453bac8e11abb6aea40a07c72ef149da1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/68d03c42407821b0efa5f81a793838a5741c57ce",
-                "reference": "68d03c42407821b0efa5f81a793838a5741c57ce",
+                "url": "https://api.github.com/repos/wmde/fundraising-donations/zipball/50687f5453bac8e11abb6aea40a07c72ef149da1",
+                "reference": "50687f5453bac8e11abb6aea40a07c72ef149da1",
                 "shasum": ""
             },
             "require": {
@@ -5885,7 +5885,7 @@
                 "ockcyp/covers-validator": "^1.2",
                 "phpmd/phpmd": "~2.6",
                 "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "~9.4.0",
+                "phpunit/phpunit": "~9.5.1",
                 "wmde/fundraising-phpcs": "~1.0",
                 "wmde/psr-log-test-doubles": "~2.1"
             },
@@ -5906,7 +5906,7 @@
             ],
             "description": "Bounded Context for the Wikimedia Deutschland fundraising donation subdomain",
             "homepage": "https://github.com/wmde/fundraising-donations",
-            "time": "2020-11-16T11:58:57+00:00"
+            "time": "2021-01-18T08:19:00+00:00"
         },
         {
             "name": "wmde/fundraising-memberships",
@@ -9009,12 +9009,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/wmde/fundraising-frontend-content",
-                "reference": "66308282e2e5de16b31435a82485d6aa9e172d66"
+                "reference": "73f2358cf804aec11718fe5c2913ba732912e549"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/66308282e2e5de16b31435a82485d6aa9e172d66",
-                "reference": "66308282e2e5de16b31435a82485d6aa9e172d66",
+                "url": "https://api.github.com/repos/wmde/fundraising-frontend-content/zipball/73f2358cf804aec11718fe5c2913ba732912e549",
+                "reference": "73f2358cf804aec11718fe5c2913ba732912e549",
                 "shasum": ""
             },
             "require-dev": {
@@ -9048,7 +9048,7 @@
                 "CC0-1.0"
             ],
             "description": "i18n for FundraisingFrontend",
-            "time": "2021-02-11T10:49:08+00:00"
+            "time": "2021-02-16T12:03:21+00:00"
         },
         {
             "name": "wmde/fundraising-phpcs",

--- a/src/Factories/FunFunFactory.php
+++ b/src/Factories/FunFunFactory.php
@@ -59,7 +59,6 @@ use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationPolicyValid
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationUseCase;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationValidator;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\InitialDonationStatusPicker;
-use WMDE\Fundraising\DonationContext\UseCases\AddDonation\ReferrerGeneralizer;
 use WMDE\Fundraising\DonationContext\UseCases\CancelDonation\CancelDonationUseCase;
 use WMDE\Fundraising\DonationContext\UseCases\CreditCardPaymentNotification\CreditCardNotificationUseCase;
 use WMDE\Fundraising\DonationContext\UseCases\GetDonation\GetDonationUseCase;
@@ -492,13 +491,6 @@ class FunFunFactory {
 		];
 	}
 
-	private function newReferrerGeneralizer(): ReferrerGeneralizer {
-		return new ReferrerGeneralizer(
-			$this->config['referrer-generalization']['default'],
-			$this->config['referrer-generalization']['domain-map']
-		);
-	}
-
 	public function getLogger(): LoggerInterface {
 		return $this->createSharedObject( LoggerInterface::class . '::Application', function () {
 			return new NullLogger();
@@ -805,7 +797,6 @@ class FunFunFactory {
 			$this->getDonationRepository(),
 			$this->newDonationValidator(),
 			$this->newDonationPolicyValidator(),
-			$this->newReferrerGeneralizer(),
 			$this->newDonationConfirmationMailer(),
 			$this->newBankTransferCodeGenerator(),
 			$this->newDonationTokenFetcher(),

--- a/src/Presentation/Presenters/DonationFormPresenter.php
+++ b/src/Presentation/Presenters/DonationFormPresenter.php
@@ -5,20 +5,19 @@ declare( strict_types = 1 );
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
 use WMDE\Euro\Euro;
-use WMDE\Fundraising\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
+use WMDE\Fundraising\Frontend\Presentation\Presenters\DonationFormPresenter\ImpressionCounts;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 use WMDE\Fundraising\Frontend\Validation\IsCustomAmountValidator;
 
 /**
  * @license GPL-2.0-or-later
- * @author Kai Nissen < kai.nissen@wikimedia.de >
  */
 class DonationFormPresenter {
 
-	private $template;
-	private $amountFormatter;
-	private $isCustomDonationAmountValidator;
+	private TwigTemplate $template;
+	private AmountFormatter $amountFormatter;
+	private IsCustomAmountValidator $isCustomDonationAmountValidator;
 
 	public function __construct(
 		TwigTemplate $template,
@@ -31,7 +30,7 @@ class DonationFormPresenter {
 	}
 
 	public function present( Euro $amount, string $paymentType, ?int $paymentInterval, bool $paymentDataIsValid,
-							 DonationTrackingInfo $trackingInfo, ?string $addressType, array $urlEndpoints ): string {
+							 ImpressionCounts $trackingInfo, ?string $addressType, array $urlEndpoints ): string {
 		return $this->template->render( [
 			'initialFormValues' => [
 				'amount' => $this->amountFormatter->format( $amount ),

--- a/src/Presentation/Presenters/DonationFormPresenter/ImpressionCounts.php
+++ b/src/Presentation/Presenters/DonationFormPresenter/ImpressionCounts.php
@@ -1,0 +1,23 @@
+<?php
+declare( strict_types=1 );
+
+namespace WMDE\Fundraising\Frontend\Presentation\Presenters\DonationFormPresenter;
+
+class ImpressionCounts {
+	private int $totalImpressionCount;
+	private int $singleBannerImpressionCount;
+
+	public function __construct( int $totalImpressionCount, int $singleBannerImpressionCount ) {
+		$this->totalImpressionCount = $totalImpressionCount;
+		$this->singleBannerImpressionCount = $singleBannerImpressionCount;
+	}
+
+	public function getTotalImpressionCount(): int {
+		return $this->totalImpressionCount;
+	}
+
+	public function getSingleBannerImpressionCount(): int {
+		return $this->singleBannerImpressionCount;
+	}
+
+}

--- a/src/Presentation/Presenters/DonationFormViolationPresenter.php
+++ b/src/Presentation/Presenters/DonationFormViolationPresenter.php
@@ -4,10 +4,10 @@ declare( strict_types = 1 );
 
 namespace WMDE\Fundraising\Frontend\Presentation\Presenters;
 
-use WMDE\Fundraising\DonationContext\Domain\Model\DonationTrackingInfo;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationRequest;
 use WMDE\Fundraising\DonationContext\UseCases\AddDonation\AddDonationValidationResult as Result;
 use WMDE\Fundraising\Frontend\Presentation\AmountFormatter;
+use WMDE\Fundraising\Frontend\Presentation\Presenters\DonationFormPresenter\ImpressionCounts;
 use WMDE\Fundraising\Frontend\Presentation\TwigTemplate;
 use WMDE\Fundraising\PaymentContext\Domain\BankDataValidationResult;
 use WMDE\Fundraising\PaymentContext\Domain\Model\PaymentMethod;
@@ -20,8 +20,8 @@ use WMDE\FunValidators\ConstraintViolation;
  */
 class DonationFormViolationPresenter {
 
-	private $template;
-	private $amountFormatter;
+	private TwigTemplate $template;
+	private AmountFormatter $amountFormatter;
 
 	public function __construct( TwigTemplate $template, AmountFormatter $amountFormatter ) {
 		$this->template = $template;
@@ -31,10 +31,10 @@ class DonationFormViolationPresenter {
 	/**
 	 * @param ConstraintViolation[] $violations
 	 * @param AddDonationRequest $request
-	 * @param DonationTrackingInfo $trackingData
+	 * @param ImpressionCounts $trackingData
 	 * @return string
 	 */
-	public function present( array $violations, AddDonationRequest $request, DonationTrackingInfo $trackingData ): string {
+	public function present( array $violations, AddDonationRequest $request, ImpressionCounts $trackingData ): string {
 		return $this->template->render(
 			[
 				'initialFormValues' => $this->getDonationFormArguments( $request ),

--- a/tests/Unit/Presentation/DonationMembershipApplicationAdapterTest.php
+++ b/tests/Unit/Presentation/DonationMembershipApplicationAdapterTest.php
@@ -29,7 +29,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 			'08771', 'Bärlin', 'DE', 'demo@cat.goat'
 		);
 		$payment = new DonationPayment( Euro::newFromCents( 45000 ), 1, $this->getDirectDebitPayment() );
-		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 
 		$adapter = new DonationMembershipApplicationAdapter();
 		$this->assertEquals(
@@ -60,7 +60,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 			'08771', 'Bärlin', 'DE', 'demo@cat.goat'
 		);
 		$payment = new DonationPayment( Euro::newFromCents( 100000 ), 1, $this->getDirectDebitPayment() );
-		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 
 		$adapter = new DonationMembershipApplicationAdapter();
 		$this->assertEquals(
@@ -88,7 +88,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 			'3389', 'Wien', 'AT', 'demo2@cat.goat'
 		);
 		$payment = new DonationPayment( Euro::newFromCents( 55000 ), 1, new SofortPayment( 'DXB' ) );
-		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 
 		$adapter = new DonationMembershipApplicationAdapter();
 		$this->assertEquals(
@@ -114,7 +114,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 			'', '', 'AT', 'demo2@cat.goat'
 		);
 		$payment = new DonationPayment( Euro::newFromCents( 55000 ), 1, new SofortPayment( 'FFG' ) );
-		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 
 		$adapter = new DonationMembershipApplicationAdapter();
 		$this->assertEquals(
@@ -166,7 +166,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 
 	public function testDefaultValidationStateIsEmpty(): void {
 		$payment = new DonationPayment( Euro::newFromCents( 45000 ), 1, $this->getBankTransferPayment() );
-		$donation = new Donation( null, Donation::STATUS_NEW, new Donor\AnonymousDonor(), $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, new Donor\AnonymousDonor(), $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 		$adapter = new DonationMembershipApplicationAdapter();
 
 		$this->assertEquals( [], $adapter->getInitialValidationState( $donation ) );
@@ -178,7 +178,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 			'08771', 'Bärlin', 'DE', 'demo@cat.goat'
 		);
 		$payment = new DonationPayment( Euro::newFromCents( 45000 ), 1, $this->getBankTransferPayment() );
-		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, $donor, $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 
 		$adapter = new DonationMembershipApplicationAdapter();
 
@@ -190,7 +190,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 
 	public function testDonationWithDirectDebitAndIbanHasValidBankData(): void {
 		$payment = new DonationPayment( Euro::newFromCents( 45000 ), 1, $this->getDirectDebitPayment() );
-		$donation = new Donation( null, Donation::STATUS_NEW, ValidDonation::newDonor(), $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, ValidDonation::newDonor(), $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 		$adapter = new DonationMembershipApplicationAdapter();
 
 		$this->assertEquals(
@@ -204,7 +204,7 @@ class DonationMembershipApplicationAdapterTest extends TestCase {
 		$bankData->setIban( new Iban( '' ) );
 		$paymentMethod = new DirectDebitPayment( $bankData );
 		$payment = new DonationPayment( Euro::newFromCents( 45000 ), 1, $paymentMethod );
-		$donation = new Donation( null, Donation::STATUS_NEW, ValidDonation::newDonor(), $payment, false, new DonationTrackingInfo, null );
+		$donation = new Donation( null, Donation::STATUS_NEW, ValidDonation::newDonor(), $payment, false, DonationTrackingInfo::newBlankTrackingInfo(), null );
 		$adapter = new DonationMembershipApplicationAdapter();
 
 		$this->assertEquals( [ 'address' => true ], $adapter->getInitialValidationState( $donation ) );


### PR DESCRIPTION
We no longer track the "Source" (web page) of a donation inside the
donation application (we use Matomo instead). This pull request removes
the parameters and object constructors for source tracking, as prepared by
https://github.com/wmde/fundraising-donations/pull/112

It also improves the layer separation by removing the reliance on the
`DonationTrackingInfo` Domain class for passing impression counts from
controller to presenter (without involving the use case). Instead, we
use the new `ImpressionCounts` value object.

This is for https://phabricator.wikimedia.org/T134327

