### PR TITLE
Improve Edge2Edge tests

### DIFF
--- a/tests/EdgeToEdge/CampaignBucketTest.php
+++ b/tests/EdgeToEdge/CampaignBucketTest.php
@@ -7,11 +7,10 @@ namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WMDE\Fundraising\Frontend\App\EventHandlers\StoreBucketSelection;
 use WMDE\Fundraising\Frontend\BucketTesting\Domain\Model\Bucket;
-use WMDE\Fundraising\Frontend\Factories\FunFunFactory;
 use WMDE\Fundraising\Frontend\Tests\Fixtures\OverridingCampaignConfigurationLoader;
 
 #[CoversClass( StoreBucketSelection::class )]
-class CampaignCookieTest extends WebRouteTestCase {
+class CampaignBucketTest extends WebRouteTestCase {
 
 	private const TEST_CAMPAIGN_CONFIG = [
 		'awesome_feature' => [
@@ -25,17 +24,19 @@ class CampaignCookieTest extends WebRouteTestCase {
 	];
 
 	public function testWhenUserVisitsWithBucketParams_bucketsAreSet(): void {
-		$this->modifyConfiguration( [ 'campaigns' => [ 'timezone' => 'UTC' ] ] );
-		$this->modifyEnvironment( static function ( FunFunFactory $ffactory ) {
-			$ffactory->setCampaignConfigurationLoader(
-				new OverridingCampaignConfigurationLoader(
-					$ffactory->getCampaignConfigurationLoader(),
-					self::TEST_CAMPAIGN_CONFIG
-				)
-			);
-		} );
-
+		$this->modifyConfiguration( [
+			'campaigns' => [ 'timezone' => 'UTC' ],
+			'skin' => 'laika'
+		] );
 		$client = $this->createClient();
+		$factory = $this->getFactory();
+		$factory->setCampaignConfigurationLoader(
+			new OverridingCampaignConfigurationLoader(
+				$factory->getCampaignConfigurationLoader(),
+				self::TEST_CAMPAIGN_CONFIG
+			)
+		);
+
 		$client->request( 'get', '/', [ 'omg' => 1 ] );
 
 		$buckets = array_filter(

--- a/tests/EdgeToEdge/MatomoTest.php
+++ b/tests/EdgeToEdge/MatomoTest.php
@@ -10,12 +10,19 @@ use PHPUnit\Framework\Attributes\CoversNothing;
  * Check if basic tracking parameters are rendered inside the HTML
  */
 #[CoversNothing]
-class PiwikTest extends WebRouteTestCase {
+class MatomoTest extends WebRouteTestCase {
 
-	public function testPiwikScriptGetsEmbedded(): void {
+	/**
+	 * Remove when https://phabricator.wikimedia.org/T163452 is done
+	 */
+	protected function setUp(): void {
+		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
+	}
+
+	public function testMatomoScriptGetsEmbedded(): void {
 		$client = $this->createClient();
 		$client->request( 'GET', '/' );
-		$this->assertStringContainsString( '<!-- Piwik -->', $client->getResponse()->getContent() ?: '' );
+		$this->assertStringContainsString( '<!-- Matomo -->', $client->getResponse()->getContent() ?: '' );
 	}
 
 	public function testConfigParametersAreUsed(): void {

--- a/tests/EdgeToEdge/PayPalRequestLoggerTest.php
+++ b/tests/EdgeToEdge/PayPalRequestLoggerTest.php
@@ -32,6 +32,7 @@ class PayPalRequestLoggerTest extends WebRouteTestCase {
 		$this->filePath = vfsStream::url( self::LOG_DIR . '/' . self::LOG_FILENAME );
 		$this->logger = new LoggerSpy();
 
+		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
 		/** @var KernelBrowser $client */
 		$client = $this->createClient();
 		$this->client = $client;

--- a/tests/EdgeToEdge/RouteNotFoundTest.php
+++ b/tests/EdgeToEdge/RouteNotFoundTest.php
@@ -12,6 +12,13 @@ use WMDE\Fundraising\Frontend\App\EventHandlers\HandleExceptions;
 #[CoversClass( HandleExceptions::class )]
 class RouteNotFoundTest extends WebRouteTestCase {
 
+	/**
+	 * Remove when https://phabricator.wikimedia.org/T163452 is done
+	 */
+	protected function setUp(): void {
+		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
+	}
+
 	public function testGivenUnknownRoute_404isReturned(): void {
 		$client = $this->createClient();
 		$client->request( 'GET', '/kittens' );

--- a/tests/EdgeToEdge/Routes/LegacyRouteTest.php
+++ b/tests/EdgeToEdge/Routes/LegacyRouteTest.php
@@ -6,11 +6,15 @@ namespace WMDE\Fundraising\Frontend\Tests\EdgeToEdge\Routes;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use WMDE\Fundraising\Frontend\App\Controllers\PageNotFoundController;
+use WMDE\Fundraising\Frontend\Tests\EdgeToEdge\WebRouteTestCase;
 
 #[CoversClass( PageNotFoundController::class )]
-class LegacyRouteTest extends WebTestCase {
+class LegacyRouteTest extends WebRouteTestCase {
+
+	protected function setUp(): void {
+		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
+	}
 
 	/**
 	 * Covers the fallback route in routes.yml

--- a/tests/EdgeToEdge/StoreLocaleTest.php
+++ b/tests/EdgeToEdge/StoreLocaleTest.php
@@ -12,6 +12,13 @@ use WMDE\Fundraising\Frontend\App\EventHandlers\StoreLocale;
 #[CoversClass( StoreLocale::class )]
 class StoreLocaleTest extends WebRouteTestCase {
 
+	/**
+	 * Remove when https://phabricator.wikimedia.org/T163452 is done
+	 */
+	protected function setUp(): void {
+		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
+	}
+
 	public function testWhenGivenSupportedCookieLocale_setsLocale(): void {
 		$client = $this->createClient();
 		$client->getCookieJar()->set( new BrowserKitCookie( CookieNames::LOCALE, 'en_GB' ) );

--- a/tests/EdgeToEdge/TrackBannerDonationRedirectsTest.php
+++ b/tests/EdgeToEdge/TrackBannerDonationRedirectsTest.php
@@ -28,6 +28,8 @@ class TrackBannerDonationRedirectsTest extends WebRouteTestCase {
 	private Donation $donation;
 
 	public function setUp(): void {
+		// Remove next line when https://phabricator.wikimedia.org/T163452 is done
+		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
 		/** @var KernelBrowser $client */
 		$client = $this->createClient();
 		$this->client = $client;

--- a/tests/EdgeToEdge/TrackingDataTest.php
+++ b/tests/EdgeToEdge/TrackingDataTest.php
@@ -14,6 +14,7 @@ class TrackingDataTest extends WebRouteTestCase {
 	private const PARAM_NAME_KEYWORD = 'piwik_kwd';
 
 	public function testWhenTrackingParamsArePassed_trackingCodeIsAddedToRequest(): void {
+		$this->modifyConfiguration( [ 'skin' => 'laika' ] );
 		$client = $this->createClient();
 		$client->request( 'get', '/', [
 			self::PARAM_NAME_CAMPAIGN => 'campaign',


### PR DESCRIPTION
We want to get rid of the `test` skin templates. All tests that do not
specifically test HTML output should use the `laika` skin.

Renamed `PiwikTest` to `MatomoTest`

Renamed `CampaignCookieTest` to `CampaignBucketTest` because we no
longer store the campaign from the URL in a cookie.

Ticket: https://phabricator.wikimedia.org/T163452
