### PR TITLE
Update campaigns config for new test

### DIFF
--- a/app/config/archived_campaigns.yaml
+++ b/app/config/archived_campaigns.yaml
@@ -200,3 +200,16 @@ new_design:
   url_key: des
   active: true
   param_only: true
+
+address_type_choice:
+  description: Test offering an "anonymous" choice (coming from a banner where the user donated less than 10 EUR)
+  reference: "https://phabricator.wikimedia.org/T380462"
+  start: "2024-11-25"
+  end: "2024-12-31"
+  buckets:
+    - "default"
+    - "choice"
+  default_bucket: "default"
+  url_key: xf
+  active: true
+  param_only: true

--- a/app/config/campaigns.dev.yml
+++ b/app/config/campaigns.dev.yml
@@ -1,12 +1,8 @@
 # This file is used in the "dev" and "uat" environments to be able to test future and past campaigns
 campaigns:
 
-  address_type_choice:
-    active: true
-    start: "2024-11-21"
-    end: "2024-12-31"
-
   address_pages:
     start: "2023-01-01"
+    end: "2028-12-31"
     default_bucket: "legacy"
     active: true

--- a/app/config/campaigns.yml
+++ b/app/config/campaigns.yml
@@ -22,20 +22,6 @@ campaigns:
     # url_key: URL parameter key used for assigning buckets to people
     # param_only: (Optional) Set to true if the campaign should return the default bucket when the url key is not in a request. This is for A/B tests triggered by banners
 
-
-    address_type_choice:
-      description: Test offering an "anonymous" choice (coming from a banner where the user donated less than 10 EUR)
-      reference: "https://phabricator.wikimedia.org/T380462"
-      start: "2024-11-25"
-      end: "2024-12-31"
-      buckets:
-        - "default"
-        - "choice"
-      default_bucket: "default"
-      url_key: xf
-      active: true
-      param_only: true
-
     address_pages:
       description: Test different iterations of address pages
       reference: "https://phabricator.wikimedia.org/T366576"
@@ -43,7 +29,8 @@ campaigns:
       end: "2026-02-28"
       buckets:
         - "legacy"
-        - "test_02"
+        - "test_02_no_anon"
+        - "test_03_compact_no_anon"
       default_bucket: "legacy"
       url_key: ap
       active: true


### PR DESCRIPTION
This removes the old choice test and adds a new
option to the address pages test.

We are keeping the old no anon form because it's
still being used for now while we test the new
one.

Ticket: https://phabricator.wikimedia.org/T403453