### PR TITLE
Add missing parameter to old command

### DIFF
--- a/cli/AnonymiseDonationCommand.php
+++ b/cli/AnonymiseDonationCommand.php
@@ -34,10 +34,12 @@ class AnonymiseDonationCommand extends Command {
 
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$donationAnonymizer = new DatabaseDonationAnonymizer(
-			$this->ffFactory->getDonationRepository(),
-			$this->ffFactory->getEntityManager(),
-			new SystemClock(),
-			new \DateInterval( 'P2D' )
+			donationRepository: $this->ffFactory->getDonationRepository(),
+			entityManager: $this->ffFactory->getEntityManager(),
+			clock: new SystemClock(),
+			exportGracePeriod: new \DateInterval( 'P2D' ),
+			moderationGracePeriod: new \DateInterval( 'P1M' )
+
 		);
 
 		try {


### PR DESCRIPTION
- we don't use this command anymore (see alternative scrubbing commands form 2026)
- but it still needs the paramters updated from our recent changes in the donations bounded context to make the CI pass