### PR TITLE
Modernize Doctrine setup for PHP >=8.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ validate-sql:
 
 setup-doctrine:
 	docker compose run --rm start_dependencies
-	docker compose run --rm app ./bin/doctrine orm:generate-proxies var/doctrine_proxies
 
 drop-db:
 	docker compose run --rm app ./bin/doctrine orm:schema-tool:drop --force

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ This will
 
 - Install PHP dependencies
 - Copy a basic configuration file. See section [Configuration](#configuration) for more details on the configuration.
-- Generate the [Doctrine Proxy classes](https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/reference/advanced-configuration.html#proxy-objects)
 - Download and install the frontend assets from
     [fundraising-app-frontend](https://gitlab.com/fun-tech/fundraising-app-frontend)
 

--- a/src/Factories/EnvironmentSetup/DevelopmentEnvironmentSetup.php
+++ b/src/Factories/EnvironmentSetup/DevelopmentEnvironmentSetup.php
@@ -42,14 +42,13 @@ class DevelopmentEnvironmentSetup implements EnvironmentSetup {
 	}
 
 	private function setDoctrineConfiguration( FunFunFactory $factory ): void {
-		// Setup will use /tmp for proxies and ArrayCache for caching
-		$factory->setDoctrineConfiguration( ORMSetup::createXMLMetadataConfiguration(
+		// Setup will use ArrayCache for caching
+		$config = ORMSetup::createXMLMetadataConfig(
 			$factory->getDoctrineXMLMappingPaths(),
-			true,
-			null,
-			null,
 			true
-		) );
+		);
+		$config->enableNativeLazyObjects( true );
+		$factory->setDoctrineConfiguration( $config );
 	}
 
 	private function setPayPalAPIClient( FunFunFactory $factory ): void {

--- a/src/Factories/EnvironmentSetup/ProductionEnvironmentSetup.php
+++ b/src/Factories/EnvironmentSetup/ProductionEnvironmentSetup.php
@@ -52,13 +52,9 @@ class ProductionEnvironmentSetup implements EnvironmentSetup {
 	}
 
 	private function setDoctrineConfiguration( FunFunFactory $factory ): void {
-		$factory->setDoctrineConfiguration( ORMSetup::createXMLMetadataConfiguration(
-			$factory->getDoctrineXMLMappingPaths(),
-			false,
-			$factory->getWritableApplicationDataPath() . '/doctrine_proxies',
-			null,
-			true
-		) );
+		$config = ORMSetup::createXMLMetadataConfig( $factory->getDoctrineXMLMappingPaths() );
+		$config->enableNativeLazyObjects( true );
+		$factory->setDoctrineConfiguration( $config );
 	}
 
 	private function setCreditCardLogger( FunFunFactory $factory ): void {

--- a/tests/TestEnvironmentSetup.php
+++ b/tests/TestEnvironmentSetup.php
@@ -16,7 +16,12 @@ class TestEnvironmentSetup implements EnvironmentSetup {
 	public function setEnvironmentDependentInstances( FunFunFactory $factory ): void {
 		$factory->setNullMessengers();
 		$factory->setDomainNameValidator( new NullDomainNameValidator() );
-		$factory->setDoctrineConfiguration( ORMSetup::createXMLMetadataConfiguration( $factory->getDoctrineXMLMappingPaths(), true ) );
+		$config = ORMSetup::createXMLMetadataConfig(
+			$factory->getDoctrineXMLMappingPaths(),
+			true
+		);
+		$config->enableNativeLazyObjects( true );
+		$factory->setDoctrineConfiguration( $config );
 		$factory->setInternalErrorHtmlPresenter( new DevelopmentInternalErrorHtmlPresenter() );
 		$factory->setFeatureReader( new FeatureReaderStub() );
 		$factory->setPayPalAPI( new FakePayPalAPI() );


### PR DESCRIPTION
We were using deprecated configuration methods.
Change code to use new methods
Remove generation of Doctrine proxy classes

Background Info:
Newer versions of Doctrine no longer use auto-generated proxy classes
but use the PHP 8.4 [Lazy Object](https://www.php.net/manual/en/language.oop5.lazy-objects.php)
feature.

This change gets rid of a deprecation warning and makes the application
ready for Doctrine ORM 4.0
